### PR TITLE
Fix DatePickerDialog sometimes storing dates at 12 PM instead of 12 AM

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -59,6 +59,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Currency;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -1275,11 +1276,11 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
         }
 
         public void onDateSet(DatePicker view, int year, int month, int day) {
-            Calendar c = Calendar.getInstance();
+            Calendar c = new GregorianCalendar();
             c.set(Calendar.YEAR, year);
             c.set(Calendar.MONTH, month);
             c.set(Calendar.DAY_OF_MONTH, day);
-            c.set(Calendar.HOUR, 0);
+            c.set(Calendar.HOUR_OF_DAY, 0);
             c.set(Calendar.MINUTE, 0);
             c.set(Calendar.SECOND, 0);
             c.set(Calendar.MILLISECOND, 0);

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -217,6 +217,11 @@ public class Utils {
         date.set(Calendar.SECOND, 0);
         date.set(Calendar.MILLISECOND, 0);
 
+        // Note: In #1083 it was discovered that `DatePickerFragment` may sometimes store the expiryDate
+        // at 12:00 PM instead of 12:00 AM in the DB. While this has been fixed and the 12-hour difference
+        // is not a problem for the way the comparison currently works, it's good to keep in mind such
+        // dates may exist in the DB in case the comparison changes in the future and the new one relies
+        // on both dates being set at 12:00 AM.
         return expiryDate.before(date.getTime());
     }
 


### PR DESCRIPTION
Following a discussion in #1083, it was discovered that the `DatePickerDialog` may sometimes store the expiry date at 12:00 PM instead of 12:00 AM in the DB. While this is currently not a problem visible to the user, this PR fixes it, so it doesn't cause issues in the future in case new types of dates are added (like a 'valid from' date) or we change the way the expiry date comparison works. I also added a note reminding that some expiry dates have already been stored at 12:00 PM in the DB.