### PR TITLE
Fix spacings in custom view of alert dialogs

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -483,15 +483,27 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
     private void showInfoDialog() {
         AlertDialog.Builder infoDialog = new MaterialAlertDialogBuilder(this);
 
+        int dialogContentPadding = getResources().getDimensionPixelSize(R.dimen.alert_dialog_content_padding);
+        int dialogTitlePadding = getResources().getDimensionPixelSize(R.dimen.alert_dialog_title_padding);
         TextView infoTitleView = new TextView(this);
-        infoTitleView.setPadding(20, 20, 20, 20);
+        infoTitleView.setPadding(
+                dialogContentPadding,
+                dialogContentPadding,
+                dialogContentPadding,
+                dialogTitlePadding
+        );
         infoTitleView.setTextSize(settings.getFontSizeMax(settings.getMediumFont()));
         infoTitleView.setText(loyaltyCard.store);
         infoDialog.setCustomTitle(infoTitleView);
         infoDialog.setTitle(loyaltyCard.store);
 
         TextView infoTextview = new TextView(this);
-        infoTextview.setPadding(20, 0, 20, 0);
+        infoTextview.setPadding(
+                dialogContentPadding,
+                0,
+                dialogContentPadding,
+                0
+        );
         infoTextview.setAutoLinkMask(Linkify.ALL);
         infoTextview.setTextIsSelectable(true);
 
@@ -544,8 +556,9 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         );
-        params.leftMargin = 60;
-        params.rightMargin = 60;
+        int contentPadding = getResources().getDimensionPixelSize(R.dimen.alert_dialog_content_padding);
+        params.leftMargin = contentPadding;
+        params.rightMargin = contentPadding;
 
         LinearLayout layout = new LinearLayout(this);
         layout.setOrientation(LinearLayout.VERTICAL);

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -34,7 +34,7 @@
     <dimen name="activity_margin">16dp</dimen>
     <!--    Padding for layouts-->
     <dimen name="activity_scanner_padding">10dp</dimen>
-    <dimen name="alert_dialog_content_padding">16dp</dimen>
+    <dimen name="alert_dialog_content_padding">@dimen/mtrl_alert_dialog_picker_background_inset</dimen>
     <dimen name="alert_dialog_title_padding">8dp</dimen>
     <!-- The default letter tile text size -->
     <dimen name="tileLetterFontSize">66sp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -34,6 +34,8 @@
     <dimen name="activity_margin">16dp</dimen>
     <!--    Padding for layouts-->
     <dimen name="activity_scanner_padding">10dp</dimen>
+    <dimen name="alert_dialog_content_padding">16dp</dimen>
+    <dimen name="alert_dialog_title_padding">8dp</dimen>
     <!-- The default letter tile text size -->
     <dimen name="tileLetterFontSize">66sp</dimen>
     <dimen name="tileLetterFontSizeForShortcut">48dp</dimen>


### PR DESCRIPTION
#1074

Views are expecting pixel values. Using 20 or 60 will result in different spacing per device resultion. 

Extract those values to dimens and we dont have to deal with that anymore.