### PR TITLE
Replace rotation lock with card rotation setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Don't allow choosing expiry before 1970 (they never worked anyway)
 - Add support for archiving cards
 - Move delete from edit to view
+- Remove rotation lock icon in favour of a new rotation lock setting
 
 ## v2.16.3 - 107 (2022-04-15)
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -255,7 +255,9 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         settings = new Settings(this);
 
         String cardOrientation = settings.getCardViewOrientation();
-        if (cardOrientation.equals(getString(R.string.settings_key_portrait_orientation))) {
+        if (cardOrientation.equals(getString(R.string.settings_key_lock_on_opening_orientation))) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+        } else if (cardOrientation.equals(getString(R.string.settings_key_portrait_orientation))) {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         } else if (cardOrientation.equals(getString(R.string.settings_key_landscape_orientation))) {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -252,13 +252,23 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        settings = new Settings(this);
+
+        String cardOrientation = settings.getCardViewOrientation();
+        if (cardOrientation.equals(getString(R.string.settings_key_portrait_orientation))) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        } else if (cardOrientation.equals(getString(R.string.settings_key_landscape_orientation))) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        } else {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        }
+
         if (savedInstanceState != null) {
             mainImageIndex = savedInstanceState.getInt(STATE_IMAGEINDEX);
             isFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN);
             bottomSheetState = savedInstanceState.getInt(STATE_BOTTOMSHEET);
         }
 
-        settings = new Settings(this);
 
         extractIntentFields(getIntent());
 
@@ -687,15 +697,6 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.card_view_menu, menu);
-
-        // Always calculate lockscreen icon, it may need a black color
-        boolean lockBarcodeScreenOrientation = settings.getLockBarcodeScreenOrientation();
-        MenuItem item = menu.findItem(R.id.action_lock_unlock);
-        setOrientatonLock(item, lockBarcodeScreenOrientation);
-        if (lockBarcodeScreenOrientation) {
-            item.setVisible(false);
-        }
-
         loyaltyCard = DBHelper.getLoyaltyCard(database, loyaltyCardId);
         starred = loyaltyCard.starStatus != 0;
 
@@ -754,15 +755,6 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
                 bundle.putBoolean("duplicateId", true);
                 intent.putExtras(bundle);
                 startActivity(intent);
-                return true;
-
-            case R.id.action_lock_unlock:
-                if (rotationEnabled) {
-                    setOrientatonLock(item, true);
-                } else {
-                    setOrientatonLock(item, false);
-                }
-                rotationEnabled = !rotationEnabled;
                 return true;
 
             case R.id.action_star_unstar:
@@ -835,19 +827,6 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
-        }
-    }
-
-    private void setOrientatonLock(MenuItem item, boolean lock) {
-        if (lock) {
-
-            item.setIcon(getIcon(R.drawable.ic_lock_outline_white_24dp, backgroundNeedsDarkIcons));
-            item.setTitle(R.string.unlockScreen);
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_NOSENSOR);
-        } else {
-            item.setIcon(getIcon(R.drawable.ic_lock_open_white_24dp, backgroundNeedsDarkIcons));
-            item.setTitle(R.string.lockScreen);
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
         }
     }
 

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -92,8 +92,8 @@ public class Settings {
         return getBoolean(R.string.settings_key_display_barcode_max_brightness, true);
     }
 
