### PR TITLE
The translation wasnt correct

### DIFF
--- a/fastlane/metadata/android/it-IT/title.txt
+++ b/fastlane/metadata/android/it-IT/title.txt
@@ -1,1 +1,1 @@
-Catima — Portafoglio di carte
+Catima — Portafoglio di Carte Fedeltà


### PR DESCRIPTION
The italian translation for Catima - Loyality Card Wallet is Catima - Portafoglio di Carte Fedeltà, but since the app isnt born only for store "fidelity cards" i suggest to change name in Catima - Portafoglio Digitale/Catima - Digital Wallet