### PR TITLE
Crash on clicking "Add from image" button in scan activity #856

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -1171,7 +1172,14 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
 
                 Intent i = new Intent(Intent.ACTION_PICK);
                 i.setType("image/*");
-                mPhotoPickerLauncher.launch(i);
+
+                try {
+                    mPhotoPickerLauncher.launch(i);
+                } catch (ActivityNotFoundException e) {
+                    Toast.makeText(getApplicationContext(), R.string.failedLaunchingPhotoPicker, Toast.LENGTH_LONG).show();
+                    Log.e(TAG, "No activity found to handle intent", e);
+                }
+
                 return null;
             });
 

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -1,6 +1,7 @@
 package protect.card_locker;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -206,6 +207,11 @@ public class ScanActivity extends CatimaAppCompatActivity {
     public void addFromImage(View view) {
         Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
         photoPickerIntent.setType("image/*");
-        photoPickerLauncher.launch(photoPickerIntent);
+        try {
+            photoPickerLauncher.launch(photoPickerIntent);
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(getApplicationContext(), R.string.failedLaunchingPhotoPicker, Toast.LENGTH_LONG).show();
+            Log.e(TAG, "No activity found to handle intent", e);
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,4 +285,5 @@
     <string name="archiveList">Archive</string>
     <string name="overflowMenu" translatable="false">Overflow menu</string>
     <string name="noUnarchivedCardsMessage">No unarchived cards exist</string>
+    <string name="failedLaunchingPhotoPicker">Could not find a supported gallery app</string>
 </resources>


### PR DESCRIPTION
This PR contains a fix for issue #856, which concerns a crash that occurs when no activity can handle the intent to pick an image file.

### The simplest way to reproduce
* Disable all the gallery apps (e.g., Google Photos)
* Go to the ScanActivity by clicking the FAB on the home screen
* The app crashes when you click the button "Select image from gallery"

### Expected behavior
Clicking that button should have launched a gallery app, or displayed a disambiguation dialog if there is more than one app that can handle the intent being invoked.

### Solution
Wrapped the call to launch in a try-catch block.