### PR TITLE
Move Archive back into overflow menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Add Monochrome icon for Android 13
 - Improve first launch screen
-- Move archive info from overflow menu to bottom of card list
 - Fidme import fixes
 
 ## v2.19.0 - 113

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,84 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="protect.card_locker.MainActivity"
     tools:showIn="@layout/main_activity">
 
     <LinearLayout
+        android:id="@+id/helpSection"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:visibility="gone">
 
-        <LinearLayout
-            android:id="@+id/helpSection"
+        <ImageView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:visibility="gone">
-
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="184dp"
-                android:scaleType="fitCenter"
-                android:src="@drawable/ic_launcher_foreground" />
-
-            <TextView
-                style="@style/TextAppearance.Material3.HeadlineLarge"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/welcome" />
-
-            <TextView
-                style="@style/AppTheme.TextView.NoData"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/noGiftCards"/>
-        </LinearLayout>
+            android:layout_height="184dp"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_launcher_foreground" />
 
         <TextView
-            style="@style/AppTheme.TextView.NoData"
-            android:id="@+id/noMatchingCardsText"
+            style="@style/TextAppearance.Material3.HeadlineLarge"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="@string/noMatchingGiftCards"
-            android:visibility="gone"/>
+            android:text="@string/welcome" />
 
         <TextView
             style="@style/AppTheme.TextView.NoData"
-            android:id="@+id/noGroupCardsText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="@string/noGroupCards"
-            android:visibility="gone"/>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/list"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:spanCount="@integer/main_view_card_columns"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:visibility="gone"/>
-
-        <TextView
-            style="@style/AppTheme.TextView.NoData"
-            android:id="@+id/openArchiveLinkText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:visibility="gone"/>
-
-            <View
-                android:id="@+id/bottomPadding"
-                android:layout_width="match_parent"
-                android:layout_height="80dp" />
+            android:text="@string/noGiftCards"/>
     </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+
+    <TextView
+        style="@style/AppTheme.TextView.NoData"
+        android:id="@+id/noMatchingCardsText"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/noMatchingGiftCards"
+        android:visibility="gone"/>
+
+    <TextView
+        style="@style/AppTheme.TextView.NoData"
+        android:id="@+id/noGroupCardsText"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/noGroupCards"
+        android:visibility="gone"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+        app:spanCount="@integer/main_view_card_columns"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="80dp"
+        android:clipToPadding="false"
+        android:scrollbars="vertical"
+        android:visibility="gone"/>
+
+</RelativeLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -27,6 +27,10 @@
         android:title="@string/groups"
         app:showAsAction="never"/>
     <item
+        android:id="@+id/action_archived"
+        android:title="@string/archiveList"
+        app:showAsAction="never"/>
+    <item
         android:id="@+id/action_import_export"
         android:icon="@drawable/ic_import_export_white_24dp"
         android:title="@string/importExport"

--- a/app/src/test/java/protect/card_locker/MainActivityTest.java
+++ b/app/src/test/java/protect/card_locker/MainActivityTest.java
@@ -60,11 +60,12 @@ public class MainActivityTest {
         assertNotNull(menu);
 
         // The settings, import/export, groups, search and add button should be present
-        assertEquals(menu.size(), 7);
+        assertEquals(menu.size(), 8);
         assertEquals("Search", menu.findItem(R.id.action_search).getTitle().toString());
         assertEquals("Sort", menu.findItem(R.id.action_sort).getTitle().toString());
         assertEquals("Hide details", menu.findItem(R.id.action_unfold).getTitle().toString());
         assertEquals("Groups", menu.findItem(R.id.action_manage_groups).getTitle().toString());
+        assertEquals("Archive", menu.findItem(R.id.action_archived).getTitle().toString());
         assertEquals("Import/Export", menu.findItem(R.id.action_import_export).getTitle().toString());
         assertEquals("About", menu.findItem(R.id.action_about).getTitle().toString());
         assertEquals("Settings", menu.findItem(R.id.action_settings).getTitle().toString());


### PR DESCRIPTION
While I much prefer the design introduced in
https://github.com/CatimaLoyalty/Android/pull/1009, it sadly caused a serious performance regression
(https://github.com/CatimaLoyalty/Android/issues/1026).

This commit restores the old behaviour so that a new release isn't blocked while this is figured out.