### PR TITLE
Set card scanned with "Select image from gallery" as photo

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportURIHelper.java
+++ b/app/src/main/java/protect/card_locker/ImportURIHelper.java
@@ -116,7 +116,7 @@ public class ImportURIHelper {
                 headerColor = Integer.parseInt(unparsedHeaderColor);
             }
 
-            return new LoyaltyCard(-1, store, note, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, 0, Utils.getUnixTime(), 100,0);
+            return new LoyaltyCard(-1, store, note, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, 0, Utils.getUnixTime(), 100,0,0,0 );
         } catch (NullPointerException | NumberFormatException | UnsupportedEncodingException ex) {
             throw new InvalidObjectException("Not a valid import URI");
         }

--- a/app/src/main/java/protect/card_locker/LoyaltyCard.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCard.java
@@ -30,6 +30,8 @@ public class LoyaltyCard implements Parcelable {
 
     public final int starStatus;
     public final int archiveStatus;
+    public final int frontUserDefined;
+    public final int backUserDefined;
     public final long lastUsed;
     public int zoomLevel;
 
@@ -37,7 +39,7 @@ public class LoyaltyCard implements Parcelable {
                        final BigDecimal balance, final Currency balanceType, final String cardId,
                        @Nullable final String barcodeId, @Nullable final CatimaBarcode barcodeType,
                        @Nullable final Integer headerColor, final int starStatus,
-                       final long lastUsed, final int zoomLevel, final int archiveStatus) {
+                       final long lastUsed, final int zoomLevel, final int archiveStatus, final int frontUserDefined, final int backUserDefined) {
         this.id = id;
         this.store = store;
         this.note = note;
@@ -52,6 +54,8 @@ public class LoyaltyCard implements Parcelable {
         this.lastUsed = lastUsed;
         this.zoomLevel = zoomLevel;
         this.archiveStatus = archiveStatus;
+        this.frontUserDefined = frontUserDefined;
+        this.backUserDefined = backUserDefined;
     }
 
     protected LoyaltyCard(Parcel in) {
@@ -72,6 +76,8 @@ public class LoyaltyCard implements Parcelable {
         lastUsed = in.readLong();
         zoomLevel = in.readInt();
         archiveStatus = in.readInt();
+        frontUserDefined =  in.readInt();
+        backUserDefined = in.readInt();
     }
 
     @Override
@@ -90,6 +96,8 @@ public class LoyaltyCard implements Parcelable {
         parcel.writeLong(lastUsed);
         parcel.writeInt(zoomLevel);
         parcel.writeInt(archiveStatus);
+        parcel.writeInt(frontUserDefined);
+        parcel.writeInt(backUserDefined);
     }
 
     public static LoyaltyCard toLoyaltyCard(Cursor cursor) {
@@ -104,6 +112,8 @@ public class LoyaltyCard implements Parcelable {
         long lastUsed = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.LAST_USED));
         int zoomLevel = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ZOOM_LEVEL));
         int archived = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS));
+        int frontUserDefined = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.FRONT_USER_DEFINED));
+        int backUserDefined = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BACK_USER_DEFINED));
 
         int barcodeTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE);
         int balanceTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE);
@@ -130,7 +140,7 @@ public class LoyaltyCard implements Parcelable {
             headerColor = cursor.getInt(headerColorColumn);
         }
 
-        return new LoyaltyCard(id, store, note, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, starred, lastUsed, zoomLevel,archived);
+        return new LoyaltyCard(id, store, note, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, starred, lastUsed, zoomLevel,archived, frontUserDefined, backUserDefined);
     }
 
     @Override

--- a/app/src/main/java/protect/card_locker/LoyaltyCardField.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardField.java
@@ -12,5 +12,7 @@ public enum LoyaltyCardField {
     barcodeType,
     headerColor,
     starStatus,
-    archiveStatus
+    archiveStatus,
+    frontUserDefined,
+    backUserDefined
 }

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -344,7 +344,8 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
 
             Bundle inputBundle = intent.getExtras();
             String group = inputBundle != null ? inputBundle.getString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP) : null;
-            processBarcodeValues(barcodeValues, group);
+            Uri coverUri = inputBundle != null ?inputBundle.getParcelable(LoyaltyCardEditActivity.BUNDLE_COVER_URI): null;
+            processBarcodeValues(barcodeValues, group,coverUri);
         });
 
         mSettingsLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
@@ -498,7 +499,7 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         }
     }
 
