### PR TITLE
Fix #399 Sort by balance

### DIFF
--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -64,7 +64,8 @@ public class DBHelper extends SQLiteOpenHelper {
     public enum LoyaltyCardOrder {
         Alpha,
         LastUsed,
-        Expiry
+        Expiry,
+        Balance
     }
 
     public enum LoyaltyCardOrderDirection {
@@ -877,6 +878,10 @@ public class DBHelper extends SQLiteOpenHelper {
 
         if (order == LoyaltyCardOrder.Expiry) {
             return LoyaltyCardDbIds.EXPIRY;
+        }
+
+        if(order == LoyaltyCardOrder.Balance) {
+            return LoyaltyCardDbIds.BALANCE;
         }
 
         throw new IllegalArgumentException("Unknown order " + order);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -12,5 +12,6 @@
         <item>@string/sort_by_name</item>
         <item>@string/sort_by_most_recently_used</item>
         <item>@string/sort_by_expiry</item>
+        <item>@string/sort_by_balance</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Ability to sort by balance. This will order via lowest and not set to highest, or in reverse highest to lowest.

I believe this is useful. If sorting was required to ignore cards with a balance not set then that could be an enhancement but the current functionality of this PR is useful.