### PR TITLE
Correct Importing Flow

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -116,7 +116,7 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
                 Log.e(TAG, "Activity returned NULL data");
                 return;
             }
-            openFileForImport(result, null);
+            showDialogAfterFileToImportChosen(result);
         });
         filePickerLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
             Intent intent = result.getData();
@@ -129,7 +129,8 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
                 Log.e(TAG, "Activity returned NULL uri");
                 return;
             }
-            openFileForImport(intent.getData(), null);
+
+            showDialogAfterFileToImportChosen(intent.getData());
         });
 
         // Check that there is a file manager available
@@ -208,68 +209,58 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
         builder.setTitle(R.string.chooseImportType)
                 .setItems(importOptions.toArray(new CharSequence[importOptions.size()]), (dialog, which) -> {
-                    switch (which) {
-                        // Catima
-                        case 0:
-                            importAlertTitle = getString(R.string.importCatima);
-                            importAlertMessage = getString(R.string.importCatimaMessage);
-                            importDataFormat = DataFormat.Catima;
-                            break;
-                        // Fidme
-                        case 1:
-                            importAlertTitle = getString(R.string.importFidme);
-                            importAlertMessage = getString(R.string.importFidmeMessage);
-                            importDataFormat = DataFormat.Fidme;
-                            break;
-                        // Loyalty Card Keychain
-                        case 2:
-                            importAlertTitle = getString(R.string.importLoyaltyCardKeychain);
-                            importAlertMessage = getString(R.string.importLoyaltyCardKeychainMessage);
-                            importDataFormat = DataFormat.Catima;
-                            break;
-                        // Stocard
-                        case 3:
-                            importAlertTitle = getString(R.string.importStocard);
-                            importAlertMessage = getString(R.string.importStocardMessage);
-                            importDataFormat = DataFormat.Stocard;
-                            break;
-                        // Voucher Vault
-                        case 4:
-                            importAlertTitle = getString(R.string.importVoucherVault);
-                            importAlertMessage = getString(R.string.importVoucherVaultMessage);
-                            importDataFormat = DataFormat.VoucherVault;
-                            break;
-                        default:
-                            throw new IllegalArgumentException("Unknown DataFormat");
-                    }
+                            switch (which) {
+                                // Catima
+                                case 0:
+                                    importAlertTitle = getString(R.string.importCatima);
+                                    importAlertMessage = getString(R.string.importCatimaMessage);
+                                    importDataFormat = DataFormat.Catima;
+                                    break;
+                                // Fidme
+                                case 1:
+                                    importAlertTitle = getString(R.string.importFidme);
+                                    importAlertMessage = getString(R.string.importFidmeMessage);
+                                    importDataFormat = DataFormat.Fidme;
+                                    break;
+                                // Loyalty Card Keychain
+                                case 2:
+                                    importAlertTitle = getString(R.string.importLoyaltyCardKeychain);
+                                    importAlertMessage = getString(R.string.importLoyaltyCardKeychainMessage);
+                                    importDataFormat = DataFormat.Catima;
+                                    break;
+                                // Stocard
+                                case 3:
+                                    importAlertTitle = getString(R.string.importStocard);
+                                    importAlertMessage = getString(R.string.importStocardMessage);
+                                    importDataFormat = DataFormat.Stocard;
+                                    break;
+                                // Voucher Vault
+                                case 4:
+                                    importAlertTitle = getString(R.string.importVoucherVault);
+                                    importAlertMessage = getString(R.string.importVoucherVaultMessage);
+                                    importDataFormat = DataFormat.VoucherVault;
+                                    break;
+                                default:
+                                    throw new IllegalArgumentException("Unknown DataFormat");
+                            }
 
-                    if (fileData != null) {
-                        openFileForImport(fileData, null);
-                        return;
-                    }
+                            if (fileData != null) {
+                                openFileForImport(fileData, null);
+                                return;
+                            }
 
-                    new MaterialAlertDialogBuilder(this)
-                            .setTitle(importAlertTitle)
-                            .setMessage(importAlertMessage)
-                            .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    try {
-                                        if (choosePicker) {
-                                            final Intent intentPickAction = new Intent(Intent.ACTION_PICK);
-                                            filePickerLauncher.launch(intentPickAction);
-                                        } else {
-                                            fileOpenLauncher.launch("*/*");
-                                        }
-                                    } catch (ActivityNotFoundException e) {
-                                        Toast.makeText(getApplicationContext(), R.string.failedOpeningFileManager, Toast.LENGTH_LONG).show();
-                                        Log.e(TAG, "No activity found to handle intent", e);
-                                    }
+                            try {
+                                if (choosePicker) {
+                                    final Intent intentPickAction = new Intent(Intent.ACTION_PICK);
+                                    filePickerLauncher.launch(intentPickAction);
+                                } else {
+                                    fileOpenLauncher.launch("*/*");
                                 }
-                            })
-                            .setNegativeButton(R.string.cancel, null)
-                            .show();
-                });
+                            } catch (ActivityNotFoundException e) {
+                                Toast.makeText(getApplicationContext(), R.string.failedOpeningFileManager, Toast.LENGTH_LONG).show();
+                                Log.e(TAG, "No activity found to handle intent", e);
+                            }
+                        });
         builder.show();
     }
 
