### PR TITLE
Refactor permission code

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,7 @@
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="23" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
+++ b/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -48,5 +49,8 @@ public class CatimaAppCompatActivity extends AppCompatActivity {
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
+    }
+
+    public void onMockedRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     }
 }

--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -43,8 +43,6 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
     private ImportExportActivityBinding binding;
     private static final String TAG = "Catima";
 
-    private static final int PERMISSIONS_EXTERNAL_STORAGE = 1;
-
     private ImportExportTask importExporter;
 
     private String importAlertTitle;
@@ -67,19 +65,6 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
         enableToolbarBackButton();
-
-        // If the application does not have permissions to external
-        // storage, ask for it now
-
-        if (ContextCompat.checkSelfPermission(ImportExportActivity.this,
-                Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED ||
-                ContextCompat.checkSelfPermission(ImportExportActivity.this,
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(ImportExportActivity.this,
-                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
-                            Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                    PERMISSIONS_EXTERNAL_STORAGE);
-        }
 
         Intent fileIntent = getIntent();
         if (fileIntent != null && fileIntent.getType() != null) {
@@ -310,30 +295,6 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
         importExporter = new ImportExportTask(ImportExportActivity.this,
                 DataFormat.Catima, target, password, listener);
         mTasks.executeTask(TaskHandler.TYPE.EXPORT, importExporter);
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-
-        if (requestCode == PERMISSIONS_EXTERNAL_STORAGE) {
-            // If request is cancelled, the result arrays are empty.
-            boolean success = grantResults.length > 0;
-
-            for (int grant : grantResults) {
-                if (grant != PackageManager.PERMISSION_GRANTED) {
-                    success = false;
-                }
-            }
-
-            if (!success) {
-                // External storage permission rejected, inform user that
-                // import/export is prevented
-                Toast.makeText(getApplicationContext(), R.string.noExternalStoragePermissionError,
-                        Toast.LENGTH_LONG).show();
-            }
-
-        }
     }
 
     @Override

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -984,6 +984,10 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
+        onMockedRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    public void onMockedRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         boolean allowed = grantResults[0] == PackageManager.PERMISSION_GRANTED;
         Integer failureReason = null;
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -111,6 +111,9 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
     private static final int PERMISSION_REQUEST_CAMERA_IMAGE_FRONT = 100;
     private static final int PERMISSION_REQUEST_CAMERA_IMAGE_BACK = 101;
     private static final int PERMISSION_REQUEST_CAMERA_IMAGE_ICON = 102;
+    private static final int PERMISSION_REQUEST_STORAGE_IMAGE_FRONT = 103;
+    private static final int PERMISSION_REQUEST_STORAGE_IMAGE_BACK = 104;
+    private static final int PERMISSION_REQUEST_STORAGE_IMAGE_ICON = 105;
 
     public static final String BUNDLE_ID = "id";
     public static final String BUNDLE_DUPLICATE_ID = "duplicateId";
@@ -981,14 +984,55 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
-        if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            if (requestCode == PERMISSION_REQUEST_CAMERA_IMAGE_FRONT) {
+        boolean allowed = grantResults[0] == PackageManager.PERMISSION_GRANTED;
+        Integer failureReason = null;
+
+        if (requestCode == PERMISSION_REQUEST_CAMERA_IMAGE_FRONT) {
+            if (allowed) {
                 takePhotoForCard(Utils.CARD_IMAGE_FROM_CAMERA_FRONT);
-            } else if (requestCode == PERMISSION_REQUEST_CAMERA_IMAGE_BACK) {
-                takePhotoForCard(Utils.CARD_IMAGE_FROM_CAMERA_BACK);
-            } else if (requestCode == PERMISSION_REQUEST_CAMERA_IMAGE_ICON) {
-                takePhotoForCard(Utils.CARD_IMAGE_FROM_CAMERA_ICON);
+                return;
             }
+
+            failureReason = R.string.cameraPermissionRequired;
+        } else if (requestCode == PERMISSION_REQUEST_CAMERA_IMAGE_BACK) {
+            if (allowed) {
+                takePhotoForCard(Utils.CARD_IMAGE_FROM_CAMERA_BACK);
+                return;
+            }
+
+            failureReason = R.string.cameraPermissionRequired;
+        } else if (requestCode == PERMISSION_REQUEST_CAMERA_IMAGE_ICON) {
+            if (allowed) {
+                takePhotoForCard(Utils.CARD_IMAGE_FROM_CAMERA_ICON);
+                return;
+            }
+
+            failureReason = R.string.cameraPermissionRequired;
+        } else if (requestCode == PERMISSION_REQUEST_STORAGE_IMAGE_FRONT) {
+            if (allowed) {
+                selectImageFromGallery(Utils.CARD_IMAGE_FROM_FILE_FRONT);
+                return;
+            }
+
+            failureReason = R.string.storageReadPermissionRequired;
+        } else if (requestCode == PERMISSION_REQUEST_STORAGE_IMAGE_BACK) {
+            if (allowed) {
+                selectImageFromGallery(Utils.CARD_IMAGE_FROM_FILE_BACK);
+                return;
+            }
+
+            failureReason = R.string.storageReadPermissionRequired;
+        } else if (requestCode == PERMISSION_REQUEST_STORAGE_IMAGE_ICON) {
+            if (allowed) {
+                selectImageFromGallery(Utils.CARD_IMAGE_FROM_FILE_ICON);
+                return;
+            }
+
+            failureReason = R.string.storageReadPermissionRequired;
+        }
+
+        if (failureReason != null) {
+            Toast.makeText(this, failureReason, Toast.LENGTH_LONG).show();
         }
     }
 
@@ -1058,6 +1102,24 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
         mRequestedImage = type;
 
         mPhotoTakerLauncher.launch(photoURI);
+    }
+
+    private void selectImageFromGallery(int type) {
+        mRequestedImage = type;
+
+        Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
+        photoPickerIntent.setType("image/*");
+        Intent contentIntent = new Intent(Intent.ACTION_GET_CONTENT);
+        contentIntent.setType("image/*");
+        Intent chooserIntent = Intent.createChooser(photoPickerIntent, getString(R.string.addFromImage));
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { contentIntent });
+
+        try {
+            mPhotoPickerLauncher.launch(chooserIntent);
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(getApplicationContext(), R.string.failedLaunchingPhotoPicker, Toast.LENGTH_LONG).show();
+            Log.e(TAG, "No activity found to handle intent", e);
+        }
     }
 
     class EditCardIdAndBarcode implements View.OnClickListener {
@@ -1141,62 +1203,37 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
             }
 
             cardOptions.put(getString(R.string.takePhoto), () -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    int permissionRequestType;
+                int permissionRequestType;
 
-                    if (v.getId() == R.id.frontImageHolder) {
-                        permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_FRONT;
-                    } else if (v.getId() == R.id.backImageHolder) {
-                        permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_BACK;
-                    } else if (v.getId() == R.id.thumbnail) {
-                        permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_ICON;
-                    } else {
-                        throw new IllegalArgumentException("Unknown ID type " + v.getId());
-                    }
-
-                    requestPermissions(new String[]{Manifest.permission.CAMERA}, permissionRequestType);
-                } else {
-                    int cardImageType;
-
-                    if (v.getId() == R.id.frontImageHolder) {
-                        cardImageType = Utils.CARD_IMAGE_FROM_CAMERA_FRONT;
-                    } else if (v.getId() == R.id.backImageHolder) {
-                        cardImageType = Utils.CARD_IMAGE_FROM_CAMERA_BACK;
-                    } else if (v.getId() == R.id.thumbnail) {
-                        cardImageType = Utils.CARD_IMAGE_FROM_CAMERA_ICON;
-                    } else {
-                        throw new IllegalArgumentException("Unknown ID type " + v.getId());
-                    }
-
-                    takePhotoForCard(cardImageType);
-                }
-                return null;
-            });
-
-            cardOptions.put(getString(R.string.addFromImage), () -> {
                 if (v.getId() == R.id.frontImageHolder) {
-                    mRequestedImage = Utils.CARD_IMAGE_FROM_FILE_FRONT;
+                    permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_FRONT;
                 } else if (v.getId() == R.id.backImageHolder) {
-                    mRequestedImage = Utils.CARD_IMAGE_FROM_FILE_BACK;
+                    permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_BACK;
                 } else if (v.getId() == R.id.thumbnail) {
-                    mRequestedImage = Utils.CARD_IMAGE_FROM_FILE_ICON;
+                    permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_ICON;
                 } else {
                     throw new IllegalArgumentException("Unknown ID type " + v.getId());
                 }
 
-                Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
-                photoPickerIntent.setType("image/*");
-                Intent contentIntent = new Intent(Intent.ACTION_GET_CONTENT);
-                contentIntent.setType("image/*");
-                Intent chooserIntent = Intent.createChooser(photoPickerIntent, getString(R.string.addFromImage));
-                chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { contentIntent });
+                PermissionUtils.requestCameraPermission(LoyaltyCardEditActivity.this, permissionRequestType);
 
-                try {
-                    mPhotoPickerLauncher.launch(chooserIntent);
-                } catch (ActivityNotFoundException e) {
-                    Toast.makeText(getApplicationContext(), R.string.failedLaunchingPhotoPicker, Toast.LENGTH_LONG).show();
-                    Log.e(TAG, "No activity found to handle intent", e);
+                return null;
+            });
+
+            cardOptions.put(getString(R.string.addFromImage), () -> {
+                int permissionRequestType;
+
+                if (v.getId() == R.id.frontImageHolder) {
+                    permissionRequestType = PERMISSION_REQUEST_STORAGE_IMAGE_FRONT;
+                } else if (v.getId() == R.id.backImageHolder) {
+                    permissionRequestType = PERMISSION_REQUEST_STORAGE_IMAGE_BACK;
+                } else if (v.getId() == R.id.thumbnail) {
+                    permissionRequestType = PERMISSION_REQUEST_STORAGE_IMAGE_ICON;
+                } else {
+                    throw new IllegalArgumentException("Unknown ID type " + v.getId());
                 }
+
+                PermissionUtils.requestStorageReadPermission(LoyaltyCardEditActivity.this, permissionRequestType);
 
                 return null;
             });

