### PR TITLE
various color fixes

### DIFF
--- a/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
+++ b/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
@@ -17,15 +17,31 @@ public class CatimaAppCompatActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // XXX on the splash screen activity, aka the main activity, this has to be executed after applying dynamic colors, not before
+        // so running this only on non main for now
+        if (!this.getClass().getSimpleName().equals(MainActivity.class.getSimpleName())) {
+            Utils.patchOledDarkTheme(this);
+        }
+    }
+
+    @Override
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
-        // material you themes uses background color for top bar, let the layout underneath show through
+        // material 3 designer does not consider status bar colors
+        // XXX changing this in onCreate causes issues with the splash screen activity, so doing this here
         if (Build.VERSION.SDK_INT >= 23) {
             getWindow().setStatusBarColor(Color.TRANSPARENT);
             getWindow().getDecorView().setSystemUiVisibility(Utils.isDarkModeEnabled(this) ? 0 : View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
         } else {
             // icons are always white back then
             getWindow().setStatusBarColor(Utils.isDarkModeEnabled(this) ? Color.TRANSPARENT : Color.argb(127, 0, 0, 0));
+        }
+        // XXX android 9 and below has a nasty rendering bug if the theme was patched earlier
+        // the splash screen activity needs the fix regardless to solve a dynamic color api issue
+        if (!this.getClass().getSimpleName().equals(MainActivity.class.getSimpleName())) {
+            Utils.postPatchOledDarkTheme(this);
         }
     }
 }

