### PR TITLE
Update AGP to 7.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,9 +58,6 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    lintOptions {
-        lintConfig file("lint.xml")
-    }
 
     sourceSets {
         test {
@@ -80,6 +77,10 @@ android {
             includeAndroidResources true
         }
     }
+    lint {
+        lintConfig file('lint.xml')
+    }
+    namespace 'protect.card_locker'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="protect.card_locker">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '7.0.4' apply false
+    id 'com.android.application' version '7.4.0' apply false
     id 'com.github.spotbugs' version "4.7.5" apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jul 25 20:59:51 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Makes Android Studio builds reproducible.

Blocked by https://github.com/WeblateOrg/weblate/issues/7520.

Luckily we can build reproducibly from the CLI, otherwise we would have to choose between reproducible or lint :(