@@ -437,5 +428,24 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
         }
 
         builder.create().show();
+    }
+
+    private void showDialogAfterFileToImportChosen(Uri uri) {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(importAlertTitle)
+                .setMessage(importAlertMessage)
+                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        try {
+                            openFileForImport(uri, null);
+                        } catch (ActivityNotFoundException e) {
+                            Toast.makeText(getApplicationContext(), R.string.failedOpeningFileManager, Toast.LENGTH_LONG).show();
+                            Log.e(TAG, "No activity found to handle intent", e);
+                        }
+                    }
+                })
+                .setNegativeButton(R.string.cancel, null)
+                .show();
     }
 }

--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -86,7 +86,7 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
 
         Intent fileIntent = getIntent();
         if (fileIntent != null && fileIntent.getType() != null) {
-            chooseImportType(false, fileIntent.getData());
+            showDialogAfterFileToImportChosen(fileIntent.getData());
         }
 
         // would use ActivityResultContracts.CreateDocument() but mime type cannot be set
@@ -192,76 +192,17 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
 
     private void chooseImportType(boolean choosePicker,
                                   @Nullable Uri fileData) {
-
-        List<CharSequence> betaImportOptions = new ArrayList<>();
-        betaImportOptions.add("Fidme");
-        betaImportOptions.add("Stocard");
-        List<CharSequence> importOptions = new ArrayList<>();
-
-        for (String importOption : getResources().getStringArray(R.array.import_types_array)) {
-            if (betaImportOptions.contains(importOption)) {
-                importOption = importOption + " (BETA)";
+        try {
+            if (choosePicker) {
+                final Intent intentPickAction = new Intent(Intent.ACTION_PICK);
+                filePickerLauncher.launch(intentPickAction);
+            } else {
+                fileOpenLauncher.launch("*/*");
             }
-
-            importOptions.add(importOption);
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(getApplicationContext(), R.string.failedOpeningFileManager, Toast.LENGTH_LONG).show();
+            Log.e(TAG, "No activity found to handle intent", e);
         }
-
-        AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
-        builder.setTitle(R.string.chooseImportType)
-                .setItems(importOptions.toArray(new CharSequence[importOptions.size()]), (dialog, which) -> {
-                            switch (which) {
-                                // Catima
-                                case 0:
-                                    importAlertTitle = getString(R.string.importCatima);
-                                    importAlertMessage = getString(R.string.importCatimaMessage);
-                                    importDataFormat = DataFormat.Catima;
-                                    break;
-                                // Fidme
-                                case 1:
-                                    importAlertTitle = getString(R.string.importFidme);
-                                    importAlertMessage = getString(R.string.importFidmeMessage);
-                                    importDataFormat = DataFormat.Fidme;
-                                    break;
-                                // Loyalty Card Keychain
-                                case 2:
-                                    importAlertTitle = getString(R.string.importLoyaltyCardKeychain);
-                                    importAlertMessage = getString(R.string.importLoyaltyCardKeychainMessage);
-                                    importDataFormat = DataFormat.Catima;
-                                    break;
-                                // Stocard
-                                case 3:
-                                    importAlertTitle = getString(R.string.importStocard);
-                                    importAlertMessage = getString(R.string.importStocardMessage);
-                                    importDataFormat = DataFormat.Stocard;
-                                    break;
-                                // Voucher Vault
-                                case 4:
-                                    importAlertTitle = getString(R.string.importVoucherVault);
-                                    importAlertMessage = getString(R.string.importVoucherVaultMessage);
-                                    importDataFormat = DataFormat.VoucherVault;
-                                    break;
-                                default:
-                                    throw new IllegalArgumentException("Unknown DataFormat");
-                            }
-
-                            if (fileData != null) {
-                                openFileForImport(fileData, null);
-                                return;
-                            }
-
-                            try {
-                                if (choosePicker) {
-                                    final Intent intentPickAction = new Intent(Intent.ACTION_PICK);
-                                    filePickerLauncher.launch(intentPickAction);
-                                } else {
-                                    fileOpenLauncher.launch("*/*");
-                                }
-                            } catch (ActivityNotFoundException e) {
-                                Toast.makeText(getApplicationContext(), R.string.failedOpeningFileManager, Toast.LENGTH_LONG).show();
-                                Log.e(TAG, "No activity found to handle intent", e);
-                            }
-                        });
-        builder.show();
     }
 
     private void startImport(final InputStream target, final Uri targetUri, final DataFormat dataFormat, final char[] password, final boolean closeWhenDone) {
@@ -431,21 +372,81 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
     }
 
     private void showDialogAfterFileToImportChosen(Uri uri) {
-        new MaterialAlertDialogBuilder(this)
-                .setTitle(importAlertTitle)
-                .setMessage(importAlertMessage)
-                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        try {
-                            openFileForImport(uri, null);
-                        } catch (ActivityNotFoundException e) {
-                            Toast.makeText(getApplicationContext(), R.string.failedOpeningFileManager, Toast.LENGTH_LONG).show();
-                            Log.e(TAG, "No activity found to handle intent", e);
-                        }
+        List<CharSequence> betaImportOptions = new ArrayList<>();
+        betaImportOptions.add("Fidme");
+        betaImportOptions.add("Stocard");
+        List<CharSequence> importOptions = new ArrayList<>();
+
+        for (String importOption : getResources().getStringArray(R.array.import_types_array)) {
+            if (betaImportOptions.contains(importOption)) {
+                importOption = importOption + " (BETA)";
+            }
+
+            importOptions.add(importOption);
+        }
+
+        AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
+        builder.setTitle(R.string.chooseImportType)
+                .setItems(importOptions.toArray(new CharSequence[importOptions.size()]), (dialog, which) -> {
+                    switch (which) {
+                        // Catima
+                        case 0:
+                            importAlertTitle = getString(R.string.importCatima);
+                            importAlertMessage = getString(R.string.importCatimaMessage);
+                            importDataFormat = DataFormat.Catima;
+                            break;
+                        // Fidme
+                        case 1:
+                            importAlertTitle = getString(R.string.importFidme);
+                            importAlertMessage = getString(R.string.importFidmeMessage);
+                            importDataFormat = DataFormat.Fidme;
+                            break;
+                        // Loyalty Card Keychain
+                        case 2:
+                            importAlertTitle = getString(R.string.importLoyaltyCardKeychain);
+                            importAlertMessage = getString(R.string.importLoyaltyCardKeychainMessage);
+                            importDataFormat = DataFormat.Catima;
+                            break;
+                        // Stocard
+                        case 3:
+                            importAlertTitle = getString(R.string.importStocard);
+                            importAlertMessage = getString(R.string.importStocardMessage);
+                            importDataFormat = DataFormat.Stocard;
+                            break;
+                        // Voucher Vault
+                        case 4:
+                            importAlertTitle = getString(R.string.importVoucherVault);
+                            importAlertMessage = getString(R.string.importVoucherVaultMessage);
+                            importDataFormat = DataFormat.VoucherVault;
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Unknown DataFormat");
                     }
-                })
-                .setNegativeButton(R.string.cancel, null)
-                .show();
+
+//                    if (uri != null) {
+//                        openFileForImport(uri, null);
+//                        return;
+//                    }
+
+                    new MaterialAlertDialogBuilder(this)
+                            .setTitle(importAlertTitle)
+                            .setMessage(importAlertMessage)
+                            .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    try {
+                                        openFileForImport(uri, null);
+                                    } catch (ActivityNotFoundException e) {
+                                        Toast.makeText(getApplicationContext(), R.string.failedOpeningFileManager, Toast.LENGTH_LONG).show();
+                                        Log.e(TAG, "No activity found to handle intent", e);
+                                    }
+                                }
+                            })
+                            .setNegativeButton(R.string.cancel, null)
+                            .show();
+                });
+
+        builder.show();
     }
