### PR TITLE
[investigation] manually probe for dynamic color

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,13 +11,13 @@ spotbugs {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     buildToolsVersion "31.0.0"
 
     defaultConfig {
         applicationId "me.hackerchick.catima"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode 107
         versionName "2.16.3"
 

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -496,7 +496,7 @@ public class Utils {
             // also handles R.string.settings_key_system_theme
 
             // https://github.com/material-components/material-components-android/blob/master/docs/theming/Color.md#apply-dynamic-colors-to-all-activities-in-the-app
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
                 // probe our own dynamic theme here to get around the weird manufacturer lookup
                 TypedArray dynamicColorAttributes = activity.obtainStyledAttributes(DYNAMIC_COLOR_THEME_OVERLAY_ATTRIBUTE);
                 int themeOverlay = dynamicColorAttributes.getResourceId(0, 0);

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -3,12 +3,9 @@ package protect.card_locker.preferences;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
@@ -19,7 +16,9 @@ import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
-import com.google.android.material.color.DynamicColors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 import nl.invissvenska.numberpickerpreference.NumberDialogPreference;
 import nl.invissvenska.numberpickerpreference.NumberPickerPreferenceDialogFragment;
@@ -149,7 +148,7 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                 refreshActivity(true);
                 return true;
             });
-            if (!DynamicColors.isDynamicColorAvailable()) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                 colorPreference.setEntryValues(R.array.color_values_no_dynamic);
                 colorPreference.setEntries(R.array.color_value_strings_no_dynamic);
             }

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -148,7 +148,7 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                 refreshActivity(true);
                 return true;
             });
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S_V2) {
                 colorPreference.setEntryValues(R.array.color_values_no_dynamic);
                 colorPreference.setEntries(R.array.color_value_strings_no_dynamic);
             }


### PR DESCRIPTION
with the process described in https://github.com/material-components/material-components-android/blob/master/docs/theming/Color.md#apply-dynamic-colors-to-all-activities-in-the-app, this works even on sdk 31 emulator, fetching it's system theme

confusingly it even has a default behaviour that works before S, it just fetch the current material theme in manifest, one can test that by lowering the min sdk version

this gets around the manufacturer white list imposed in the material component library

wonder what it looks like with samsung sdk 31 oneui < 40100, as the only manufacturer that has a dedicated work around
https://github.com/material-components/material-components-android/blob/051410b7efc089e50e7f83db9a922258e2ba359e/lib/java/com/google/android/material/color/DynamicColors.java#L70
<img src="https://user-images.githubusercontent.com/22017945/173468037-d0d57989-801b-4047-b757-936f387c2310.png" width=270>
<img src="https://user-images.githubusercontent.com/22017945/173468503-dd079ff4-ba91-4047-b85f-1d81213ea4d6.png" width=270>