-    private void processBarcodeValues(BarcodeValues barcodeValues, String group) {
+    private void processBarcodeValues(BarcodeValues barcodeValues, String group, Uri coverUri) {
         if (barcodeValues.isEmpty()) {
             throw new IllegalArgumentException("barcodesValues may not be empty");
         }
@@ -507,6 +508,9 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         Bundle newBundle = new Bundle();
         newBundle.putString(LoyaltyCardEditActivity.BUNDLE_BARCODETYPE, barcodeValues.format());
         newBundle.putString(LoyaltyCardEditActivity.BUNDLE_CARDID, barcodeValues.content());
+        if(coverUri != null) {
+            newBundle.putParcelable(LoyaltyCardEditActivity.BUNDLE_COVER_URI, coverUri);
+        }
         if (group != null) {
             newBundle.putString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP, group);
         }
@@ -548,7 +552,7 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
                     finish();
                     return;
                 }
-                processBarcodeValues(barcodeValues, null);
+                processBarcodeValues(barcodeValues, null, null);
             } else {
                 Log.e(TAG, "Wrong mime-type");
             }

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -206,6 +206,7 @@ public class ScanActivity extends CatimaAppCompatActivity {
             Bundle manualResultBundle = new Bundle();
             manualResultBundle.putString(BarcodeSelectorActivity.BARCODE_CONTENTS, barcodeValues.content());
             manualResultBundle.putString(BarcodeSelectorActivity.BARCODE_FORMAT, barcodeValues.format());
+            manualResultBundle.putParcelable(LoyaltyCardEditActivity.BUNDLE_COVER_URI, intent.getData());
             if (addGroup != null) {
                 manualResultBundle.putString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP, addGroup);
             }

--- a/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
@@ -354,8 +354,23 @@ public class CatimaImporter implements Importer {
             // This field did not exist in versions 2.5.0 and before
             // We catch this exception so we can still import old backups
         }
+        int frontUserDefined = 0;
+        try {
+            frontUserDefined = CSVHelpers.extractInt(DBHelper.LoyaltyCardDbIds.FRONT_USER_DEFINED, record, false);
+        } catch (FormatException _e) {
+            // This field did not exist in versions 0.28 and before
+            // We catch this exception so we can still import old backups
+        }
+        int backUserDefined = 0;
+        try {
+            backUserDefined = CSVHelpers.extractInt(DBHelper.LoyaltyCardDbIds.BACK_USER_DEFINED, record, false);
+        } catch (FormatException _e) {
+            // This field did not exist in versions 0.28 and before
+            // We catch this exception so we can still import old backups
+        }
 