--- a/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
+++ b/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
@@ -1,7 +1,12 @@
 package protect.card_locker;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class CatimaAppCompatActivity extends AppCompatActivity {
@@ -9,5 +14,18 @@ public class CatimaAppCompatActivity extends AppCompatActivity {
     protected void attachBaseContext(Context base) {
         // Apply chosen language
         super.attachBaseContext(Utils.updateBaseContextLocale(base));
+    }
+
+    @Override
+    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        // material you themes uses background color for top bar, let the layout underneath show through
+        if (Build.VERSION.SDK_INT >= 23) {
+            getWindow().setStatusBarColor(Color.TRANSPARENT);
+            getWindow().getDecorView().setSystemUiVisibility(Utils.isDarkModeEnabled(this) ? 0 : View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+        } else {
+            // icons are always white back then
+            getWindow().setStatusBarColor(Utils.isDarkModeEnabled(this) ? Color.TRANSPARENT : Color.argb(127, 0, 0, 0));
+        }
     }
 }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -50,6 +50,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.Guideline;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.widget.NestedScrollView;
@@ -575,7 +576,16 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         maximizeButton.setColorFilter(textColor);
         minimizeButton.setColorFilter(textColor);
         bottomSheetButton.setColorFilter(textColor);
-        editButton.setBackgroundTintList(ColorStateList.valueOf(Utils.getComplementaryColor(darkenedColor)));
+        int complementaryColor = Utils.getComplementaryColor(darkenedColor);
+        editButton.setBackgroundTintList(ColorStateList.valueOf(complementaryColor));
+        Drawable editButtonIcon = editButton.getDrawable();
+        editButtonIcon.mutate();
+        if (Utils.needsDarkForeground(complementaryColor)) {
+            editButtonIcon.setTint(ContextCompat.getColor(this, R.color.md_theme_light_onBackground));
+        } else {
+            editButtonIcon.setTint(ContextCompat.getColor(this, R.color.md_theme_dark_onBackground));
+        }
+        editButton.setImageDrawable(editButtonIcon);
 
         Bitmap icon = Utils.retrieveCardImage(this, loyaltyCard.id, ImageLocationType.icon);
         if (icon != null) {

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -11,6 +11,7 @@ import android.database.CursorIndexOutOfBoundsException;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.GestureDetector;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -28,6 +29,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.splashscreen.SplashScreen;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.color.DynamicColors;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.tabs.TabLayout;
 
@@ -178,8 +180,18 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
     protected void onCreate(Bundle inputSavedInstanceState) {
         super.onCreate(inputSavedInstanceState);
         SplashScreen.installSplashScreen(this);
+
+        // onPreCreate can't tell this activity uses a material theme due to splash screen, force color application here
+        DynamicColors.applyIfAvailable(this);
         setTitle(R.string.app_name);
+
         setContentView(R.layout.main_activity);
+
+        // XXX more dynamic color fixing due to splash screen
+        TypedValue typedValue = new TypedValue();
+        getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true);
+        findViewById(android.R.id.content).setBackgroundColor(typedValue.data);
+
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -183,13 +183,15 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
 
         // onPreCreate can't tell this activity uses a material theme due to splash screen, force color application here
         DynamicColors.applyIfAvailable(this);
+        Utils.patchOledDarkTheme(this);
         setTitle(R.string.app_name);
 
         setContentView(R.layout.main_activity);
 
         // XXX more dynamic color fixing due to splash screen
+        // without this the background color will get stuck with the old color before dynamic color
         TypedValue typedValue = new TypedValue();
-        getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true);
+        getTheme().resolveAttribute(android.R.attr.colorBackground, typedValue, true);
         findViewById(android.R.id.content).setBackgroundColor(typedValue.data);
 
         Toolbar toolbar = findViewById(R.id.toolbar);

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import android.os.LocaleList;
 import android.provider.MediaStore;
 import android.util.Log;
+import android.util.TypedValue;
 import android.widget.Toast;
 
 import com.google.zxing.BinaryBitmap;
@@ -39,9 +40,11 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.Map;
 
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.graphics.ColorUtils;
 import androidx.exifinterface.media.ExifInterface;
+
 import protect.card_locker.preferences.Settings;
 
 public class Utils {
@@ -457,6 +460,25 @@ public class Utils {
         R = 255 - R;
         G = 255 - G;
         B = 255 - B;
-        return R + (G << 8) + ( B << 16) + ( A << 24);
+        return R + (G << 8) + (B << 16) + (A << 24);
+    }
+
+    // replace colors in the current theme
+    // use before views are inflated, after dynamic color
+    public static void patchOledDarkTheme(AppCompatActivity activity) {
+        if (isDarkModeEnabled(activity) && new Settings(activity).getOledDark()) {
+            activity.getTheme().applyStyle(R.style.DarkBackground, true);
+        }
+    }
+
+    // XXX android 9 and below has issues with patched theme where the background becomes a
+    // rendering mess
+    // use after views are inflated
+    public static void postPatchOledDarkTheme(AppCompatActivity activity) {
+        if (isDarkModeEnabled(activity) && new Settings(activity).getOledDark()) {
+            TypedValue typedValue = new TypedValue();
+            activity.getTheme().resolveAttribute(android.R.attr.colorBackground, typedValue, true);
+            activity.findViewById(android.R.id.content).setBackgroundColor(typedValue.data);
+        }
     }
 }

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -9,6 +9,7 @@ import androidx.annotation.IntegerRes;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.preference.PreferenceManager;
+
 import protect.card_locker.R;
 import protect.card_locker.Utils;
 
@@ -101,5 +102,9 @@ public class Settings {
 
     public boolean getDisableLockscreenWhileViewingCard() {
         return getBoolean(R.string.settings_key_disable_lockscreen_while_viewing_card, true);
+    }
+
+    public boolean getOledDark() {
+        return getBoolean(R.string.settings_key_oled_dark, false);
     }
 }

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -18,6 +18,7 @@ import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
 import nl.invissvenska.numberpickerpreference.NumberDialogPreference;
 import nl.invissvenska.numberpickerpreference.NumberPickerPreferenceDialogFragment;
 import protect.card_locker.CatimaAppCompatActivity;
@@ -129,6 +130,13 @@ public class SettingsActivity extends CatimaAppCompatActivity {
             });
 
             localePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                refreshActivity(true);
+                return true;
+            });
+
+            Preference oledDarkPreference = findPreference(getResources().getString(R.string.settings_key_oled_dark));
+            assert oledDarkPreference != null;
+            oledDarkPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                 refreshActivity(true);
                 return true;
             });

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -30,4 +30,12 @@
 
         <item name="windowActionModeOverlay">true</item>
     </style>
+
+    <!-- note that this is not used directly, these are used to patch the active theme runtime with
+    theme.applyStyle
+    -->
+    <style name="DarkBackground">
+        <item name="android:colorBackground">#000000</item>
+        <item name="colorSurface">#000000</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="settings_key_keep_screen_on" translatable="false">pref_keep_screen_on</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Prevent screen lock</string>
     <string name="settings_key_disable_lockscreen_while_viewing_card" translatable="false">pref_disable_lockscreen_while_viewing_card</string>