-    public boolean getLockBarcodeScreenOrientation() {
-        return getBoolean(R.string.settings_key_lock_barcode_orientation, false);
+    public String getCardViewOrientation() {
+        return getString(R.string.settings_key_card_orientation, getResString(R.string.settings_key_follow_system_orientation));
     }
 
     public boolean getKeepScreenOn() {

--- a/app/src/main/res/menu/card_view_menu.xml
+++ b/app/src/main/res/menu/card_view_menu.xml
@@ -3,11 +3,6 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/action_lock_unlock"
-        android:icon="@drawable/ic_lock_open_white_24dp"
-        android:title="@string/lockScreen"
-        app:showAsAction="always"/>
-    <item
         android:id="@+id/action_share"
         android:icon="@drawable/ic_share_white"
         android:title="@string/share"

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -87,7 +87,6 @@
     <string name="enter_group_name">Въведете име на списъка</string>
     <string name="intent_import_card_from_url_share_text">Искам да споделя тази карта с вас</string>
     <string name="settings_display_barcode_max_brightness">Увеличаване на яркостта при видим щрихкод</string>
-    <string name="settings_lock_barcode_orientation">Без на завъртане на щрихкода</string>
     <string name="settings_keep_screen_on">Поддържане на екрана включен</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Предотвратяване на заключване на екрана</string>
     <string name="settings_max_font_size_scale">Максимален размер на шрифта</string>
@@ -139,8 +138,6 @@
     <string name="importOptionFilesystemTitle">Внасяне от файловата система</string>
     <string name="importCatima">Внасяне от Catima</string>
     <string name="exportSuccessful">Данните са изнесени</string>
-    <string name="unlockScreen">Разрешава автоматичното завъртане</string>
-    <string name="lockScreen">Спира автоматичното завъртане</string>
     <plurals name="selectedCardCount">
         <item quantity="one"><xliff:g>%d</xliff:g> избрана</item>
         <item quantity="other"><xliff:g>%d</xliff:g> избрани</item>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="intent_import_card_from_url_share_text">url শেয়ার টেক্সট থেকে ইন্টেন্ট ইম্পোর্ট কার্ড</string>
     <string name="settings_disable_lockscreen_while_viewing_card"> কার্ড দেখা কালিন লকস্ক্রিন নিষ্ক্রিয়</string>
     <string name="settings_keep_screen_on">সেটিংস পর্দা খোলা রাখুন</string>
-    <string name="settings_lock_barcode_orientation"> তালাবদ্ধ বার কোড অভিযোজন</string>
     <string name="settings_max_font_size_scale">সর্বোচ্চ হরফ আকার</string>
     <string name="settings_light_theme">সাদাটে থিম</string>
     <string name="settings_system_theme">যন্ত্রর থিম</string>
@@ -82,7 +81,6 @@
     <string name="share">ভাগ</string>
     <string name="copy_to_clipboard">নকল করুন ক্লিপবোর্ড এ</string>
     <string name="deleteConfirmation">নিশ্চিতকরণ মুছে দিন</string>
-    <string name="unlockScreen">পর্দা আনলক করুন</string>
     <string name="confirm">নিশ্চিত করুন</string>
     <string name="delete">মুছে ফেলুন</string>
     <string name="edit">সম্পাদনা</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -21,7 +21,6 @@
     <string name="intent_import_card_from_url_share_text">Želim podijeliti čestitku s tobom</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Spriječi zaključavanje ekrana</string>
     <string name="settings_keep_screen_on">Zadrži ekran</string>
-    <string name="settings_lock_barcode_orientation">Zaključaj barcode orjentacija</string>
     <string name="settings_max_font_size_scale">Max. veliäťina fonta</string>
     <string name="settings_light_theme">Svjetlo</string>
     <string name="settings_system_theme">Sistem</string>
@@ -82,7 +81,6 @@
     <string name="share">Podijeli</string>
     <string name="copy_to_clipboard">Kopiraj ID u clipboard</string>
     <string name="deleteConfirmation">Izbriši trajno ovu karticu\?</string>
-    <string name="unlockScreen">Odblokalna Rotacija</string>
     <string name="confirm">Potvrdi</string>
     <string name="delete">Obriši</string>
     <string name="edit">Izmijeni</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -62,8 +62,6 @@
     <string name="noCardsMessage">Nejprve přidejte kartu</string>
     <string name="cardShortcut">Zástupce Karty</string>
     <string name="share">Podíl</string>
-    <string name="unlockScreen">Odblokovat Rotaci</string>
-    <string name="lockScreen">Otáčení Bloku</string>
     <string name="unstar">Odebrat z oblíbených</string>
     <string name="star">Přidat do oblíbených</string>
     <string name="noBarcode">Žádný čárový kód</string>
@@ -87,7 +85,6 @@
     <string name="intent_import_card_from_url_share_text">Chci s Vámi sdílet kartu</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Bránit uzamykání obrazovky</string>
     <string name="settings_keep_screen_on">Udržovat obrazovku zapnutou</string>
-    <string name="settings_lock_barcode_orientation">Zamknout orientaci čárového kódu</string>
     <string name="settings_max_font_size_scale">Maximální velikost písma</string>
     <string name="settings_dark_theme">Tmavý</string>
     <string name="settings_light_theme">Světlý</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -13,8 +13,6 @@
         <item quantity="other">Streichen <xliff:g>%d</xliff:g> korts</item>
     </plurals>
     <string name="deleteTitle">Karte streichen</string>
-    <string name="unlockScreen">Afbloker rotation</string>
-    <string name="lockScreen">Blokrotation</string>
     <string name="confirm">Bekræft</string>
     <string name="delete">Slet</string>
     <string name="edit">Rediger</string>
@@ -85,7 +83,6 @@
     <string name="intent_import_card_from_url_share_text">Jeg vil dele et kort med jer</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Forebyg låseskærm</string>
     <string name="settings_keep_screen_on">LHold skærm tændt</string>
-    <string name="settings_lock_barcode_orientation">Lås stregkode-orientering</string>
     <string name="moveUp">Bevæg dig opad</string>
     <string name="leaveWithoutSaveConfirmation">Forlade uden at gemme\?</string>
     <string name="settings_display_barcode_max_brightness">Lysere stregkodevisning</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -12,8 +12,6 @@
     <string name="edit">Bearbeiten</string>
     <string name="delete">Löschen</string>
     <string name="confirm">Bestätigen</string>
-    <string name="lockScreen">Rotation sperren</string>
-    <string name="unlockScreen">Rotation erlauben</string>
     <string name="star">Zu den Favoriten hinzufügen</string>
     <string name="unstar">Aus den Favoriten entfernen</string>
     <string name="ok">OK</string>
@@ -56,7 +54,6 @@
     <string name="settings">Einstellungen</string>
     <string name="settings_category_title_ui">Benutzeroberfläche</string>
     <string name="settings_display_barcode_max_brightness">Barcodeansicht aufhellen</string>
-    <string name="settings_lock_barcode_orientation">Barcoderotation sperren</string>
     <string name="exportSuccessful">Daten exportiert</string>
     <string name="importSuccessful">Daten importiert</string>
     <string name="intent_import_card_from_url_share_text">Ich würde gerne diese Karte mit dir teilen</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -10,8 +10,6 @@
     <string name="edit">Επεξεργασία</string>
     <string name="delete">Διαγραφή</string>
     <string name="confirm">Επιβεβαίωση</string>
-    <string name="lockScreen">Αποκλεισμός Περιστροφής</string>
-    <string name="unlockScreen">Περιστροφή</string>
     <string name="ok">Εντάξει</string>
     <string name="copy_to_clipboard">Αντιγραφή κωδικού στο πρόχειρο</string>
     <string name="sendLabel">Αποστολή…</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -52,7 +52,6 @@
     <string name="action_search">Serĉi</string>
     <string name="deleteConfirmation">Ĉu forigi ĉi tiun karton\?</string>
     <string name="deleteTitle">Forigi karton</string>
-    <string name="settings_lock_barcode_orientation">Seruro barcode orientiĝo</string>
     <string name="settings_display_barcode_max_brightness">Heligi barcode vido</string>
     <string name="settings_max_font_size_scale">Max. tiparo grandeco</string>
     <string name="starImage">Preferata stelo</string>
@@ -76,8 +75,6 @@
     <string name="cardShortcut">Karto Mallongirejo</string>
     <string name="scanCardBarcode">Scintigrafio Barcode Card</string>
     <string name="share">Interŝanĝado</string>
-    <string name="unlockScreen">Malbloki Rotacio</string>
-    <string name="lockScreen">Bloko Rotacio</string>
     <string name="star">Aldoni al miaj plej ŝatataj</string>
     <string name="copy_to_clipboard_toast">Card ID kopiita al la tondujo</string>
     <string name="settings_keep_screen_on">Teni sur ekrano</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,8 +10,6 @@
     <string name="edit">Editar</string>
     <string name="delete">Eliminar</string>
     <string name="confirm">Confirmar</string>
-    <string name="lockScreen">Bloquear giro</string>
-    <string name="unlockScreen">Desbloquear giro</string>
     <string name="ok">Aceptar</string>
     <string name="copy_to_clipboard">Copiar id. en portapapeles</string>
     <string name="sendLabel">Enviar…</string>
@@ -51,7 +49,6 @@
     <string name="exportSuccessful">Datos de las tarjetas exportados</string>
     <string name="importSuccessful">Datos de las tarjetas importados</string>
     <string name="intent_import_card_from_url_share_text">Quiero compartirte una tarjeta</string>
-    <string name="settings_lock_barcode_orientation">Bloquear giro en el código de barras</string>
     <string name="settings_dark_theme">Oscuro</string>
     <string name="settings_light_theme">Claro</string>
     <string name="settings_system_theme">Sistema</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -70,7 +70,6 @@
     <string name="intent_import_card_from_url_share_text">Haluan jakaa kortin kanssasi</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Estä näytön lukitus</string>
     <string name="settings_keep_screen_on">Pidä näyttö päällä</string>
-    <string name="settings_lock_barcode_orientation">Lukitse viivakoodin suunta</string>
     <string name="settings_display_barcode_max_brightness">Kirkasta viivakoodinäkymää</string>
     <string name="settings_max_font_size_scale">Fontin enimmäiskoko</string>
     <string name="settings_dark_theme">Tumma</string>
@@ -126,8 +125,6 @@
     <string name="share">Jaa</string>
     <string name="copy_to_clipboard">Kopioi ID-tunnus leikepöydälle</string>
     <string name="ok">OK</string>
-    <string name="unlockScreen">Poista kierron esto</string>
-    <string name="lockScreen">Estä kierto</string>
     <string name="confirm">Vahvista</string>
     <string name="delete">Poista</string>
     <string name="edit">Muokkaa</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,8 +10,6 @@
     <string name="edit">Modifier</string>
     <string name="delete">Supprimer</string>
     <string name="confirm">Confirmer</string>
-    <string name="lockScreen">Désactiver la rotation</string>
-    <string name="unlockScreen">Activer la rotation</string>
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Copier le numéro dans le presse-papier</string>
     <string name="sendLabel">Envoyer…</string>
@@ -52,7 +50,6 @@
     <string name="settings">Paramètres</string>
     <string name="settings_category_title_ui">Interface utilisateur</string>
     <string name="settings_display_barcode_max_brightness">Augmenter la luminosité du code-barres</string>
-    <string name="settings_lock_barcode_orientation">Verrouiller l’orientation du code-barres</string>
     <string name="exportSuccessful">Données exportées</string>
     <string name="importSuccessful">Données importées</string>
     <string name="intent_import_card_from_url_share_text">Je veux partager une carte avec toi</string>

--- a/app/src/main/res/values-he-rIL/strings.xml
+++ b/app/src/main/res/values-he-rIL/strings.xml
@@ -7,7 +7,6 @@
     <string name="ok">אישור</string>
     <string name="action_search">חיפוש</string>
     <string name="noGiftCards">לחץ על לחצן ה + להוספת כרטיס, או ייבא מספר כרטיסים באמצעות התפריט ⋮.</string>
-    <string name="lockScreen">סיבוב</string>
     <string name="share">שיתוף</string>
     <string name="copy_to_clipboard">העתקת מזהה ללוח</string>
     <string name="addCardTitle">הוספת כרטיס</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -6,8 +6,6 @@
     <string name="edit">Uredi</string>
     <string name="delete">Ukloni</string>
     <string name="confirm">Potvrdi</string>
-    <string name="lockScreen">Rotacija bloka</string>
-    <string name="unlockScreen">Otključaj Rotaciju</string>
     <string name="deleteTitle">Ukloni kartu</string>
     <string name="deleteConfirmation">Izbrisati ovu karticu zauvijek\?</string>
     <string name="copy_to_clipboard">Kopiraj ID u međuspremnik</string>
@@ -66,7 +64,6 @@
     <string name="thumbnailDescription">Sličica za karticu</string>
     <string name="starImage">Omiljena zvijezda</string>
     <string name="settings_category_title_ui">Korisničko sučelje</string>
-    <string name="settings_lock_barcode_orientation">Zaključavanje orijentacije crtičnog koda</string>
     <string name="exportSuccessful">Izvezeni podaci o karti</string>
     <string name="settings_keep_screen_on">Držite zaslon uključen</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Spriječiti zaključavanje zaslona</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -23,8 +23,6 @@
     <string name="edit">Szerkesztés</string>
     <string name="delete">Törlés</string>
     <string name="confirm">Alkalmaz</string>
-    <string name="lockScreen">Forgatás blokkolása</string>
-    <string name="unlockScreen">Blokkolás engedélyezése</string>
     <plurals name="deleteCardsTitle">
         <item quantity="one"><xliff:g>%d</xliff:g> törlése</item>
         <item quantity="other"><xliff:g>%d</xliff:g> törlése</item>
@@ -106,7 +104,6 @@
     <string name="settings_light_theme">Világos</string>
     <string name="settings_max_font_size_scale">Max. betű méret</string>
     <string name="settings_display_barcode_max_brightness">Fényes vonalkód nézet</string>
-    <string name="settings_lock_barcode_orientation">Vonalkód tájolás zárolása</string>
     <string name="settings_keep_screen_on">Képernyő bekapcsolva marad</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Képernyő zárólás megakadályozása</string>
     <string name="intent_import_card_from_url_share_text">Meg akarok veled osztani egy kártyát</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_dark_theme">Gelap</string>
     <string name="settings_max_font_size_scale">Ukuran maksimal huruf</string>
     <string name="settings_display_barcode_max_brightness">Terangkan tampilan barcode</string>
-    <string name="settings_lock_barcode_orientation">Kunci orientasi barcode</string>
     <string name="settings_keep_screen_on">Biarkan layar menyala</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Mencegah layar menyala</string>
     <string name="intent_import_card_from_url_share_text">Saya ingin berbagi kartu dengan anda</string>
@@ -187,8 +186,6 @@
     <string name="on_github">di GitHub</string>
     <string name="and_data_usage">dan penggunaan data</string>
     <string name="on_google_play">di Google Play</string>
-    <string name="lockScreen">Blokir rotasi</string>
-    <string name="unlockScreen">Buka blokir rotasi</string>
     <string name="cardShortcut">Pintasan kartu</string>
     <string name="card_ids_copied">ID kartu yang tersalin</string>
     <string name="barcodeImageDescriptionWithType">Gambar dari jenis barcode <xliff:g>%s</xliff:g></string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -4,7 +4,6 @@
     <string name="noBarcode">Nei strikamerkið</string>
     <string name="action_search">Leita að</string>
     <string name="delete">Eyða</string>
-    <string name="unlockScreen">Opna Snúningur</string>
     <string name="noGiftCards">Smelltu á + plús takka til að bæta kort, eða að flytja inn sumir frá ⋮ matseðill fyrst.</string>
     <string name="note">Athugið</string>
     <string name="barcodeType">Strikamerkið tegund</string>
@@ -17,7 +16,6 @@
     <string name="save">Sparaðu</string>
     <string name="edit">Breyta</string>
     <string name="confirm">Staðfesta</string>
-    <string name="lockScreen">Blokk Snúningur</string>
     <string name="ok">OK</string>
     <string name="sendLabel">Sendu…</string>
     <string name="deleteConfirmation">Eyða þetta kort til frambúðar\?</string>
@@ -49,7 +47,6 @@
     <string name="about">Um</string>
     <string name="settings">Stillingar</string>
     <string name="settings_max_font_size_scale">Max. letrið</string>
-    <string name="settings_lock_barcode_orientation">Læsa strikamerkið stefnumörkun</string>
     <string name="settings_keep_screen_on">Halda á skjánum</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Að koma í veg fyrir að læsa skjánum</string>
     <string name="editBarcode">Breyta strikamerkið</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -13,8 +13,6 @@
     <string name="edit">Modifica</string>
     <string name="delete">Elimina</string>
     <string name="confirm">Conferma</string>
-    <string name="lockScreen">Blocca rotazione</string>
-    <string name="unlockScreen">Sblocca rotazione</string>
     <string name="ok">Ok</string>
     <string name="copy_to_clipboard">Copia codice negli appunti</string>
     <string name="share">Condividi</string>
@@ -62,7 +60,6 @@
     <string name="settings_light_theme">Chiaro</string>
     <string name="settings_dark_theme">Scuro</string>
     <string name="settings_display_barcode_max_brightness">Aumenta luminosità dello schermo quando viene aperto un codice a barre</string>
-    <string name="settings_lock_barcode_orientation">Blocca orientamento del codice a barre</string>
     <string name="intent_import_card_from_url_share_text">Voglio condividere una carta fedeltà con te</string>
     <string name="exportSuccessful">Dati della carta esportati</string>
     <string name="importSuccessful">Dati importati</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -57,7 +57,6 @@
     <string name="intent_import_card_from_url_share_text">カード共有をしましょう</string>
     <string name="settings_disable_lockscreen_while_viewing_card">バーコード表示中は画面をロックしない</string>
     <string name="settings_keep_screen_on">バーコード表示中は画面を消灯しない</string>
-    <string name="settings_lock_barcode_orientation">バーコード表示画面を自動回転しない</string>
     <string name="settings_display_barcode_max_brightness">バーコード表示画面を明るくする</string>
     <string name="settings_max_font_size_scale">最大のフォントサイズ</string>
     <string name="settings_dark_theme">ダーク</string>
@@ -118,8 +117,6 @@
     <string name="share">共有</string>
     <string name="copy_to_clipboard">カード番号をクリップボードにコピーする</string>
     <string name="ok">確定</string>
-    <string name="unlockScreen">自動回転を無効にしない</string>
-    <string name="lockScreen">自動回転を無効にする</string>
     <string name="confirm">確認</string>
     <string name="delete">削除</string>
     <string name="edit">編集</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -5,7 +5,6 @@
     <string name="all">모두</string>
     <string name="groups">그룹</string>
     <string name="enter_group_name">그룹 이름 입력</string>
-    <string name="settings_lock_barcode_orientation">바코드 회전 잠금</string>
     <string name="settings_dark_theme">어두움</string>
     <string name="settings_light_theme">밝음</string>
     <string name="debug_version_fmt">버전: <xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="version">%s</xliff:g></string>
@@ -31,8 +30,6 @@
     <string name="share">공유</string>
     <string name="copy_to_clipboard">ID를 클립보드에 복사</string>
     <string name="ok">확인</string>
-    <string name="unlockScreen">회전 잠금 해제</string>
-    <string name="lockScreen">회전 잠금</string>
     <string name="confirm">확인</string>
     <string name="delete">삭제</string>
     <string name="edit">편집</string>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -11,8 +11,6 @@
     <string name="edit">Änneren</string>
     <string name="delete">Läschen</string>
     <string name="confirm">Bestätegen</string>
-    <string name="lockScreen">Blockrotation</string>
-    <string name="unlockScreen">Déblockéieren Rotatioun</string>
     <string name="deleteConfirmation">Dës Kaart dauerhaft läschen\?</string>
     <string name="ok">Okay</string>
     <string name="share">Aktie</string>
@@ -73,7 +71,6 @@
     <string name="copy_to_clipboard_multiple_toast">Kaarten-IDs an d \' Tëschentablag inspiréiere</string>
     <string name="updateBarcodeQuestionText">Si hunn d \' Kaarten-ID geännert. Wëllt Dir och de Barcode aktualiséieren, fir deselwechte Wäert ze benotzen\?</string>
     <string name="settings_dark_theme">Donkel</string>
-    <string name="settings_lock_barcode_orientation">Barcode-Ausriichtung spären</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Bildschierm spären verhënneren</string>
     <string name="settings_light_theme">Liicht</string>
     <string name="settings_max_font_size_scale">Max. Schrëftgréisst</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -34,8 +34,6 @@
     <string name="card_ids_copied">Nukopijuotos kortelės ID</string>
     <string name="noCardsMessage">Pirmiausia pridėkite kortelę</string>
     <string name="sendLabel">Siųsti…</string>
-    <string name="unlockScreen">Atblokuoti pasukimą</string>
-    <string name="lockScreen">Blokuoti pasukimą</string>
     <string name="unstar">Pašalinti iš mėgstamiausių</string>
     <string name="star">Pridėti prie mėgstamiausių</string>
     <string name="noBarcode">Nėra brūkšninio kodo</string>
@@ -130,7 +128,6 @@
     <string name="intent_import_card_from_url_share_text">Noriu pasidalyti su jumis kortele</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Neleisti užrakinti ekrano</string>
     <string name="settings_keep_screen_on">Laikyti ekraną įjungtą</string>
-    <string name="settings_lock_barcode_orientation">Užrakinti brūkšninio kodo orientaciją</string>
     <string name="settings_max_font_size_scale">Didžiausias šrifto dydis</string>
     <string name="settings_dark_theme">Tamsi</string>
     <string name="settings_light_theme">Šviesi</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -27,8 +27,6 @@
     <string name="editCardTitle">Rediģēt Karti</string>
     <string name="share">Daļa</string>
     <string name="confirm">Apstiprināt</string>
-    <string name="lockScreen">Bloķēt Rotāciju</string>
-    <string name="unlockScreen">Atbloķēt Rotāciju</string>
     <string name="deleteTitle">Dzēst karti</string>
     <string name="deleteConfirmation">Dzēst šo karti pastāvīgi\?</string>
     <string name="ok">LABI</string>
@@ -72,7 +70,6 @@
     <string name="settings_dark_theme">Tumšs</string>
     <string name="settings_max_font_size_scale">Max. fonts</string>
     <string name="settings_display_barcode_max_brightness">Izgaismojiet svītrkoda skatu</string>
-    <string name="settings_lock_barcode_orientation">Lock svītrkoda orientācija</string>
     <string name="settings_keep_screen_on">Saglabāt ekrānu</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Novērst bloķēšanas ekrānu</string>
     <string name="intent_import_card_from_url_share_text">Es vēlos dalīties ar jums karti</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -11,8 +11,6 @@
     <string name="edit">Rediger</string>
     <string name="delete">Slett</string>
     <string name="confirm">Bekreft</string>
-    <string name="lockScreen">Skru av rotering</string>
-    <string name="unlockScreen">Skru på rotering</string>
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Kopier ID til utklippstavle</string>
     <string name="sendLabel">Send…</string>
@@ -55,7 +53,6 @@
     <string name="settings">Innstillinger</string>
     <string name="settings_category_title_ui">Brukergrensesnitt</string>
     <string name="settings_display_barcode_max_brightness">Lysere strekkodevisning</string>
-    <string name="settings_lock_barcode_orientation">Lås strekkodesideretning</string>
     <string name="exportSuccessful">Data eksportert</string>
     <string name="importSuccessful">Data importert</string>
     <string name="intent_import_card_from_url_share_text">Jeg ønsker å dele et kort med deg</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -14,8 +14,6 @@
     <string name="edit">Bewerken</string>
     <string name="delete">Verwijderen</string>
     <string name="confirm">Bevestigen</string>
-    <string name="lockScreen">Draaien niet toestaan</string>
-    <string name="unlockScreen">Draaien toestaan</string>
     <string name="ok">Oké</string>
     <string name="copy_to_clipboard">Kaartnummer kopiëren naar klembord</string>
     <string name="share">Delen</string>
@@ -64,7 +62,6 @@
     <string name="settings_light_theme">Licht</string>
     <string name="settings_dark_theme">Donker</string>
     <string name="settings_display_barcode_max_brightness">Scherm helderder maken bij tonen van barcode</string>
-    <string name="settings_lock_barcode_orientation">Barcode-oriëntatie vergrendelen</string>
     <string name="intent_import_card_from_url_share_text">Ik wil een klantenkaart met je delen</string>
     <string name="all">Alles</string>
     <string name="importSuccessful">De gegevens zijn geïmporteerd</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -22,8 +22,6 @@
     <string name="editCardTitle">Modificar la carta</string>
     <string name="sendLabel">Enviar…</string>
     <string name="share">Partejar</string>
-    <string name="unlockScreen">Activar la rotacion</string>
-    <string name="lockScreen">Desactivar la rotacion</string>
     <string name="confirm">Confirmar</string>
     <string name="delete">Suprimir</string>
     <string name="edit">Modificar</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -13,8 +13,6 @@
     <string name="edit">Edytuj</string>
     <string name="delete">Usuń</string>
     <string name="confirm">Potwierdź</string>
-    <string name="lockScreen">Zablokuj autoobracanie ekranu</string>
-    <string name="unlockScreen">Odblokuj autoobracanie ekranu</string>
     <string name="ok">OK</string>
     <string name="copy_to_clipboard">Skopiuj identyfikator do schowka</string>
     <string name="share">Udostępnij</string>
@@ -62,7 +60,6 @@
     <string name="settings_light_theme">Jasny</string>
     <string name="settings_dark_theme">Ciemny</string>
     <string name="settings_display_barcode_max_brightness">Rozjaśnij widok kodu kreskowego</string>
-    <string name="settings_lock_barcode_orientation">Zablokuj autoobracanie kodów kreskowych</string>
     <string name="intent_import_card_from_url_share_text">Chcę udostępnić Ci kartę lojalnościową</string>
     <string name="deleteConfirmationGroup">Usunąć grupę\?</string>
     <string name="all">Wszystko</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -22,9 +22,7 @@
     <string name="about">Sobre</string>
     <string name="app_license">Software livre de partilha sob a mesma licença e segundo a licença GPLv3+</string>
     <string name="addCardTitle">Adicionar cartão</string>
-    <string name="lockScreen">Bloquear rotação</string>
     <string name="editCardTitle">Editar cartão</string>
-    <string name="unlockScreen">Desbloquear rotação</string>
     <string name="deleteTitle">Eliminar cartão</string>
     <string name="copy_to_clipboard">Copiar identificador para a área de transferência</string>
     <string name="sendLabel">Enviar…</string>
@@ -53,7 +51,6 @@
     <string name="settings_keep_screen_on">Manter ecrã ligado</string>
     <string name="enter_group_name">Introduza o nome do grupo</string>
     <string name="groups">Grupos</string>
-    <string name="settings_lock_barcode_orientation">Bloquear orientação do código de barras</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Desativar bloqueio do ecrã</string>
     <string name="exportSuccessful">Dados exportados</string>
     <string name="all">Todos</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -13,8 +13,6 @@
     <string name="copy_to_clipboard">Copiați ID-ul în clipboard</string>
     <string name="deleteConfirmation">Să șterg definitiv acest card\?</string>
     <string name="deleteTitle">Ștergeți cardul</string>
-    <string name="unlockScreen">Deblocarea rotației</string>
-    <string name="lockScreen">Rotația blocurilor</string>
     <string name="confirm">Confirmați</string>
     <string name="delete">Ștergeți</string>
     <string name="edit">Editați</string>
@@ -62,7 +60,6 @@
     <string name="noBarcodeFound">Nu a fost găsit niciun cod de bare</string>
     <string name="settings_max_font_size_scale">Mărimea maximă a fontului</string>
     <string name="settings_display_barcode_max_brightness">Luminați vizualizarea codurilor de bare</string>
-    <string name="settings_lock_barcode_orientation">Blocare orientare cod de bare</string>
     <string name="settings_keep_screen_on">Păstrați ecranul pornit</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Evitați ecranul de blocare</string>
     <string name="balance">Balanță</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -14,8 +14,6 @@
     <string name="edit">Изменить</string>
     <string name="delete">Удалить карту</string>
     <string name="confirm">Подтвердить</string>
-    <string name="lockScreen">Блокировать поворот экрана</string>
-    <string name="unlockScreen">Автоповорот экрана</string>
     <string name="ok">ОК</string>
     <string name="copy_to_clipboard">Копировать номер карты</string>
     <string name="share">Переслать</string>
@@ -64,7 +62,6 @@
     <string name="settings_light_theme">Светлая</string>
     <string name="settings_dark_theme">Тёмная</string>
     <string name="settings_display_barcode_max_brightness">Максимальная яркость при отображении карты</string>
-    <string name="settings_lock_barcode_orientation">Портретная ориентация экрана при отображении карты</string>
     <string name="intent_import_card_from_url_share_text">Я хочу поделиться с вами картой</string>
     <string name="exportSuccessful">Данные успешно экспортированы</string>
     <string name="all">Все</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -10,8 +10,6 @@
     <string name="edit">Upraviť</string>
     <string name="delete">Vymazať</string>
     <string name="confirm">Potvrdiť</string>
-    <string name="lockScreen">Zakázať rotáciu</string>
-    <string name="unlockScreen">Povoliť rotáciu</string>
     <string name="ok">Áno</string>
     <string name="copy_to_clipboard">Kopírovať ID do schránky</string>
     <string name="sendLabel">Odoslať…</string>
@@ -52,7 +50,6 @@
     <string name="settings">Nastavenia</string>
     <string name="settings_category_title_ui">Používateľské prostredie</string>
     <string name="settings_display_barcode_max_brightness">Zvýšiť jas pri zobrazení čiarového kódu </string>
-    <string name="settings_lock_barcode_orientation">Uzamkni orientáciu čiarového kódu</string>
     <string name="deleteTitle">Odstrániť kartu</string>
     <string name="deleteConfirmation">Naozaj chcete túto kartu odstrániť?</string>
     <string name="star">Pridať k obľúbeným</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -10,8 +10,6 @@
     <string name="edit">Uredi</string>
     <string name="delete">Izbriši</string>
     <string name="confirm">Potrdi</string>
-    <string name="lockScreen">Onemogoči obračanje zaslona</string>
-    <string name="unlockScreen">Omogoči obračanje zaslona</string>
     <string name="ok">Vredu</string>
     <string name="copy_to_clipboard">Kopirajte številko kartice</string>
     <string name="sendLabel">Pošlji…</string>
@@ -52,7 +50,6 @@
     <string name="settings">Nastavitve</string>
     <string name="settings_category_title_ui">Uporabniški vmesnik</string>
     <string name="settings_display_barcode_max_brightness">Povečaj osvetljenost prikaza črtne kode</string>
-    <string name="settings_lock_barcode_orientation">Zakleni orientacijo črtne kode</string>
     <string name="deleteTitle">Odstrani kartico zvestobe</string>
     <string name="deleteConfirmation">Prosim potrdite, če želite izbrisati to kartico\?</string>
     <string name="card">Kartica</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
-    <string name="settings_lock_barcode_orientation">Lås streckkodens riktning</string>
     <string name="settings_display_barcode_max_brightness">Gör streckkodsvyn ljusare</string>
     <string name="settings_max_font_size_scale">Max. teckenstorlek</string>
     <string name="settings_keep_screen_on">Håll skärmen påslagen</string>
@@ -151,7 +150,6 @@
     <string name="privacy_policy_popup_text">Notis rörande integritetspolicy (krävs av vissa appbutiker):
 \n
 \nINGEN DATA ALLS SAMLAS IN, vilket vem som helst kan bekräfta eftersom vår app är fri programvara.</string>
-    <string name="unlockScreen">Tillåt rotation</string>
     <string name="privacy_policy">Integritetspolicy</string>
     <string name="expiryStateSentenceExpired">Förföll: <xliff:g>%s</xliff:g></string>
     <string name="chooseExpiryDate">Välj förfallodatum</string>
@@ -164,7 +162,6 @@
     <string name="balance">Saldo</string>
     <string name="balanceSentence">Saldo: <xliff:g>%s</xliff:g></string>
     <string name="settings_disable_lockscreen_while_viewing_card">Förhindra skärmlåsning</string>
-    <string name="lockScreen">Förhindra rotation</string>
     <string name="importCatimaMessage">Välj den exporterade <i>catima.zip</i> från Catima som du vill importera.
 \nSkapa den från Import/Export-menyn i en annan Catima-app genom att trycka på Exportera där först.</string>
     <string name="expiryStateSentence">Giltigt till: <xliff:g>%s</xliff:g></string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -98,7 +98,6 @@
     <string name="intent_import_card_from_url_share_text">Seninle bir kart paylaşmak istiyorum</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Ekran kilidini engelle</string>
     <string name="settings_keep_screen_on">Ekranı açık tut</string>
-    <string name="settings_lock_barcode_orientation">Barkod yönünü kilitle</string>
     <string name="settings_display_barcode_max_brightness">Barkod görünümünü aydınlat</string>
     <string name="settings_max_font_size_scale">Azami yazı tipi boyutu</string>
     <string name="settings_dark_theme">Koyu</string>
@@ -167,8 +166,6 @@
         <item quantity="other"><xliff:g>%d</xliff:g> kartı sil</item>
     </plurals>
     <string name="deleteTitle">Kartı sil</string>
-    <string name="unlockScreen">Döndürme Engelini Kaldır</string>
-    <string name="lockScreen">Döndürmeyi Engelle</string>
     <string name="confirm">Doğrula</string>
     <string name="delete">Sil</string>
     <string name="edit">Düzenle</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -77,7 +77,6 @@
     <string name="intent_import_card_from_url_share_text">Я хочу поділитися з тобою картою</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Не блокувати екран</string>
     <string name="settings_keep_screen_on">Не вимикати екран</string>
-    <string name="settings_lock_barcode_orientation">Заблокувати орієнтацію штрих-коду</string>
     <string name="settings_max_font_size_scale">Макс. розмір шрифту</string>
     <string name="settings_dark_theme">Темна</string>
     <string name="settings_light_theme">Світла</string>
@@ -132,8 +131,6 @@
     <string name="share">Поділитися</string>
     <string name="copy_to_clipboard">Копіювати ID до буферу обміну</string>
     <string name="ok">ОК</string>
-    <string name="unlockScreen">Розблокувати обертання</string>
-    <string name="lockScreen">Блокувати обертання</string>
     <string name="confirm">Підтвердити</string>
     <string name="delete">Видалити</string>
     <string name="edit">Редагувати</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -73,7 +73,6 @@
     <string name="intent_import_card_from_url_share_text">我想和你分享一张卡</string>
     <string name="settings_disable_lockscreen_while_viewing_card">防止锁屏</string>
     <string name="settings_keep_screen_on">保持屏幕常亮</string>
-    <string name="settings_lock_barcode_orientation">锁定条码方向</string>
     <string name="settings_display_barcode_max_brightness">提高条码界面亮度</string>
     <string name="settings_max_font_size_scale">最大字体大小</string>
     <string name="settings_dark_theme">暗色</string>
@@ -121,8 +120,6 @@
     <string name="share">分享</string>
     <string name="copy_to_clipboard">复制卡号到剪贴板</string>
     <string name="ok">确定</string>
-    <string name="unlockScreen">解除旋转锁定</string>
-    <string name="lockScreen">锁定旋转</string>
     <string name="confirm">确认</string>
     <string name="delete">删除</string>
     <string name="edit">编辑</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -151,14 +151,11 @@
     <string name="settings_light_theme">淺色</string>
     <string name="settings_dark_theme">深色</string>
     <string name="settings_display_barcode_max_brightness">調高條碼介面螢幕亮度</string>
-    <string name="settings_lock_barcode_orientation">鎖定條碼螢幕方向</string>
     <string name="settings_keep_screen_on">螢幕恆亮</string>
     <string name="settings_disable_lockscreen_while_viewing_card">防止螢幕鎖定</string>
     <string name="importSuccessful">已匯入資料</string>
     <string name="moveUp">往上移動</string>
     <string name="moveDown">往下移動</string>
-    <string name="lockScreen">禁止旋轉</string>
-    <string name="unlockScreen">允許旋轉</string>
     <string name="ok">OK</string>
     <string name="sendLabel">送出…</string>
     <string name="scanCardBarcode">掃描條碼</string>

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -98,6 +98,18 @@
         <item>zh-rCN</item>
     </string-array>
 
+    <string-array name="card_orientation_values">
+        <item>@string/settings_key_follow_system_orientation</item>
+        <item>@string/settings_key_portrait_orientation</item>
+        <item>@string/settings_key_landscape_orientation</item>
+    </string-array>
+
+    <string-array name="card_orientation_values_strings">
+        <item>@string/settings_follow_system_orientation</item>
+        <item>@string/settings_portrait_orientation</item>
+        <item>@string/settings_landscape_orientation</item>
+    </string-array>
+
     <array name="letter_tile_colors">
         <item>#f16364</item>
         <item>#f58559</item>

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -100,12 +100,14 @@
 
     <string-array name="card_orientation_values">
         <item>@string/settings_key_follow_system_orientation</item>
+        <item>@string/settings_key_lock_on_opening_orientation</item>
         <item>@string/settings_key_portrait_orientation</item>
         <item>@string/settings_key_landscape_orientation</item>
     </string-array>
 
     <string-array name="card_orientation_values_strings">
         <item>@string/settings_follow_system_orientation</item>
+        <item>@string/settings_lock_on_opening_orientation</item>
         <item>@string/settings_portrait_orientation</item>
         <item>@string/settings_landscape_orientation</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,8 +22,6 @@
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>
     <string name="confirm">Confirm</string>
-    <string name="lockScreen">Block Rotation</string>
-    <string name="unlockScreen">Unblock Rotation</string>
     <!-- START NOTE: i18n oddness -->
     <!-- The following may seem weird, but it is necessary to give translators enough flexibility.
          For example, in Russian, Android's plural quantity "one" actually refers to "any number ending on 1 but not ending in 11".
@@ -99,12 +97,18 @@
     <string name="settings_key_light_theme" translatable="false">light</string>
     <string name="settings_dark_theme">Dark</string>
     <string name="settings_key_dark_theme" translatable="false">dark</string>
+    <string name="settings_card_orientation">Barcode orientation</string>
+    <string name="settings_key_card_orientation" translatable="false">pref_card_orientation</string>
+    <string name="settings_follow_system_orientation">Follow system</string>
+    <string name="settings_key_follow_system_orientation" translatable="false">follow_system</string>
+    <string name="settings_portrait_orientation">Portrait</string>
+    <string name="settings_key_portrait_orientation" translatable="false">portrait</string>
+    <string name="settings_landscape_orientation">Landscape</string>
+    <string name="settings_key_landscape_orientation" translatable="false">landscape</string>
     <string name="settings_key_max_font_size_scale" translatable="false">pref_max_font_size_scale</string>
     <string name="settings_max_font_size_scale">Max. font size</string>
     <string name="settings_display_barcode_max_brightness">Brighten barcode view</string>
     <string name="settings_key_display_barcode_max_brightness" translatable="false">pref_display_card_max_brightness</string>
-    <string name="settings_lock_barcode_orientation">Lock barcode orientation</string>
-    <string name="settings_key_lock_barcode_orientation" translatable="false">pref_lock_barcode_orientation</string>
     <string name="settings_keep_screen_on">Keep screen on</string>
     <string name="settings_key_keep_screen_on" translatable="false">pref_keep_screen_on</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Prevent screen lock</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,8 @@
     <string name="settings_key_portrait_orientation" translatable="false">portrait</string>
     <string name="settings_landscape_orientation">Landscape</string>
     <string name="settings_key_landscape_orientation" translatable="false">landscape</string>
+    <string name="settings_lock_on_opening_orientation">Lock to orientation used when opening the card</string>
+    <string name="settings_key_lock_on_opening_orientation" translatable="false">lock_on_opening</string>
     <string name="settings_key_max_font_size_scale" translatable="false">pref_max_font_size_scale</string>
     <string name="settings_max_font_size_scale">Max. font size</string>
     <string name="settings_display_barcode_max_brightness">Brighten barcode view</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -58,10 +58,12 @@
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
 
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="@string/settings_key_lock_barcode_orientation"
-            android:title="@string/settings_lock_barcode_orientation"
+        <ListPreference
+            android:defaultValue="@string/settings_key_follow_system_orientation"
+            android:entries="@array/card_orientation_values_strings"
+            android:entryValues="@array/card_orientation_values"
+            android:key="@string/settings_key_card_orientation"
+            android:title="@string/settings_card_orientation"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
 

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -981,7 +981,7 @@ public class LoyaltyCardViewActivityTest {
         final Menu menu = shadowOf(activity).getOptionsMenu();
         assertTrue(menu != null);
 
-        // The share, settings, star and duplicate options should be present
+        // The share, star and overflow options should be present
         assertEquals(menu.size(), 3);
 
         assertEquals("Share", menu.findItem(R.id.action_share).getTitle().toString());
@@ -1165,7 +1165,7 @@ public class LoyaltyCardViewActivityTest {
         final Menu menu = shadowOf(activity).getOptionsMenu();
         assertTrue(menu != null);
 
-        // The share, settings, star and duplicate options should be present
+        // The share, star and overflow options should be present
         assertEquals(menu.size(), 3);
 
         assertEquals("Add to favorites", menu.findItem(R.id.action_star_unstar).getTitle().toString());

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -982,9 +982,8 @@ public class LoyaltyCardViewActivityTest {
         assertTrue(menu != null);
 
         // The share, settings, star and duplicate options should be present
-        assertEquals(menu.size(), 4);
+        assertEquals(menu.size(), 3);
 
-        assertEquals("Block Rotation", menu.findItem(R.id.action_lock_unlock).getTitle().toString());
         assertEquals("Share", menu.findItem(R.id.action_share).getTitle().toString());
         assertEquals("Add to favorites", menu.findItem(R.id.action_star_unstar).getTitle().toString());
 
@@ -1149,40 +1148,6 @@ public class LoyaltyCardViewActivityTest {
     }
 
     @Test
-    public void checkScreenOrientationLockSetting() {
-        for (boolean locked : new boolean[]{false, true}) {
-            ActivityController activityController = createActivityWithLoyaltyCard(false);
-
-            Activity activity = (Activity) activityController.get();
-            SQLiteDatabase database = new DBHelper(activity).getWritableDatabase();
-            DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
-
-            SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(activity);
-            settings.edit()
-                    .putBoolean(activity.getResources().getString(R.string.settings_key_lock_barcode_orientation), locked)
-                    .apply();
-
-            activityController.start();
-            activityController.resume();
-            activityController.visible();
-
-            assertEquals(false, activity.isFinishing());
-
-            MenuItem item = shadowOf(activity).getOptionsMenu().findItem(R.id.action_lock_unlock);
-
-            if (locked) {
-                assertEquals(item.isVisible(), false);
-            } else {
-                assertEquals(item.isVisible(), true);
-                String title = item.getTitle().toString();
-                assertEquals(title, activity.getString(R.string.lockScreen));
-            }
-
-            database.close();
-        }
-    }
-
-    @Test
     public void checkPushStarIcon() {
         ActivityController activityController = createActivityWithLoyaltyCard(false);
 
@@ -1201,7 +1166,7 @@ public class LoyaltyCardViewActivityTest {
         assertTrue(menu != null);
 
         // The share, settings, star and duplicate options should be present
-        assertEquals(menu.size(), 4);
+        assertEquals(menu.size(), 3);
 
         assertEquals("Add to favorites", menu.findItem(R.id.action_star_unstar).getTitle().toString());
 


### PR DESCRIPTION
Fixes #899, fixes #719 and fixes #771.

This removes the lock icon and replaces it with an option in settings, defaulting to "Follow system".

This allows users who tend to accidentally rotate their device when about to scan something to lock the barcode orientation to make scanning easier.