-        DBHelper.insertLoyaltyCard(database, id, store, note, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, starStatus, lastUsed, archiveStatus);
+
+        DBHelper.insertLoyaltyCard(database, id, store, note, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, starStatus, lastUsed, archiveStatus,frontUserDefined,backUserDefined);
     }
 
     /**

--- a/app/src/main/java/protect/card_locker/importexport/FidmeImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/FidmeImporter.java
@@ -124,10 +124,12 @@ public class FidmeImporter implements Importer {
         // No favourite data or colour in the export either
         int starStatus = 0;
         int archiveStatus = 0;
+        int frontUserDefined = 0;
+        int backUserDefined = 0;
         int headerColor = Utils.getRandomHeaderColor(context);
 
         // TODO: Front and back image
 
-        DBHelper.insertLoyaltyCard(database, store, note, null, BigDecimal.valueOf(0), null, cardId, null, barcodeType, headerColor, starStatus, null,archiveStatus);
+        DBHelper.insertLoyaltyCard(database, store, note, null, BigDecimal.valueOf(0), null, cardId, null, barcodeType, headerColor, starStatus, null,archiveStatus,frontUserDefined, backUserDefined);
     }
 }

--- a/app/src/main/java/protect/card_locker/importexport/StocardImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/StocardImporter.java
@@ -234,7 +234,7 @@ public class StocardImporter implements Importer {
                 headerColor = Utils.getHeaderColorFromImage(cardIcon, headerColor);
             }
 
-            long loyaltyCardInternalId = DBHelper.insertLoyaltyCard(database, store, note, null, BigDecimal.valueOf(0), null, cardId, null, barcodeType, headerColor, 0, null,0);
+            long loyaltyCardInternalId = DBHelper.insertLoyaltyCard(database, store, note, null, BigDecimal.valueOf(0), null, cardId, null, barcodeType, headerColor, 0, null,0,0, 0);
 
             if (cardIcon != null) {
                 Utils.saveCardImage(context, cardIcon, (int) loyaltyCardInternalId, ImageLocationType.icon);

--- a/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
@@ -126,7 +126,7 @@ public class VoucherVaultImporter implements Importer {
                     throw new FormatException("Unknown colour type found: " + colorFromJSON);
             }
 
-            DBHelper.insertLoyaltyCard(database, store, "", expiry, balance, balanceType, cardId, null, barcodeType, headerColor, 0, Utils.getUnixTime(),0);
+            DBHelper.insertLoyaltyCard(database, store, "", expiry, balance, balanceType, cardId, null, barcodeType, headerColor, 0, Utils.getUnixTime(),0, 0 , 0);
         }
 
         bufferedReader.close();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@
     <string name="setBackImage">Set back image</string>
     <string name="removeImage">Remove image</string>
     <string name="takePhoto">Take a photo</string>
+    <string name="replacePhoto">Do you want to replace %s with current barcode?</string>
     <string name="updateBarcodeQuestionTitle">Update barcode value?</string>
     <string name="updateBarcodeQuestionText">You changed the ID. Do you want to also update the barcode to use the same value?</string>
     <string name="yes">Yes</string>

--- a/app/src/test/java/protect/card_locker/DatabaseTest.java
+++ b/app/src/test/java/protect/card_locker/DatabaseTest.java
@@ -43,7 +43,7 @@ public class DatabaseTest {
     @Test
     public void addRemoveOneGiftCard() {
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -70,12 +70,12 @@ public class DatabaseTest {
 
     @Test
     public void updateGiftCard() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
-        result = DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, new BigDecimal("10.00"), Currency.getInstance("EUR"), "cardId1", null, CatimaBarcode.fromBarcode(BarcodeFormat.AZTEC), DEFAULT_HEADER_COLOR, 0, null, 0);
+        result = DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, new BigDecimal("10.00"), Currency.getInstance("EUR"), "cardId1", null, CatimaBarcode.fromBarcode(BarcodeFormat.AZTEC), DEFAULT_HEADER_COLOR, 0, null, 0,0,0);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
@@ -96,7 +96,7 @@ public class DatabaseTest {
 
     @Test
     public void updateGiftCardOnlyStar() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -125,14 +125,14 @@ public class DatabaseTest {
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
 
         boolean result = DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, new BigDecimal("0"), null, "cardId1",
-                null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null, 0);
+                null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null, 0,0,0);
         assertEquals(false, result);
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
     }
 
     @Test
     public void emptyGiftCardValues() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "", "", null, new BigDecimal("0"), null, "", null, null, null, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "", "", null, new BigDecimal("0"), null, "", null, null, null, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -160,7 +160,7 @@ public class DatabaseTest {
         // that they are sorted
         for (int index = CARDS_TO_ADD - 1; index >= 0; index--) {
             long id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, new BigDecimal("0"), null, "cardId" + index,
-                    null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 0, null,0);
+                    null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 0, null,0,0,0);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -205,10 +205,10 @@ public class DatabaseTest {
         for (int index = CARDS_TO_ADD - 1; index >= 0; index--) {
             if (index == CARDS_TO_ADD - 1) {
                 id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, new BigDecimal("0"), null, "cardId" + index,
-                        null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 1, null,0);
+                        null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 1, null,0,0,0);
             } else {
                 id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, new BigDecimal("0"), null, "cardId" + index,
-                        null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 0, null,0);
+                        null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 0, null,0,0,0);
             }
             boolean result = (id != -1);
             assertTrue(result);
@@ -305,7 +305,7 @@ public class DatabaseTest {
     public void updateGroup() {
         // Create card
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -417,7 +417,7 @@ public class DatabaseTest {
     public void cardAddAndRemoveGroups() {
         // Create card
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -507,7 +507,7 @@ public class DatabaseTest {
 
     @Test
     public void updateGiftCardOnlyBalance() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -86,7 +86,7 @@ public class ImportExportTest {
         for (int index = cardsToAdd; index > 0; index--) {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
-            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0);
+            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0,0,0);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -100,7 +100,7 @@ public class ImportExportTest {
         for (int index = cardsToAdd; index > 4; index--) {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
-            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 1, null,0);
+            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 1, null,0,0,0);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -108,7 +108,7 @@ public class ImportExportTest {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
             //if index is even
-            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0);
+            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0,0,0);
             boolean result = (id != -1);
             assertTrue(result);
         }
@@ -117,7 +117,7 @@ public class ImportExportTest {
 
     @Test
     public void addLoyaltyCardsWithExpiryNeverPastTodayFuture() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "No Expiry", "", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "No Expiry", "", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0,0,0);
         boolean result = (id != -1);
         assertTrue(result);
 
@@ -133,7 +133,7 @@ public class ImportExportTest {
         assertEquals(Integer.valueOf(0), card.headerColor);
         assertEquals(0, card.starStatus);
 
-        id = DBHelper.insertLoyaltyCard(mDatabase, "Past", "", new Date((long) 1), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
+        id = DBHelper.insertLoyaltyCard(mDatabase, "Past", "", new Date((long) 1), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0,0,0);
         result = (id != -1);
         assertTrue(result);
 
@@ -149,7 +149,7 @@ public class ImportExportTest {
         assertEquals(Integer.valueOf(0), card.headerColor);
         assertEquals(0, card.starStatus);
 
-        id = DBHelper.insertLoyaltyCard(mDatabase, "Today", "", new Date(), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
+        id = DBHelper.insertLoyaltyCard(mDatabase, "Today", "", new Date(), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0,0,0);
         result = (id != -1);
         assertTrue(result);
 
@@ -168,7 +168,7 @@ public class ImportExportTest {
 
         // This will break after 19 January 2038
         // If someone is still maintaining this code base by then: I love you
-        id = DBHelper.insertLoyaltyCard(mDatabase, "Future", "", new Date(2147483648000L), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
+        id = DBHelper.insertLoyaltyCard(mDatabase, "Future", "", new Date(2147483648000L), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0,0,0);
         result = (id != -1);
         assertTrue(result);
 
@@ -889,7 +889,7 @@ public class ImportExportTest {
         HashMap<Integer, Bitmap> loyaltyCardIconImages = new HashMap<>();
 
         // Create card 1
-        int loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 1", "Note 1", new Date(1618053234), new BigDecimal("100"), Currency.getInstance("USD"), "1234", "5432", CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), 1, 0, null,0);
+        int loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 1", "Note 1", new Date(1618053234), new BigDecimal("100"), Currency.getInstance("USD"), "1234", "5432", CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), 1, 0, null,0,0,0);
         loyaltyCardHashMap.put(loyaltyCardId, DBHelper.getLoyaltyCard(mDatabase, loyaltyCardId));
         DBHelper.insertGroup(mDatabase, "One");
         List<Group> groups = Arrays.asList(DBHelper.getGroup(mDatabase, "One"));
@@ -903,7 +903,7 @@ public class ImportExportTest {
         loyaltyCardIconImages.put(loyaltyCardId, launcherBitmap);
 
         // Create card 2
-        loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 2", "", null, new BigDecimal(0), null, "123456", null, null, 2, 1, null,0);
+        loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 2", "", null, new BigDecimal(0), null, "123456", null, null, 2, 1, null,0,0,0);
         loyaltyCardHashMap.put(loyaltyCardId, DBHelper.getLoyaltyCard(mDatabase, loyaltyCardId));
 
         // Export everything

--- a/app/src/test/java/protect/card_locker/ImportURITest.java
+++ b/app/src/test/java/protect/card_locker/ImportURITest.java
@@ -42,7 +42,7 @@ public class ImportURITest {
         // Generate card
         Date date = new Date();
 
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "This note contains evil symbols like & and = that will break the parser if not escaped right $#!%()*+;:á", date, new BigDecimal("100"), null, BarcodeFormat.UPC_E.toString(), BarcodeFormat.UPC_A.toString(), CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), Color.BLACK, 1, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "This note contains evil symbols like & and = that will break the parser if not escaped right $#!%()*+;:á", date, new BigDecimal("100"), null, BarcodeFormat.UPC_E.toString(), BarcodeFormat.UPC_A.toString(), CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), Color.BLACK, 1, null,0,0,0);
 
         // Get card
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
@@ -71,7 +71,7 @@ public class ImportURITest {
     @Test
     public void ensureNoCrashOnMissingHeaderFields() throws InvalidObjectException, UnsupportedEncodingException {
         // Generate card
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("EUR"), BarcodeFormat.UPC_A.toString(), null, CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), null, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("EUR"), BarcodeFormat.UPC_A.toString(), null, CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), null, 0, null,0,0,0);
 
         // Get card
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
@@ -104,7 +104,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapterEmptyNote() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -119,7 +119,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapterWithNote() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -137,7 +137,7 @@ public class LoyaltyCardCursorAdapterTest {
         Date expiryDate = new Date();
         String dateString = DateFormat.getDateInstance(DateFormat.LONG).format(expiryDate);
 
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", expiryDate, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", expiryDate, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -157,10 +157,10 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapterStarring() {
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeA", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,1));
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeB", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,1));
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeC", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0));
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeD", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0));
+        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeA", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,1,0,0));
+        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeB", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,1,0,0));
+        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeC", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0));
+        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeD", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0,0,0));
 
         assertEquals(4, DBHelper.getLoyaltyCardCount(mDatabase));
 
@@ -208,7 +208,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter0Points() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -223,7 +223,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter0EUR() {
-        DBHelper.insertLoyaltyCard(mDatabase,"store", "", null, new BigDecimal("0"), Currency.getInstance("EUR"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase,"store", "", null, new BigDecimal("0"), Currency.getInstance("EUR"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -238,7 +238,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter100Points() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -253,7 +253,7 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter10USD() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("USD"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("USD"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -355,7 +355,7 @@ public class LoyaltyCardViewActivityTest {
             SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
             if (!newCard) {
-                DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+                DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
             }
 
             activityController.start();
@@ -591,7 +591,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -609,7 +609,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -627,7 +627,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -651,7 +651,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -689,7 +689,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -721,7 +721,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -745,7 +745,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -795,7 +795,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -835,7 +835,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -866,7 +866,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -899,7 +899,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -935,7 +935,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -970,7 +970,7 @@ public class LoyaltyCardViewActivityTest {
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -1015,7 +1015,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -1034,7 +1034,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -1053,7 +1053,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -1071,7 +1071,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -1090,7 +1090,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -1119,7 +1119,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         final int LARGE_FONT_SIZE = 40;
 
@@ -1153,7 +1153,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
         activityController.start();
         activityController.visible();
         activityController.resume();
@@ -1187,7 +1187,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();
@@ -1291,7 +1291,7 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0,0,0);
 
         activityController.start();
         activityController.visible();

--- a/app/src/test/java/protect/card_locker/MainActivityTest.java
+++ b/app/src/test/java/protect/card_locker/MainActivityTest.java
@@ -96,7 +96,7 @@ public class MainActivityTest {
         assertEquals(0, list.getAdapter().getItemCount());
 
         SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "store", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
 
         assertEquals(View.VISIBLE, helpSection.getVisibility());
         assertEquals(View.GONE, noMatchingCardsText.getVisibility());
@@ -131,10 +131,10 @@ public class MainActivityTest {
         assertEquals(0, list.getAdapter().getItemCount());
 
         SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "storeB", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
-        DBHelper.insertLoyaltyCard(database, "storeA", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
-        DBHelper.insertLoyaltyCard(database, "storeD", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0);
-        DBHelper.insertLoyaltyCard(database, "storeC", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0);
+        DBHelper.insertLoyaltyCard(database, "storeB", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
+        DBHelper.insertLoyaltyCard(database, "storeA", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0,0,0);
+        DBHelper.insertLoyaltyCard(database, "storeD", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0,0,0);
+        DBHelper.insertLoyaltyCard(database, "storeC", "note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0,0,0);
 
         assertEquals(View.VISIBLE, helpSection.getVisibility());
         assertEquals(View.GONE, noMatchingCardsText.getVisibility());
@@ -225,8 +225,8 @@ public class MainActivityTest {
         TabLayout groupTabs = mainActivity.findViewById(R.id.groups);
 
         SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "The First Store", "Initial note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
-        DBHelper.insertLoyaltyCard(database, "The Second Store", "Secondary note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        DBHelper.insertLoyaltyCard(database, "The First Store", "Initial note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0, 0,0);
+        DBHelper.insertLoyaltyCard(database, "The Second Store", "Secondary note", null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0, 0,0);
 
         DBHelper.insertGroup(database, "Group one");
         List<Group> groups = new ArrayList<>();


### PR DESCRIPTION
This Pull Request fixes #1057.

The changes are listed below.

# Implemented
* Added a feature that automatically sets the front/back image with the scanned barcode. There will be a dialog shown to the users to confirm if they want to automatically set the image or not.
# Code changes
* Added `frontUserDefined` and `backUserDefined` to LoyaltyCardField to distinguish if the image of the front and back card was added automatically or manually.
* Added 2 more columns(`frontuserdefined` and `frontuserdefined`) to the table of `LoyaltyCardDbGroups`.
* Bumped up the database version from `15` to `16`.
* Added database upgrading code to migrate the database from version `15` to `16`.
* Added logic code to display a dialog letting users select if they want to automatically set the scanned barcode as the front/back image of the current card.
* Added the file's URI of the scanned barcode to the intent so that `LoyaltyCardEditActivity` could use it to set the front/back image.
* Changed Test files to reflect the changes of `DBHelper`.

# Potential Issues
* Might need to check if the current logic of automatic card adding is appropriate (especially for card rescanning). 
* The prompted image-setting dialog may be ungrammatical or could be more concise...