+    <string name="settings_key_oled_dark" translatable="false">pref_oled_dark</string>
     <string name="sharedpreference_active_tab" translatable="false">sharedpreference_active_tab</string>
     <string name="sharedpreference_privacy_policy_shown" translatable="false">sharedpreference_privacy_policy_shown</string>
     <string name="sharedpreference_sort" translatable="false">sharedpreference_sort</string>
@@ -212,6 +213,7 @@
     <string name="turn_flashlight_on">Turn flashlight on</string>
     <string name="turn_flashlight_off">Turn flashlight off</string>
     <string name="settings_locale">Language</string>
+    <string name="settings_oled_dark">Pure black background for dark theme</string>
     <string name="settings_key_locale" translatable="false">pref_locale</string>
     <string name="settings_system_locale">System</string>
     <string name="selectColor">Select color</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,5 @@
 <resources>
+
     <style name="AppTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
@@ -48,4 +49,7 @@
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>
     </style>
+
+    <!-- place holder for dark background night theme overrides -->
+    <style name="DarkBackground" />
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
@@ -8,20 +7,27 @@
         app:iconSpaceReserved="false">
 
         <ListPreference
-            android:key="@string/settings_key_theme"
-            android:title="@string/settings_theme"
             android:defaultValue="@string/settings_key_system_theme"
             android:entries="@array/theme_value_strings"
             android:entryValues="@array/theme_values"
+            android:key="@string/settings_key_theme"
+            android:title="@string/settings_theme"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/settings_key_oled_dark"
+            android:title="@string/settings_oled_dark"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
 
         <ListPreference
-            android:key="@string/settings_key_locale"
-            android:title="@string/settings_locale"
             android:defaultValue=""
             android:entries="@array/locale_values"
             android:entryValues="@array/locale_values"
+            android:key="@string/settings_key_locale"
+            android:title="@string/settings_locale"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
 
@@ -29,11 +35,11 @@
             android:key="@string/settings_key_max_font_size_scale"
             android:title="@string/settings_max_font_size_scale"
             app:defaultValue="@integer/settings_max_font_size_scale_pct"
+            app:iconSpaceReserved="false"
             app:numberPickerPreference_maxValue="@integer/settings_max_font_size_scale_pct_max"
             app:numberPickerPreference_minValue="@integer/settings_max_font_size_scale_pct_min"
             app:numberPickerPreference_stepValue="10"
             app:numberPickerPreference_unitText="%"
-            app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
 
         <SwitchPreferenceCompat


### PR DESCRIPTION
### band-aid fixes for splash screen theme and material 3 dynamic color api
<img src="https://user-images.githubusercontent.com/22017945/152009820-fe6d7586-b2f7-4d86-94c9-33abf179597e.png"  width=50% height=50%>
<img src="https://user-images.githubusercontent.com/22017945/152009892-8bf2480c-daa7-4768-923a-6ecac77b1e9b.png"  width=50% height=50%>


### change editbutton icon's color in card view based on editbutton background color
<img src="https://user-images.githubusercontent.com/22017945/152010031-15db6d84-f743-4dc7-ad3f-b17097d877e7.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/22017945/152010065-175f5514-ba97-4f9a-a2c0-8fe5ba10a614.png" width=50% height=50%>

### make status bar transparent as per material 3, or tainted transparent for api level < 23 + light theme, given the color creator expect no status bar color
https://github.com/CatimaLoyalty/Android/discussions/749#discussioncomment-1991766
<img src="https://user-images.githubusercontent.com/22017945/152010424-96a5ff43-abba-43a1-a8f7-1ebf03a8097c.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/22017945/152010481-34694b8e-0cce-45fc-8cd4-1116006d0c41.png" width=50% height=50%>

please review

### added the option for black backgrounds in dark theme
<img src="https://user-images.githubusercontent.com/22017945/152132971-a330977f-0328-4a2b-bcb0-3c630b729da7.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/22017945/152133030-81e0c5cd-f77b-49e3-8981-bd3cde72f9d8.png" width=50% height=50%>