--- a/app/src/main/java/protect/card_locker/PermissionUtils.java
+++ b/app/src/main/java/protect/card_locker/PermissionUtils.java
@@ -19,6 +19,7 @@ public class PermissionUtils {
      * @return
      */
     private static boolean needsStorageReadPermission(Activity activity) {
+        // Testing showed this permission wasn't needed for anything Catima did past Marshmallow
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             return false;
         }
@@ -48,14 +49,21 @@ public class PermissionUtils {
      * @param activity
      * @param requestCode
      */
-    public static void requestStorageReadPermission(Activity activity, int requestCode) {
+    public static void requestStorageReadPermission(CatimaAppCompatActivity activity, int requestCode) {
         String[] permissions = new String[]{ android.Manifest.permission.READ_EXTERNAL_STORAGE };
         int[] mockedResults = new int[]{ PackageManager.PERMISSION_GRANTED };
 
         if (needsStorageReadPermission(activity)) {
             ActivityCompat.requestPermissions(activity, permissions, requestCode);
         } else {
-            activity.onRequestPermissionsResult(requestCode, permissions, mockedResults);
+            // FIXME: This points to onMockedRequestPermissionResult instead of to
+            // onRequestPermissionResult because onRequestPermissionResult was only introduced in
+            // Android 6.0 (SDK 23) and we and to support Android 5.0 (SDK 21) too.
+            //
+            // When minSdk becomes 23, this should point to onRequestPermissionResult directly and
+            // the activity input variable should be changed from CatimaAppCompatActivity to
+            // Activity.
+            activity.onMockedRequestPermissionsResult(requestCode, permissions, mockedResults);
         }
     }
 
@@ -66,14 +74,21 @@ public class PermissionUtils {
      * @param activity
      * @param requestCode
      */
-    public static void requestCameraPermission(Activity activity, int requestCode) {
+    public static void requestCameraPermission(CatimaAppCompatActivity activity, int requestCode) {
         String[] permissions = new String[]{ Manifest.permission.CAMERA };
         int[] mockedResults = new int[]{ PackageManager.PERMISSION_GRANTED };
 
         if (needsCameraPermission(activity)) {
             ActivityCompat.requestPermissions(activity, permissions, requestCode);
         } else {
-            activity.onRequestPermissionsResult(requestCode, permissions, mockedResults);
+            // FIXME: This points to onMockedRequestPermissionResult instead of to
+            // onRequestPermissionResult because onRequestPermissionResult was only introduced in
+            // Android 6.0 (SDK 23) and we and to support Android 5.0 (SDK 21) too.
+            //
+            // When minSdk becomes 23, this should point to onRequestPermissionResult directly and
+            // the activity input variable should be changed from CatimaAppCompatActivity to
+            // Activity.
+            activity.onMockedRequestPermissionsResult(requestCode, permissions, mockedResults);
         }
     }
 }

--- a/app/src/main/java/protect/card_locker/PermissionUtils.java
+++ b/app/src/main/java/protect/card_locker/PermissionUtils.java
@@ -1,0 +1,79 @@
+package protect.card_locker;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+public class PermissionUtils {
+    /**
+     * Check if storage read permission is needed.
+     *
+     * This is only necessary on Android 6.0 (Marshmallow) and below. See
+     * https://github.com/CatimaLoyalty/Android/issues/979 for more info.
+     *
+     * @param activity
+     * @return
+     */
+    private static boolean needsStorageReadPermission(Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return false;
+        }
+
+        return ContextCompat.checkSelfPermission(activity, android.Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Check if camera permission is needed.
+     *
+     * @param activity
+     * @return
+     */
+    public static boolean needsCameraPermission(Activity activity) {
+        // Android only introduced the runtime permission system in Marshmallow (Android 6.0)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return false;
+        }
+
+        return ContextCompat.checkSelfPermission(activity, android.Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Call onRequestPermissionsResult after storage read permission was granted.
+     * Mocks a successful grant if a grant is not necessary.
+     *
+     * @param activity
+     * @param requestCode
+     */
+    public static void requestStorageReadPermission(Activity activity, int requestCode) {
+        String[] permissions = new String[]{ android.Manifest.permission.READ_EXTERNAL_STORAGE };
+        int[] mockedResults = new int[]{ PackageManager.PERMISSION_GRANTED };
+
+        if (needsStorageReadPermission(activity)) {
+            ActivityCompat.requestPermissions(activity, permissions, requestCode);
+        } else {
+            activity.onRequestPermissionsResult(requestCode, permissions, mockedResults);
+        }
+    }
+
+    /**
+     * Call onRequestPermissionsResult after camera permission was granted.
+     * Mocks a successful grant if a grant is not necessary.
+     *
+     * @param activity
+     * @param requestCode
+     */
+    public static void requestCameraPermission(Activity activity, int requestCode) {
+        String[] permissions = new String[]{ Manifest.permission.CAMERA };
+        int[] mockedResults = new int[]{ PackageManager.PERMISSION_GRANTED };
+
+        if (needsCameraPermission(activity)) {
+            ActivityCompat.requestPermissions(activity, permissions, requestCode);
+        } else {
+            activity.onRequestPermissionsResult(requestCode, permissions, mockedResults);
+        }
+    }
+}

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -282,6 +282,10 @@ public class ScanActivity extends CatimaAppCompatActivity {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
+        onMockedRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    public void onMockedRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode == CaptureManager.getCameraPermissionReqCode()) {
             showCameraPermissionMissingText(grantResults[0] != PackageManager.PERMISSION_GRANTED);
         } else if (requestCode == PERMISSION_SCAN_ADD_FROM_IMAGE) {

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -53,6 +53,8 @@ public class ScanActivity extends CatimaAppCompatActivity {
     private static final int MEDIUM_SCALE_FACTOR_DIP = 460;
     private static final int COMPAT_SCALE_FACTOR_DIP = 320;
 
+    private static final int PERMISSION_SCAN_ADD_FROM_IMAGE = 100;
+
     private CaptureManager capture;
     private DecoratedBarcodeView barcodeScannerView;
 
@@ -226,6 +228,10 @@ public class ScanActivity extends CatimaAppCompatActivity {
     }
 
     public void addFromImage(View view) {
+        PermissionUtils.requestStorageReadPermission(this, PERMISSION_SCAN_ADD_FROM_IMAGE);
+    }
+
+    private void addFromImageAfterPermission() {
         Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
         photoPickerIntent.setType("image/*");
         Intent contentIntent = new Intent(Intent.ACTION_GET_CONTENT);
@@ -275,9 +281,15 @@ public class ScanActivity extends CatimaAppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == CaptureManager.getCameraPermissionReqCode())
+
+        if (requestCode == CaptureManager.getCameraPermissionReqCode()) {
             showCameraPermissionMissingText(grantResults[0] != PackageManager.PERMISSION_GRANTED);
-
+        } else if (requestCode == PERMISSION_SCAN_ADD_FROM_IMAGE) {
+            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                addFromImageAfterPermission();
+            } else {
+                Toast.makeText(this, R.string.storageReadPermissionRequired, Toast.LENGTH_LONG).show();
+            }
+        }
     }
-
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -39,7 +39,6 @@
     <string name="exportSuccessfulTitle">متصدر</string>
     <string name="exportFailedTitle">فشل التصدير</string>
     <string name="exportFailed">لا يمكن عمل التصدير</string>
-    <string name="noExternalStoragePermissionError">امنح التخزين الخارجي اذن لاستيراد وتصدير البيانات</string>
     <string name="exportOptionExplanation">ستتم كتابة البيانات في الموقع الذي تختاره.</string>
     <string name="importOptionFilesystemButton">من نظام الملفات</string>
     <string name="importOptionApplicationTitle">استخدم تطبيقًا آخر</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -34,7 +34,6 @@
     <string name="setFrontImage">Снимка на предната страна</string>
     <string name="photos">Снимки</string>
     <string name="importOptionApplicationExplanation">Изберете файл на друго приложение.</string>
-    <string name="noExternalStoragePermissionError">Разрешете достъп до хранилището, за да работи внасянето и изнасянето</string>
     <string name="noCardExistsError">Картата не е намерена</string>
     <string name="updateBarcodeQuestionText">Идентификаторът е променен. Желаете ли с неговата стойност да бъде променен и щрихкодът\?</string>
     <string name="updateBarcodeQuestionTitle">Обновяване на щрихкода\?</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -29,7 +29,6 @@
     <string name="exportFailed">Export nelze provést</string>
     <string name="importing">Importuji…</string>
     <string name="exporting">Exportuji…</string>
-    <string name="noExternalStoragePermissionError">Udělit oprávnění přístupu k externímu úložišti pro import nebo export dat</string>
     <string name="importOptionFilesystemTitle">Import ze souborového systému</string>
     <string name="importOptionFilesystemExplanation">Vyberte konkrétní soubor v úložišti.</string>
     <string name="importOptionFilesystemButton">Ze souborového systému</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -67,7 +67,6 @@
     <string name="importOptionFilesystemExplanation">Vælg en bestemt fil fra filsystemet.</string>
     <string name="importOptionFilesystemTitle">Import fra filsystem</string>
     <string name="exportOptionExplanation">Dataene skrives til en placering efter eget valg.</string>
-    <string name="noExternalStoragePermissionError">Giv først tilladelse til ekstern lagring til at importere eller eksportere kort</string>
     <string name="failedParsingImportUriError">Kunne ikke analysere import-URI\'en</string>
     <string name="noCardExistsError">Kunne ikke finde kort</string>
     <string name="noCardIdError">Der er ikke angivet noget kort-ID</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -36,7 +36,6 @@
     <string name="exportFailed">Export konnte nicht durchgeführt werden</string>
     <string name="importing">Importiere…</string>
     <string name="exporting">Exportiere…</string>
-    <string name="noExternalStoragePermissionError">Berechtigung für den externen Speicher zum Importieren oder Exportieren von Daten erteilen</string>
     <string name="importOptionFilesystemTitle">Importiere aus dem Dateisystem</string>
     <string name="importOptionFilesystemExplanation">Wähle eine Datei vom Dateisystem aus.</string>
     <string name="importOptionFilesystemButton">Wähle vom Dateisystem</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -32,7 +32,6 @@
     <string name="exportFailed">Δεν ήταν δυνατή η εξαγωγή</string>
     <string name="importing">Γίνεται εισαγωγή του…</string>
     <string name="exporting">Γίνεται εξαγωγή του…</string>
-    <string name="noExternalStoragePermissionError">Εγκρίνετε την άδεια εξωτερικής αποθήκευσης για να εισάγετε ή εξάγετε δεδομένα</string>
     <string name="importOptionFilesystemTitle">Εισαγωγή από το σύστημα αρχείων</string>
     <string name="importOptionFilesystemExplanation">Επιλέξτε ένα συγκεκριμένο αρχείο από το σύστημα αρχείων.</string>
     <string name="importOptionFilesystemButton">Από το σύστημα αρχείων</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -63,7 +63,6 @@
     <string name="importOptionApplicationTitle">Uzi alian app</string>
     <string name="importOptionFilesystemExplanation">Elektu specifa dosiero de la dosiersistemo.</string>
     <string name="exportOptionExplanation">La datumoj estos skribita al loko de via elekto.</string>
-    <string name="noExternalStoragePermissionError">Grant ekstera stokado permeso de importado aŭ eksportado kartoj unua</string>
     <string name="exportFailed">Ne povis eksporti kartoj</string>
     <string name="importFailed">Ne povis importi kartoj</string>
     <string name="importExportHelp">Subtenanta supre vian kartoj permesas vin movi ilin al alia aparato.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -32,7 +32,6 @@
     <string name="exportFailed">No se han podido exportar</string>
     <string name="importing">Importando…</string>
     <string name="exporting">Exportando…</string>
-    <string name="noExternalStoragePermissionError">Otorgar permiso de almacenamiento para importar o exportar datos</string>
     <string name="importOptionFilesystemTitle">Importar desde el sistema de archivos</string>
     <string name="importOptionFilesystemExplanation">Elegir un archivo concreto del sistema de archivos.</string>
     <string name="importOptionFilesystemButton">Desde el sistema de archivos</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
-    <string name="noExternalStoragePermissionError">Salli käyttöoikeus ulkoisen tallennustilan käyttöön voidaksesi tuoda tai viedä tietoja</string>
     <string name="no">Ei</string>
     <string name="yes">Kyllä</string>
     <string name="updateBarcodeQuestionText">Vaihdoit ID-tunnuksen. Haluatko päivittää myös viivakoodin käyttämään samaa arvoa\?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -32,7 +32,6 @@
     <string name="exportFailed">Impossible d’effectuer l’exportation</string>
     <string name="importing">Import …</string>
     <string name="exporting">Export …</string>
-    <string name="noExternalStoragePermissionError">Accorder au stockage externe l’autorisation d’importer ou d’exporter des données</string>
     <string name="importOptionFilesystemTitle">Importer depuis le système de fichiers</string>
     <string name="importOptionFilesystemExplanation">Choisissez le fichier à importer.</string>
     <string name="importOptionFilesystemButton">Système de fichiers</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -150,5 +150,4 @@
     <string name="debug_version_fmt">संस्करण: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_revision_fmt"><xliff:g id="app_revision_url">%s</xliff:g> संशोधन के बारे में</string>
     <string name="copy_to_clipboard_toast">आई डी क्लिपबोर्ड पर कॉपी किया गया</string>
-    <string name="noExternalStoragePermissionError">डेटा आयात या निर्यात करने के लिए एक्सटर्नल स्टोरेज एक्सेस प्रदान करें</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -44,7 +44,6 @@
     <string name="exportOptionExplanation">Podaci će biti zabilježeni na odabranom mjestu.</string>
     <string name="exportFailedTitle">Izvoz nije uspio</string>
     <string name="exporting">Opskrba…</string>
-    <string name="noExternalStoragePermissionError">Najprije odobrite dopuštenje za vanjsku pohranu za uvoz ili izvoz kartica</string>
     <string name="importOptionFilesystemExplanation">Odaberite određenu datoteku iz datotečnog sustava.</string>
     <string name="importOptionApplicationTitle">Koristite drugu aplikaciju</string>
     <string name="settings">Postavke</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -81,7 +81,6 @@
     <string name="exportFailed">Exportálás sikertelen</string>
     <string name="importing">Importálás…</string>
     <string name="exporting">Exportálás…</string>
-    <string name="noExternalStoragePermissionError">Külső háttértárhoz való hozzáférés engedélyezése adat import vagy export miatt</string>
     <string name="exportOptionExplanation">Az adatokat a kiválasztott helyre fogjuk menteni.</string>
     <string name="importOptionFilesystemTitle">Importálás fájlrendszerből</string>
     <string name="importOptionFilesystemButton">A fájlrendszerből</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -96,7 +96,6 @@
     <string name="exportFailed">Tidak dapat mengekspor</string>
     <string name="importing">Sedang mengimpor…</string>
     <string name="exporting">Sedang mengekspor…</string>
-    <string name="noExternalStoragePermissionError">Berikan izin penyimpanan eksternal untuk mengimpor atau mengekspor data</string>
     <string name="exportOptionExplanation">Data akan ditulis ke lokasi pilihan Anda.</string>
     <string name="importOptionFilesystemTitle">Impor dari pengelola file bawaan</string>
     <string name="importOptionFilesystemExplanation">Pilih file dari pengelola file bawaan.</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -33,7 +33,6 @@
     <string name="importExportHelp">Stuðningur upp spil gerir þér kleift að færa þá til annar tæki.</string>
     <string name="importSuccessfulTitle">Flutt</string>
     <string name="importFailedTitle">Innflutningur mistókst</string>
-    <string name="noExternalStoragePermissionError">Grant ytri geymslu leyfi til að flytja eða flytja spil fyrstu</string>
     <string name="exportOptionExplanation">Gögnum verður skrifað á stað af eigin vali.</string>
     <string name="importOptionFilesystemTitle">Innflutningur frá möppuna</string>
     <string name="importOptionFilesystemExplanation">Velja ákveðna skrá frá möppuna.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -37,7 +37,6 @@
     <string name="exportFailed">Impossibile eseguire l\'esportazione</string>
     <string name="importing">Importazione in corso…</string>
     <string name="exporting">Esportazione in corso…</string>
-    <string name="noExternalStoragePermissionError">Concedi il permesso di archiviazione esterna per importare o esportare dati</string>
     <string name="importOptionFilesystemTitle">Importa dall\'archivio</string>
     <string name="importOptionFilesystemExplanation">Scegli un file dall\'archivio.</string>
     <string name="importOptionFilesystemButton">Dall\'archivio</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -87,7 +87,6 @@
     <string name="importOptionFilesystemExplanation">ストレージからファイルを選択してください。</string>
     <string name="importOptionFilesystemTitle">ストレージからインポート</string>
     <string name="exportOptionExplanation">選択した場所にデータを出力します。</string>
-    <string name="noExternalStoragePermissionError">データをインポート/エクスポートするために外部ストレージへのアクセスを許可してください</string>
     <string name="exporting">エクスポート中…</string>
     <string name="importing">インポート中…</string>
     <string name="exportFailed">カードをエクスポートできませんでした</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -23,7 +23,6 @@
     <string name="exportFailed">Nepavyko eksportuoti</string>
     <string name="importing">Importuoja…</string>
     <string name="exporting">Eksportuoja…</string>
-    <string name="noExternalStoragePermissionError">Pirmiausia suteikite išorinės saugyklos leidimą, kad galėtumėte importuoti arba eksportuoti korteles</string>
     <string name="about">Apie</string>
     <string name="app_license">Copylefted laisvoji programinė įranga, licencijuota GPLv3+</string>
     <string name="about_title_fmt">Apie <xliff:g id="app_name">%s</xliff:g></string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -48,7 +48,6 @@
     <string name="exportFailed">Kartes neizdevās eksportēt</string>
     <string name="importing">Importē…</string>
     <string name="exporting">Eksportē…</string>
-    <string name="noExternalStoragePermissionError">Piešķiriet ārējai atmiņai atļauju vispirms importēt vai eksportēt kartes</string>
     <string name="exportOptionExplanation">Dati tiks saglabāti Jūsu izvēlētajā vietā.</string>
     <string name="importOptionFilesystemTitle">Imports no failu sistēmas</string>
     <string name="importOptionFilesystemExplanation">Izvēlieties konkrētu failu no failu sistēmas.</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -33,7 +33,6 @@
     <string name="exportFailed">Kunne ikke utføre eksport</string>
     <string name="importing">Importerer…</string>
     <string name="exporting">Exporterer…</string>
-    <string name="noExternalStoragePermissionError">Innvilg lagringstilgang til eksternlager for å importere eller eksportere data</string>
     <string name="exportOptionExplanation">Data skrives dit du ønsker det.</string>
     <string name="importOptionFilesystemTitle">Importer fra filsystem</string>
     <string name="importOptionFilesystemExplanation">Velg spesifikk fil fra filsystemet.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -38,7 +38,6 @@
     <string name="exportFailed">Het exporteren is mislukt</string>
     <string name="importing">Bezig met importeren…</string>
     <string name="exporting">Bezig met exporteren…</string>
-    <string name="noExternalStoragePermissionError">Verleen het recht ‘externe opslag’ om gegevens te kunnen im- of exporteren</string>
     <string name="exportOptionExplanation">De gegevens worden weggeschreven op een locatie naar keuze.</string>
     <string name="importOptionFilesystemTitle">Importeren uit bestandssysteem</string>
     <string name="importOptionFilesystemExplanation">Kies een specifiek bestand van het bestandssysteem.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -37,7 +37,6 @@
     <string name="exportFailed">Nie udało się wyeksportować</string>
     <string name="importing">Importowanie…</string>
     <string name="exporting">Eksportowanie…</string>
-    <string name="noExternalStoragePermissionError">Zezwalaj na przechowywanie zewnętrzne w celu importowania lub eksportowania danych</string>
     <string name="importOptionFilesystemTitle">Importuj z systemu plików</string>
     <string name="importOptionFilesystemExplanation">Wybierz określony plik z systemu plików.</string>
     <string name="importOptionFilesystemButton">Z systemu plików</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -72,7 +72,6 @@
     <string name="moveUp">Subir</string>
     <string name="moveDown">Descer</string>
     <string name="leaveWithoutSaveTitle">Sair</string>
-    <string name="noExternalStoragePermissionError">Conceda primeiro a autorização de acesso ao armazenamento externo para importar ou exportar dados</string>
     <string name="importExportHelp">A cópia de segurança dos seus dados permite-lhe movê-los para outro dispositivo.</string>
     <string name="importSuccessfulTitle">Importado</string>
     <string name="importFailedTitle">A importação falhou</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -38,7 +38,6 @@
     <string name="exportFailed">Nu s-a putut exporta carduri</string>
     <string name="importing">Importul…</string>
     <string name="exporting">Exportul…</string>
-    <string name="noExternalStoragePermissionError">Acordați mai întâi permisiunea de stocare externă pentru a importa sau exporta carduri</string>
     <string name="exportOptionExplanation">Datele vor fi scrise într-o locație aleasă de dumneavoastră.</string>
     <string name="importOptionFilesystemTitle">Import din sistemul de fișiere</string>
     <string name="importOptionApplicationTitle">Utilizați o altă aplicație</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -38,7 +38,6 @@
     <string name="exportFailed">Невозможно выполнить экспорт</string>
     <string name="importing">Импорт…</string>
     <string name="exporting">Экспорт…</string>
-    <string name="noExternalStoragePermissionError">Импорт или экспорт данных невозможен без разрешения на доступ к хранилищу</string>
     <string name="exportOptionExplanation">Данные будут записаны в выбранное место.</string>
     <string name="importOptionFilesystemTitle">Импорт из файловой системы</string>
     <string name="importOptionFilesystemExplanation">Выберете файл на файловой системе.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -32,7 +32,6 @@
     <string name="exportFailed">Zlyhal export</string>
     <string name="importing">Importujem…</string>
     <string name="exporting">Exportujem…</string>
-    <string name="noExternalStoragePermissionError">Nie je možné importovať a exportovať karty bez prístupu k externému úložisku</string>
     <string name="importOptionFilesystemTitle">Import zo súborového systému</string>
     <string name="importOptionFilesystemExplanation">Vyberte súbor zo súborového systému.</string>
     <string name="importOptionFilesystemButton">Zo súborového systému</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -32,7 +32,6 @@
     <string name="exportFailed">Napaka pri izvozu baze</string>
     <string name="importing">Uvažanje…</string>
     <string name="exporting">Izvažanje…</string>
-    <string name="noExternalStoragePermissionError">Izvažanje in uvažanje je nemogoče brez omogočenega dostopa do zunanje shrambe</string>
     <string name="importOptionFilesystemTitle">Uvozi iz datotečnega sistema</string>
     <string name="importOptionFilesystemExplanation">Izberite specifično datoteko iz datotečnega sistema.</string>
     <string name="importOptionFilesystemButton">Iz datotečnega sistema</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -171,7 +171,6 @@
     <string name="note">Anteckning</string>
     <string name="settings_system_locale">System</string>
     <string name="settings_locale">Språk</string>
-    <string name="noExternalStoragePermissionError">Bevilja tillstånd för extern lagring för att kunna importera eller exportera data</string>
     <string name="app_contributors">Möjliggjordes av: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Brunt</string>
     <string name="settings_grey_theme">Grått</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -128,7 +128,6 @@
     <string name="importOptionFilesystemExplanation">Dosya sisteminden belirli bir dosya seçin.</string>
     <string name="importOptionFilesystemTitle">Dosya sisteminden içe aktar</string>
     <string name="exportOptionExplanation">Veriler seçtiğiniz bir konuma yazılacak.</string>
-    <string name="noExternalStoragePermissionError">Verileri içeri veya dışarı aktarmak için harici depolama izni verin</string>
     <string name="exporting">Dışa aktarılıyor…</string>
     <string name="importing">İçe aktarılıyor…</string>
     <string name="exportFailed">Dışa aktarma gerçekleştirilemedi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -106,7 +106,6 @@
     <string name="importOptionFilesystemExplanation">Оберіть файл у провіднику.</string>
     <string name="importOptionFilesystemTitle">Імпорт з файлу</string>
     <string name="exportOptionExplanation">Дані буде записано до локації обраної вами.</string>
-    <string name="noExternalStoragePermissionError">Надайте дозвіл на доступ до пам\'яті пристрою для імпорту/експорту даних</string>
     <string name="exporting">Експортуємо…</string>
     <string name="importing">Імпортуємо…</string>
     <string name="exportFailed">Неможливо здійснити експорт</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -94,7 +94,6 @@
     <string name="importOptionFilesystemExplanation">请从文件系统选择文件.</string>
     <string name="importOptionFilesystemTitle">从文件系统导入</string>
     <string name="exportOptionExplanation">导出的数据将储存至你选择的位置.</string>
-    <string name="noExternalStoragePermissionError">在导入导出前需要获得外部储存权限</string>
     <string name="cameraPermissionDeniedTitle">无法访问相机</string>
     <string name="noCameraPermissionDirectToSystemSetting">Catima需要访问您的相机来扫描条形码. 轻触这里以更改您的权限设置。</string>
     <string name="exporting">导出中…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -161,7 +161,6 @@
     <string name="scanCardBarcode">掃描條碼</string>
     <string name="noStoreError">尚未輸入卡片名稱</string>
     <string name="importExportHelp">備份您的資料以將其轉移至其他裝置中。</string>
-    <string name="noExternalStoragePermissionError">在匯入及匯出資料前，請先允許外部儲存裝置存取權限</string>
     <string name="importOptionFilesystemTitle">自檔案系統中匯入</string>
     <string name="importOptionFilesystemExplanation">自檔案系統中選取檔案。</string>
     <string name="importOptionFilesystemButton">自檔案系統</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,8 @@
     <string name="exportFailed">Could not perform export</string>
     <string name="importing">Importing…</string>
     <string name="exporting">Exporting…</string>
-    <string name="noExternalStoragePermissionError">Grant external storage permission to import or export data</string>
+    <string name="storageReadPermissionRequired">Permission to read storage needed for this action…</string>
+    <string name="cameraPermissionRequired">Permission to access camera needed for this action…</string>
     <string name="cameraPermissionDeniedTitle">Could not access the camera</string>
     <string name="noCameraPermissionDirectToSystemSetting">To scan barcodes, Catima will need access to your camera. Tap here to change your permission settings.</string>
     <string name="exportOptionExplanation">The data will be written to a location of your choice.</string>


### PR DESCRIPTION
- Remove write permission (was never needed)
- Only use read permission for Android 5 and 6
- Simplify logic by mocking a valid permission result if permission already granted

Fixes #979 
Supersedes #1110 