+
 }

--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -423,11 +423,6 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
                             throw new IllegalArgumentException("Unknown DataFormat");
                     }
 
-//                    if (uri != null) {
-//                        openFileForImport(uri, null);
-//                        return;
-//                    }
-
                     new MaterialAlertDialogBuilder(this)
                             .setTitle(importAlertTitle)
                             .setMessage(importAlertMessage)


### PR DESCRIPTION
Fixes #1102 

To allow for the importing flow to be:

1. User opens Import/Export screen
2. User clicks Import From Filesystem
3. User selects file
4. User is asked what type the import is
5. User selects option and import starts

the logic inside the **chooseFileToImport** method was altered. The part which was in charge of presenting a specific dialog per the file type chosen has been moved to a new method called **showDialogAfterFileToImportChosen** which accepts a Uri argument.

This method is called from three places:

1. fileOpenLauncher activity result handler
2. filePickerLauncher activity result handler
3. onCreate when there is an intent (activity was opened by a file import action)

The in-app flow has been tested as well as the outside app flow.

**In App Flow**

![import_from_app](https://user-images.githubusercontent.com/23402988/197411387-01724456-a46e-4b45-8f76-ba1b096e3684.gif)

**Out Of App Flow**

![import_from_outside_of_app](https://user-images.githubusercontent.com/23402988/197411456-9e4ac21d-a59e-4a79-99d9-331eed52dd5c.gif)

