### PR TITLE
Add Percent To Currency

### DIFF
--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -18,6 +18,8 @@ import java.util.Currency;
 import java.util.Date;
 import java.util.List;
 
+import protect.card_locker.currency.CatimaCurrency;
+
 public class DBHelper extends SQLiteOpenHelper {
     public static final String DATABASE_NAME = "Catima.db";
     public static final int ORIGINAL_DATABASE_VERSION = 1;
@@ -359,7 +361,7 @@ public class DBHelper extends SQLiteOpenHelper {
 
     public static long insertLoyaltyCard(
             final SQLiteDatabase database, final String store, final String note, final Date expiry,
-            final BigDecimal balance, final Currency balanceType, final String cardId,
+            final BigDecimal balance, final CatimaCurrency balanceType, final String cardId,
             final String barcodeId, final CatimaBarcode barcodeType, final Integer headerColor,
             final int starStatus, final Long lastUsed, final int archiveStatus) {
         database.beginTransaction();
@@ -424,7 +426,7 @@ public class DBHelper extends SQLiteOpenHelper {
 
     public static boolean updateLoyaltyCard(
             SQLiteDatabase database, final int id, final String store, final String note,
-            final Date expiry, final BigDecimal balance, final Currency balanceType,
+            final Date expiry, final BigDecimal balance, final CatimaCurrency balanceType,
             final String cardId, final String barcodeId, final CatimaBarcode barcodeType,
             final Integer headerColor, final int starStatus, final Long lastUsed, final int archiveStatus) {
         database.beginTransaction();

--- a/app/src/main/java/protect/card_locker/ImportURIHelper.java
+++ b/app/src/main/java/protect/card_locker/ImportURIHelper.java
@@ -15,6 +15,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
+import protect.card_locker.currency.CatimaCurrency;
+
 public class ImportURIHelper {
     private static final String STORE = DBHelper.LoyaltyCardDbIds.STORE;
     private static final String NOTE = DBHelper.LoyaltyCardDbIds.NOTE;
@@ -64,7 +66,7 @@ public class ImportURIHelper {
             CatimaBarcode barcodeType = null;
             Date expiry = null;
             BigDecimal balance = new BigDecimal("0");
-            Currency balanceType = null;
+            CatimaCurrency balanceType = null;
             Integer headerColor = null;
 
             // Store everything in a simple key/value hashmap
@@ -104,7 +106,8 @@ public class ImportURIHelper {
             }
             String unparsedBalanceType = kv.get(BALANCE_TYPE);
             if (unparsedBalanceType != null && !unparsedBalanceType.equals("")) {
-                balanceType = Currency.getInstance(unparsedBalanceType);
+                Currency currency = Currency.getInstance(unparsedBalanceType);
+                balanceType = new CatimaCurrency(currency);
             }
             String unparsedExpiry = kv.get(EXPIRY);
             if (unparsedExpiry != null && !unparsedExpiry.equals("")) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCard.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCard.java
@@ -9,6 +9,7 @@ import java.util.Currency;
 import java.util.Date;
 
 import androidx.annotation.Nullable;
+import protect.card_locker.currency.CatimaCurrency;
 
 public class LoyaltyCard implements Parcelable {
     public final int id;
@@ -16,7 +17,7 @@ public class LoyaltyCard implements Parcelable {
     public final String note;
     public final Date expiry;
     public final BigDecimal balance;
-    public final Currency balanceType;
+    public final CatimaCurrency balanceType;
     public final String cardId;
 
     @Nullable
@@ -34,7 +35,7 @@ public class LoyaltyCard implements Parcelable {
     public int zoomLevel;
 
     public LoyaltyCard(final int id, final String store, final String note, final Date expiry,
-                       final BigDecimal balance, final Currency balanceType, final String cardId,
+                       final BigDecimal balance, final CatimaCurrency balanceType, final String cardId,
                        @Nullable final String barcodeId, @Nullable final CatimaBarcode barcodeType,
                        @Nullable final Integer headerColor, final int starStatus,
                        final long lastUsed, final int zoomLevel, final int archiveStatus) {
@@ -61,7 +62,7 @@ public class LoyaltyCard implements Parcelable {
         long tmpExpiry = in.readLong();
         expiry = tmpExpiry != -1 ? new Date(tmpExpiry) : null;
         balance = (BigDecimal) in.readValue(BigDecimal.class.getClassLoader());
-        balanceType = (Currency) in.readValue(Currency.class.getClassLoader());
+        balanceType = (CatimaCurrency) in.readValue(Currency.class.getClassLoader());
         cardId = in.readString();
         barcodeId = in.readString();
         String tmpBarcodeType = in.readString();
@@ -110,7 +111,7 @@ public class LoyaltyCard implements Parcelable {
         int headerColorColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR);
 
         CatimaBarcode barcodeType = null;
-        Currency balanceType = null;
+        CatimaCurrency balanceType = null;
         Date expiry = null;
         Integer headerColor = null;
 
@@ -119,7 +120,19 @@ public class LoyaltyCard implements Parcelable {
         }
 
         if (cursor.isNull(balanceTypeColumn) == false) {
-            balanceType = Currency.getInstance(cursor.getString(balanceTypeColumn));
+            String currencySymbol = cursor.getString(balanceTypeColumn);
+            Currency currency = null;
+            try {
+                currency = Currency.getInstance(currencySymbol);
+            } catch(Exception exception) {
+                exception.printStackTrace();
+            }
+
+            if (currency == null) {
+                balanceType = new CatimaCurrency(currencySymbol);
+            } else {
+                balanceType = new CatimaCurrency(currency);
+            }
         }
 
         if (expiryLong > 0) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCard.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCard.java
@@ -128,11 +128,9 @@ public class LoyaltyCard implements Parcelable {
                 exception.printStackTrace();
             }
 
-            if (currency == null) {
-                balanceType = new CatimaCurrency(currencySymbol);
-            } else {
-                balanceType = new CatimaCurrency(currency);
-            }
+            balanceType = currency == null ?
+                    new CatimaCurrency(currencySymbol) :
+                    new CatimaCurrency(currency);
         }
 
         if (expiryLong > 0) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -323,8 +323,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
             currencies.put(currency.getSymbol(), new CatimaCurrency(currency));
         }
 
-        CatimaCurrency percentCurrency = new CatimaCurrency("Percent");
-        CatimaCurrency pointCurrency = new CatimaCurrency("Points");
+        CatimaCurrency percentCurrency = new CatimaCurrency(getString(R.string.percent));
+        CatimaCurrency pointCurrency = new CatimaCurrency(getString(R.string.points));
 
         currencies.put(percentCurrency.getSymbol(), percentCurrency);
         currencies.put(pointCurrency.getSymbol(), pointCurrency);
@@ -469,8 +469,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                     currencyPrioritizeLocaleSymbols(currencyList, mSystemLocale);
                 }
 
-                currencyList.add(0, "Points");
-                currencyList.add(1,"Percent");
+                currencyList.add(0, getString(R.string.points));
+                currencyList.add(1,getString(R.string.percent));
                 ArrayAdapter<String> currencyAdapter = new ArrayAdapter<>(LoyaltyCardEditActivity.this, android.R.layout.select_dialog_item, currencyList);
                 balanceCurrencyField.setAdapter(currencyAdapter);
             }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -80,6 +80,7 @@ import androidx.core.content.FileProvider;
 import androidx.exifinterface.media.ExifInterface;
 import androidx.fragment.app.DialogFragment;
 import protect.card_locker.async.TaskHandler;
+import protect.card_locker.currency.CatimaCurrency;
 import protect.card_locker.databinding.LayoutChipChoiceBinding;
 import protect.card_locker.databinding.LoyaltyCardEditActivityBinding;
 
@@ -167,7 +168,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
     boolean validBalance = true;
     Runnable barcodeImageGenerationFinishedCallback;
 
-    HashMap<String, Currency> currencies = new HashMap<>();
+    HashMap<String, CatimaCurrency> currencies = new HashMap<>();
 
     LoyaltyCard tempLoyaltyCard;
 
@@ -207,7 +208,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                 (String) (fieldName == LoyaltyCardField.note ? value : loyaltyCard.note),
                 (Date) (fieldName == LoyaltyCardField.expiry ? value : loyaltyCard.expiry),
                 (BigDecimal) (fieldName == LoyaltyCardField.balance ? value : loyaltyCard.balance),
-                (Currency) (fieldName == LoyaltyCardField.balanceType ? value : loyaltyCard.balanceType),
+                (CatimaCurrency) (fieldName == LoyaltyCardField.balanceType ? value : loyaltyCard.balanceType),
                 (String) (fieldName == LoyaltyCardField.cardId ? value : loyaltyCard.cardId),
                 (String) (fieldName == LoyaltyCardField.barcodeId ? value : loyaltyCard.barcodeId),
                 (CatimaBarcode) (fieldName == LoyaltyCardField.barcodeType ? value : loyaltyCard.barcodeType),
@@ -319,8 +320,14 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
         importUriHelper = new ImportURIHelper(this);
 
         for (Currency currency : Currency.getAvailableCurrencies()) {
-            currencies.put(currency.getSymbol(), currency);
+            currencies.put(currency.getSymbol(), new CatimaCurrency(currency));
         }
+
+        CatimaCurrency percentCurrency = new CatimaCurrency("Percent");
+        CatimaCurrency pointCurrency = new CatimaCurrency("Points");
+
+        currencies.put(percentCurrency.getSymbol(), percentCurrency);
+        currencies.put(pointCurrency.getSymbol(), pointCurrency);
 
         tabs = binding.tabs;
         thumbnail = binding.thumbnail;
@@ -423,13 +430,9 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
         balanceCurrencyField.addTextChangedListener(new SimpleTextWatcher() {
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-                Currency currency;
+                CatimaCurrency currency;
 
-                if (s.toString().equals(getString(R.string.points))) {
-                    currency = null;
-                } else {
-                    currency = currencies.get(s.toString());
-                }
+                currency = currencies.get(s.toString());
 
                 updateTempState(LoyaltyCardField.balanceType, currency);
 
@@ -466,7 +469,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                     currencyPrioritizeLocaleSymbols(currencyList, mSystemLocale);
                 }
 
-                currencyList.add(0, getString(R.string.points));
+                currencyList.add(0, "Points");
+                currencyList.add(1,"Percent");
                 ArrayAdapter<String> currencyAdapter = new ArrayAdapter<>(LoyaltyCardEditActivity.this, android.R.layout.select_dialog_item, currencyList);
                 balanceCurrencyField.setAdapter(currencyAdapter);
             }
@@ -967,7 +971,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
         }
     }
 
-    private void formatBalanceCurrencyField(Currency balanceType) {
+    private void formatBalanceCurrencyField(CatimaCurrency balanceType) {
         if (balanceType == null) {
             balanceCurrencyField.setText(getString(R.string.points));
         } else {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -323,7 +323,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
             currencies.put(currency.getSymbol(), new CatimaCurrency(currency));
         }
 
-        CatimaCurrency percentCurrency = new CatimaCurrency(getString(R.string.percent));
+        CatimaCurrency percentCurrency = new CatimaCurrency(getString(R.string.percentSymbol));
         CatimaCurrency pointCurrency = new CatimaCurrency(getString(R.string.points));
 
         currencies.put(percentCurrency.getSymbol(), percentCurrency);
@@ -470,7 +470,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                 }
 
                 currencyList.add(0, getString(R.string.points));
-                currencyList.add(1,getString(R.string.percent));
+                currencyList.add(1,getString(R.string.percentSymbol));
                 ArrayAdapter<String> currencyAdapter = new ArrayAdapter<>(LoyaltyCardEditActivity.this, android.R.layout.select_dialog_item, currencyList);
                 balanceCurrencyField.setAdapter(currencyAdapter);
             }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -2,7 +2,6 @@ package protect.card_locker;
 
 import android.content.ActivityNotFoundException;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.ColorStateList;
@@ -15,7 +14,6 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
-import android.text.Editable;
 import android.text.InputType;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -58,7 +56,6 @@ import androidx.core.graphics.BlendModeColorFilterCompat;
 import androidx.core.graphics.BlendModeCompat;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.core.widget.TextViewCompat;
 
@@ -74,10 +71,10 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Currency;
 import java.util.List;
 
 import protect.card_locker.async.TaskHandler;
+import protect.card_locker.currency.CatimaCurrency;
 import protect.card_locker.databinding.LoyaltyCardViewLayoutBinding;
 import protect.card_locker.preferences.Settings;
 
@@ -616,7 +613,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         input.requestFocus();
     }
 
-    private BigDecimal calculateNewBalance(BigDecimal currentBalance, Currency currency, String unparsedSubtraction) throws ParseException {
+    private BigDecimal calculateNewBalance(BigDecimal currentBalance, CatimaCurrency currency, String unparsedSubtraction) throws ParseException {
         BigDecimal subtraction = Utils.parseBalance(unparsedSubtraction, currency);
         return currentBalance.subtract(subtraction).max(new BigDecimal(0));
     }

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -235,7 +235,7 @@ public class Utils {
                 numberFormat.setMaximumFractionDigits(0);
                 return context.getResources().getQuantityString(R.plurals.balancePoints, value.intValue(), numberFormat.format(value));
 
-            } else if (catimaCurrency.getSymbol().equals(context.getString(R.string.percent))) {
+            } else if (catimaCurrency.getSymbol().equals(context.getString(R.string.percentSymbol))) {
                 numberFormat.setMaximumFractionDigits(2);
                 return numberFormat.format(value) + context.getString(R.string.percentSymbol);
             }

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -51,6 +51,7 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.Map;
 
+import protect.card_locker.currency.CatimaCurrency;
 import protect.card_locker.preferences.Settings;
 
 public class Utils {
@@ -225,23 +226,30 @@ public class Utils {
         return expiryDate.before(date.getTime());
     }
 
-    static public String formatBalance(Context context, BigDecimal value, Currency currency) {
+    static public String formatBalance(Context context, BigDecimal value, CatimaCurrency catimaCurrency) {
         NumberFormat numberFormat = NumberFormat.getInstance();
-
+        Currency currency = catimaCurrency.getCurrency();
+        //Points or Percent
         if (currency == null) {
-            numberFormat.setMaximumFractionDigits(0);
-            return context.getResources().getQuantityString(R.plurals.balancePoints, value.intValue(), numberFormat.format(value));
+            if (catimaCurrency.getSymbol().equals("Points")) {
+                numberFormat.setMaximumFractionDigits(0);
+                return context.getResources().getQuantityString(R.plurals.balancePoints, value.intValue(), numberFormat.format(value));
+
+            } else if (catimaCurrency.getSymbol().equals("Percent")) {
+                numberFormat.setMaximumFractionDigits(2);
+                return value.intValue() + catimaCurrency.getSymbol();
+            }
         }
 
         NumberFormat currencyFormat = NumberFormat.getCurrencyInstance();
-        currencyFormat.setCurrency(currency);
-        currencyFormat.setMinimumFractionDigits(currency.getDefaultFractionDigits());
-        currencyFormat.setMaximumFractionDigits(currency.getDefaultFractionDigits());
+        currencyFormat.setCurrency(catimaCurrency.getCurrency());
+        currencyFormat.setMinimumFractionDigits(catimaCurrency.getDefaultFractionDigits());
+        currencyFormat.setMaximumFractionDigits(catimaCurrency.getDefaultFractionDigits());
 
         return currencyFormat.format(value);
     }
 
-    static public String formatBalanceWithoutCurrencySymbol(BigDecimal value, Currency currency) {
+    static public String formatBalanceWithoutCurrencySymbol(BigDecimal value, CatimaCurrency currency) {
         NumberFormat numberFormat = NumberFormat.getInstance();
 
         if (currency == null) {
@@ -255,7 +263,7 @@ public class Utils {
         return numberFormat.format(value);
     }
 
-    static public BigDecimal parseBalance(String value, Currency currency) throws ParseException {
+    static public BigDecimal parseBalance(String value, CatimaCurrency currency) throws ParseException {
         NumberFormat numberFormat = NumberFormat.getInstance();
 
         if (currency == null) {

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -237,7 +237,7 @@ public class Utils {
 
             } else if (catimaCurrency.getSymbol().equals(context.getString(R.string.percent))) {
                 numberFormat.setMaximumFractionDigits(2);
-                return numberFormat.format(value) + "%";
+                return numberFormat.format(value) + context.getString(R.string.percentSymbol);
             }
         }
 

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -231,13 +231,13 @@ public class Utils {
         Currency currency = catimaCurrency.getCurrency();
         //Points or Percent
         if (currency == null) {
-            if (catimaCurrency.getSymbol().equals("Points")) {
+            if (catimaCurrency.getSymbol().equals(context.getString(R.string.points))) {
                 numberFormat.setMaximumFractionDigits(0);
                 return context.getResources().getQuantityString(R.plurals.balancePoints, value.intValue(), numberFormat.format(value));
 
-            } else if (catimaCurrency.getSymbol().equals("Percent")) {
+            } else if (catimaCurrency.getSymbol().equals(context.getString(R.string.percent))) {
                 numberFormat.setMaximumFractionDigits(2);
-                return value.intValue() + catimaCurrency.getSymbol();
+                return numberFormat.format(value) + "%";
             }
         }
 

--- a/app/src/main/java/protect/card_locker/currency/CatimaCurrency.java
+++ b/app/src/main/java/protect/card_locker/currency/CatimaCurrency.java
@@ -6,10 +6,8 @@ import androidx.annotation.Nullable;
 
 public class CatimaCurrency {
 
-    private Currency mCurrency;
-    private String mSpecialSymbol;
-
-    private static final String Percent = "Percent";
+    private final Currency mCurrency;
+    private final String mSpecialSymbol;
 
     public CatimaCurrency(Currency currency) {
         mCurrency = currency;

--- a/app/src/main/java/protect/card_locker/currency/CatimaCurrency.java
+++ b/app/src/main/java/protect/card_locker/currency/CatimaCurrency.java
@@ -1,0 +1,74 @@
+package protect.card_locker.currency;
+
+import java.util.Currency;
+
+import androidx.annotation.Nullable;
+
+public class CatimaCurrency {
+
+    private Currency mCurrency;
+    private String mSpecialSymbol = "%";
+
+    private static final String Points = "Points";
+    private static final String Percentage = "Percentage";
+    private static final String None = "";
+
+    public CatimaCurrency(Currency currency, String currencySymbol) {
+        mCurrency = currency;
+        mSpecialSymbol = currencySymbol;
+    }
+
+    public CatimaCurrency fromCurrency(Currency currency) {
+        if (currency == null) {
+            mCurrency = null;
+            mSpecialSymbol = CatimaCurrency.None;
+        } else {
+            mCurrency = currency;
+            mSpecialSymbol = currency.getSymbol();
+        }
+
+        return this;
+    }
+
+    public CatimaCurrency fromCurrencyCode(String currencyCode) {
+        //Points
+        if (currencyCode == null) {
+            mCurrency = null;
+            mSpecialSymbol = CatimaCurrency.Points;
+        } else if (currencyCode.equals("%")) {
+            mCurrency = null;
+            mSpecialSymbol = CatimaCurrency.Percentage;
+        } else {
+            mCurrency = Currency.getInstance(currencyCode);
+            mSpecialSymbol = CatimaCurrency.None;
+        }
+
+        return this;
+    }
+
+    public int getDefaultFractionDigits() {
+        if (mCurrency != null) {
+            return mCurrency.getDefaultFractionDigits();
+        } else if (mSpecialSymbol.equals(CatimaCurrency.Percentage)) {
+            return 2;
+        }
+        return 0;
+    }
+
+    public String getSymbol() {
+        return mSpecialSymbol;
+    }
+
+    public String getCurrencyCode() {
+        if (mCurrency != null) {
+            return mCurrency.getCurrencyCode();
+        }
+        return mSpecialSymbol;
+    }
+
+    @Nullable
+    public Currency getCurrency() {
+        return mCurrency;
+    }
+
+}

--- a/app/src/main/java/protect/card_locker/currency/CatimaCurrency.java
+++ b/app/src/main/java/protect/card_locker/currency/CatimaCurrency.java
@@ -7,55 +7,33 @@ import androidx.annotation.Nullable;
 public class CatimaCurrency {
 
     private Currency mCurrency;
-    private String mSpecialSymbol = "%";
+    private String mSpecialSymbol;
 
-    private static final String Points = "Points";
-    private static final String Percentage = "Percentage";
-    private static final String None = "";
+    private static final String Percent = "Percent";
 
-    public CatimaCurrency(Currency currency, String currencySymbol) {
+    public CatimaCurrency(Currency currency) {
         mCurrency = currency;
+        mSpecialSymbol = null;
+    }
+
+    public CatimaCurrency(String currencySymbol) {
         mSpecialSymbol = currencySymbol;
-    }
-
-    public CatimaCurrency fromCurrency(Currency currency) {
-        if (currency == null) {
-            mCurrency = null;
-            mSpecialSymbol = CatimaCurrency.None;
-        } else {
-            mCurrency = currency;
-            mSpecialSymbol = currency.getSymbol();
-        }
-
-        return this;
-    }
-
-    public CatimaCurrency fromCurrencyCode(String currencyCode) {
-        //Points
-        if (currencyCode == null) {
-            mCurrency = null;
-            mSpecialSymbol = CatimaCurrency.Points;
-        } else if (currencyCode.equals("%")) {
-            mCurrency = null;
-            mSpecialSymbol = CatimaCurrency.Percentage;
-        } else {
-            mCurrency = Currency.getInstance(currencyCode);
-            mSpecialSymbol = CatimaCurrency.None;
-        }
-
-        return this;
+        mCurrency = null;
     }
 
     public int getDefaultFractionDigits() {
         if (mCurrency != null) {
             return mCurrency.getDefaultFractionDigits();
-        } else if (mSpecialSymbol.equals(CatimaCurrency.Percentage)) {
-            return 2;
         }
+
         return 0;
     }
 
     public String getSymbol() {
+        if (mCurrency != null) {
+            return mCurrency.getSymbol();
+        }
+
         return mSpecialSymbol;
     }
 

--- a/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
@@ -27,6 +27,7 @@ import protect.card_locker.CatimaBarcode;
 import protect.card_locker.DBHelper;
 import protect.card_locker.FormatException;
 import protect.card_locker.Utils;
+import protect.card_locker.currency.CatimaCurrency;
 
 /**
  * Class for importing a database from CSV (Comma Separate Values)
@@ -67,8 +68,8 @@ public class VoucherVaultImporter implements Importer {
             } else if (!jsonCard.isNull("balance")) {
                 balance = new BigDecimal(String.valueOf(jsonCard.getDouble("balance")));
             }
-
-            Currency balanceType = Currency.getInstance("USD");
+            Currency currency = Currency.getInstance("USD");
+            CatimaCurrency balanceType = new CatimaCurrency(currency);
 
             String cardId = jsonCard.getString("code");
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="currency">Currency</string>
     <string name="points">Points</string>
     <string name="percent">Percent</string>
+    <string name="percentSymbol">%</string>
     <string name="parsingBalanceFailed"><xliff:g>%s</xliff:g> does not seem to be a valid balance.</string>
     <string name="chooseImportType">Import data from</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,7 @@
     <string name="balance">Balance</string>
     <string name="currency">Currency</string>
     <string name="points">Points</string>
+    <string name="percent">Percent</string>
     <string name="parsingBalanceFailed"><xliff:g>%s</xliff:g> does not seem to be a valid balance.</string>
     <string name="chooseImportType">Import data from</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>

--- a/app/src/test/java/protect/card_locker/DatabaseTest.java
+++ b/app/src/test/java/protect/card_locker/DatabaseTest.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
 
+import protect.card_locker.currency.CatimaCurrency;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -75,7 +77,7 @@ public class DatabaseTest {
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
-        result = DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, new BigDecimal("10.00"), Currency.getInstance("EUR"), "cardId1", null, CatimaBarcode.fromBarcode(BarcodeFormat.AZTEC), DEFAULT_HEADER_COLOR, 0, null, 0);
+        result = DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, new BigDecimal("10.00"), new CatimaCurrency(Currency.getInstance("EUR")), "cardId1", null, CatimaBarcode.fromBarcode(BarcodeFormat.AZTEC), DEFAULT_HEADER_COLOR, 0, null, 0);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 
 import androidx.core.content.res.ResourcesCompat;
 import protect.card_locker.async.TaskHandler;
+import protect.card_locker.currency.CatimaCurrency;
 import protect.card_locker.importexport.DataFormat;
 import protect.card_locker.importexport.ImportExportResult;
 import protect.card_locker.importexport.ImportExportResultType;
@@ -889,7 +890,7 @@ public class ImportExportTest {
         HashMap<Integer, Bitmap> loyaltyCardIconImages = new HashMap<>();
 
         // Create card 1
-        int loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 1", "Note 1", new Date(1618053234), new BigDecimal("100"), Currency.getInstance("USD"), "1234", "5432", CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), 1, 0, null,0);
+        int loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 1", "Note 1", new Date(1618053234), new BigDecimal("100"), new CatimaCurrency(Currency.getInstance("USD")), "1234", "5432", CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), 1, 0, null,0);
         loyaltyCardHashMap.put(loyaltyCardId, DBHelper.getLoyaltyCard(mDatabase, loyaltyCardId));
         DBHelper.insertGroup(mDatabase, "One");
         List<Group> groups = Arrays.asList(DBHelper.getGroup(mDatabase, "One"));

--- a/app/src/test/java/protect/card_locker/ImportURITest.java
+++ b/app/src/test/java/protect/card_locker/ImportURITest.java
@@ -20,6 +20,8 @@ import java.math.BigDecimal;
 import java.util.Currency;
 import java.util.Date;
 
+import protect.card_locker.currency.CatimaCurrency;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -71,7 +73,7 @@ public class ImportURITest {
     @Test
     public void ensureNoCrashOnMissingHeaderFields() throws InvalidObjectException, UnsupportedEncodingException {
         // Generate card
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("EUR"), BarcodeFormat.UPC_A.toString(), null, CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), null, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), new CatimaCurrency(Currency.getInstance("EUR")), BarcodeFormat.UPC_A.toString(), null, CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), null, 0, null,0);
 
         // Get card
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
@@ -25,6 +25,7 @@ import java.util.Date;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.preference.PreferenceManager;
+import protect.card_locker.currency.CatimaCurrency;
 import protect.card_locker.preferences.Settings;
 
 import static org.junit.Assert.assertEquals;
@@ -223,7 +224,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter0EUR() {
-        DBHelper.insertLoyaltyCard(mDatabase,"store", "", null, new BigDecimal("0"), Currency.getInstance("EUR"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase,"store", "", null, new BigDecimal("0"), new CatimaCurrency(Currency.getInstance("EUR")), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -253,7 +254,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter10USD() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("USD"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), new CatimaCurrency(Currency.getInstance("USD")), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -57,6 +57,7 @@ import java.util.Date;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.widget.TextViewCompat;
 import androidx.preference.PreferenceManager;
+import protect.card_locker.currency.CatimaCurrency;
 
 import static android.os.Looper.getMainLooper;
 import static org.junit.Assert.assertEquals;
@@ -795,7 +796,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("10.00"), new CatimaCurrency(Currency.getInstance("USD")), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
 
         activityController.start();
         activityController.visible();


### PR DESCRIPTION
Fixes #1031 

To allow for Catima to support the percentage symbol as a type of currency an overhaul was made.
This was needed because percentage is not considered a currency by the operating system and a null currency was considered to be points.

Therefore, a new class was created, called **CatimaCurrency**. It has two fields:

- mCurrency of Currency type
- mSpecialSymbol of String type

It was placed inside a new module called currency. In this object, you can either have a currency field or a specialSymbol field but not both.

A lot of places in the code which used to work with a Currency object, now work with a CatimaCurrency object.

As such, I have opened  this as a DRAFT PR.

A screen recording can be seen below of changing currency type for a specific card.
![qemu-system-x86_64_amQTT0Ybms](https://user-images.githubusercontent.com/23402988/199607858-8510ef1b-ba8c-42b3-bf73-3f683db47268.gif)