### PR TITLE
Improved Settings screen 

### DIFF
--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import com.google.android.material.color.DynamicColors;
 
@@ -92,7 +93,6 @@ public class SettingsActivity extends CatimaAppCompatActivity {
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
         private static final String DIALOG_FRAGMENT_TAG = "SettingsFragment";
-
         public boolean mReloadMain;
 
         @Override
@@ -126,14 +126,24 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                 } else {
                     AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
                 }
-
+                refreshActivity(true);
                 return true;
             });
+
+            if(AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_NO){
+                themePreference.setSummary(getResources().getString(R.string.settings_light_theme));
+            } else if(AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES){
+                themePreference.setSummary(getResources().getString(R.string.settings_dark_theme));
+            }
+            else{
+                themePreference.setSummary(getResources().getString(R.string.settings_system_theme));
+            }
 
             localePreference.setOnPreferenceChangeListener((preference, newValue) -> {
                 refreshActivity(true);
                 return true;
             });
+            localePreference.setSummary(localePreference.getEntry());
 
             Preference oledDarkPreference = findPreference(getResources().getString(R.string.settings_key_oled_dark));
             assert oledDarkPreference != null;
@@ -148,10 +158,20 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                 refreshActivity(true);
                 return true;
             });
+            colorPreference.setSummary(colorPreference.getEntry());
+
             if (!DynamicColors.isDynamicColorAvailable()) {
                 colorPreference.setEntryValues(R.array.color_values_no_dynamic);
                 colorPreference.setEntries(R.array.color_value_strings_no_dynamic);
             }
+
+            ListPreference barcodeOrientation = findPreference(getResources().getString(R.string.settings_key_card_orientation));
+            assert barcodeOrientation != null;
+            barcodeOrientation.setOnPreferenceChangeListener(((preference, o) -> {
+                refreshActivity(true);
+                return true;
+            }));
+            barcodeOrientation.setSummary(barcodeOrientation.getEntry());
         }
 
         private void refreshActivity(boolean reloadMain) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,8 @@
     <string name="starImage">Favorite star</string>
     <string name="settings">Settings</string>
     <string name="settings_category_title_ui">User interface</string>
+    <string name="settings_category_title_barcode">Barcode</string>
+    <string name="settings_category_title_display">Display</string>
     <string name="settings_theme">Theme</string>
     <string name="settings_key_theme" translatable="false">pref_theme</string>
     <string name="settings_system_theme">System</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -51,12 +51,10 @@
             app:numberPickerPreference_unitText="%"
             app:singleLineTitle="false" />
 
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="@string/settings_key_display_barcode_max_brightness"
-            android:title="@string/settings_display_barcode_max_brightness"
-            app:iconSpaceReserved="false"
-            app:singleLineTitle="false" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:title="@string/settings_category_title_barcode"
+        app:iconSpaceReserved="false">
 
         <ListPreference
             android:defaultValue="@string/settings_key_follow_system_orientation"
@@ -66,6 +64,16 @@
             android:title="@string/settings_card_orientation"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="@string/settings_key_display_barcode_max_brightness"
+            android:title="@string/settings_display_barcode_max_brightness"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:title="@string/settings_category_title_display"
+        app:iconSpaceReserved="false">
 
         <SwitchPreferenceCompat
             android:defaultValue="true"
@@ -73,7 +81,6 @@
             android:title="@string/settings_keep_screen_on"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
-
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="@string/settings_key_disable_lockscreen_while_viewing_card"


### PR DESCRIPTION
This pull request fixes #1024 

Changes made -    
- Added two more groups in the settings screen, "Barcode" & "Display".
- Added the preference summary where needed.

I fixed the issue of adding the setting summary by just using the setSummary() method. I also added the refreshActivity() calls where necessary, to update this summary.

Signed-off-by: Shantanu Chaudhari <shantanuc1111@gmail.com>