### PR TITLE
Fix Stocard export filenames

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -93,7 +93,7 @@
     <string name="importFidme">الاستيراد من FidMe</string>
     <string name="importFidmeMessage">حدد ملفك <i>fidme-export-request-xxxxxx.zip</i> تصدير من FidMe للاستيراد ، ثم حدد أنواع الباركود يدويًا بعد ذلك.
 \nقم بإنشائه من ملف تعريف FidMe الخاص بك عن طريق اختيار حماية البيانات ثم الضغط على استخراج بياناتي أولاً.</string>
-    <string name="importStocardMessage">حدد ملفك <i>***-sync.zip</i> تصدير من Stocard للاستيراد.
+    <string name="importStocardMessage">حدد ملفك <i>***.zip</i> تصدير من Stocard للاستيراد.
 \nاحصل عليه عن طريق إرسال بريد إلكتروني إلى support@stocardapp.com لطلب تصدير بياناتك.</string>
     <string name="importVoucherVault">الاستيراد من Voucher Vault</string>
     <string name="importVoucherVaultMessage">حدد ملفك <i>vouchervault.json</i> تصدير من Voucher Vault للاستيراد.

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -152,7 +152,7 @@
     <string name="importVoucherVault">Внасяне от Voucher Vault</string>
     <string name="importVoucherVaultMessage">Изберете файла <i>vouchervault.json</i>, предварително изнесен от Voucher Vault.
 \nСъздайте такъв файл от меню „Export“ във Voucher Vault.</string>
-    <string name="importStocardMessage">Изберете файла <i>***-sync.zip</i>, предварително изнесен от Stocard.
+    <string name="importStocardMessage">Изберете файла <i>***.zip</i>, предварително изнесен от Stocard.
 \nПолучете го като изпратите писмо на support@stocardapp.com с искане за изнасяне вашите данни.</string>
     <string name="importLoyaltyCardKeychainMessage">Изберете файла <i>LoyaltyCardKeychain.csv</i>, предварително изнесен от Loyalty Card Keychain.
 \nСъздайте такъв файл от меню Внасяне/изнасяне от друго устройство с Loyalty Card Keychain като изберете Изнасяне.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -135,7 +135,7 @@
     <string name="importVoucherVaultMessage">Vyberte k importu svůj <i>vouchervault.json</i> exportovaný z Voucher Vault.
 \nVytvoříte jej tak, že nejprve stisknete tlačítko Exportovat v aplikaci Voucher Vault.</string>
     <string name="importVoucherVault">Import z Voucher Vault</string>
-    <string name="importStocardMessage">Vyberte k importu svůj <i>***-sync.zip</i> exportovaný z aplikace Stocard.
+    <string name="importStocardMessage">Vyberte k importu svůj <i>***.zip</i> exportovaný z aplikace Stocard.
 \nZískejte ji zasláním e-mailu na adresu support@stocardapp.com s žádostí o export vašich dat.</string>
     <string name="importStocard">Import ze Stocard</string>
     <string name="importLoyaltyCardKeychainMessage">Vyberte k importu <i>LoyaltyCardKeychain.csv</i> exportovaný z Loyalty Card Keychain.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -150,7 +150,7 @@
     <string name="frontImageDescription">Bild auf der Vorseite</string>
     <string name="backImageDescription">Bild auf der Rückseite</string>
     <string name="passwordRequired">Bitte gib das Passwort ein</string>
-    <string name="importStocardMessage">Wähle deinen <i>***-sync.zip</i>-Export aus Stocard zum Importieren aus.
+    <string name="importStocardMessage">Wähle deinen <i>***.zip</i>-Export aus Stocard zum Importieren aus.
 \nSie erhalten ihn, indem du eine E-Mail an support@stocardapp.com sendest und um einen Export deiner Daten bitten.</string>
     <string name="importStocard">Von Stocard importieren</string>
     <string name="turn_flashlight_off">Licht ausschalten</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -140,7 +140,7 @@
     </plurals>
     <string name="importCatimaMessage">Επιλέξτε την <i>catima.zip</i> εξαγωγή από το Catima για εισαγωγή
 \nΔημιουργήστε το από το μενού Εισαγωγής/Εξαγωγής μιας άλλης εφαρμογής Catima κάνοντας εξαγωγή εκεί πρώτα.</string>
-    <string name="importStocardMessage">Επιλέξτε την <i>***-sync.zip</i> εξαγωγή από το Stocard για εισαγωγή.
+    <string name="importStocardMessage">Επιλέξτε την <i>***.zip</i> εξαγωγή από το Stocard για εισαγωγή.
 \nΠάρτε το στέλνοντας email στο: support@stocardapp.com ζητώντας μια εξαγωγή αρχείων των δεδομένων σας.</string>
     <string name="intent_import_card_from_url_share_multiple_text">Θέλω να μοιραστώ μερικές κάρτες μαζί σου</string>
     <string name="editGroup">Επεξεργασία Ομάδας: <xliff:g>%s</xliff:g></string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -108,7 +108,7 @@
 \nCréalo primero desde tu perfil de FidMe eligiendo Protección de datos y pulsa Extraer mis datos.</string>
     <string name="importLoyaltyCardKeychainMessage">Seleccione su <i>LoyaltyCardKeychain.csv</i> exportado desde Loyalty Card Keychain para importarlo.
 \nCréalo primero desde el menú Importar/Exportar en Loyalty Card Keychain pulsando Exportar desde allí.</string>
-    <string name="importStocardMessage">Seleccione su exportación <i>*-sync.zip</i> de Stocard para importarla.
+    <string name="importStocardMessage">Seleccione su exportación <i>*.zip</i> de Stocard para importarla.
 \nConsígalo enviando un correo electrónico a support@stocardapp.com solicitando una exportación de sus datos.</string>
     <string name="importVoucherVaultMessage">Seleccione su <i>vouchervault.json</i> exportado desde Voucher Vault para importarlo.
 \nCréalo pulsando primero Exportar en Voucher Vault.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -163,7 +163,7 @@
         <item quantity="other"><xliff:g>%d</xliff:g> valittu</item>
     </plurals>
     <string name="importStocard">Tuo Stocardista</string>
-    <string name="importStocardMessage">Valitse tuotava <i>***-sync.zip</i>-vienti Stocardista.
+    <string name="importStocardMessage">Valitse tuotava <i>***.zip</i>-vienti Stocardista.
 \nHanki se lähettämällä sähköpostia osoitteeseen support@stocardapp.com ja pyytämällä tietojesi vientiä.</string>
     <string name="passwordRequired">Ole hyvä ja syötä salasana</string>
     <string name="failedGeneratingShareURL">Jaettavaa URL-osoitetta ei voitu luoda. Ilmoita tästä.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -150,7 +150,7 @@
     <string name="backImageDescription">Image du verso</string>
     <string name="frontImageDescription">Image du recto</string>
     <string name="passwordRequired">Veuillez entrer le mot de passe</string>
-    <string name="importStocardMessage">Sélectionnez votre exportation <i>***-sync.zip</i> de Stocard pour l’importer.
+    <string name="importStocardMessage">Sélectionnez votre exportation <i>***.zip</i> de Stocard pour l’importer.
 \nVous pouvez l’obtenir en envoyant un courriel à support@stocardapp.com pour demander une exportation de vos données.</string>
     <string name="importStocard">Importer depuis Stocard</string>
     <string name="turn_flashlight_off">Éteindre la lampe de poche</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -55,7 +55,7 @@
     <string name="barcodeImageDescriptionWithType"><xliff:g>%s</xliff:g> vonalkód képe</string>
     <string name="noCardIdError">Nincs azonosító megadva</string>
     <string name="noCardExistsError">Kártya nem található</string>
-    <string name="importStocardMessage">Válassza ki a <i>***-sync.zip</i> Stocard exportot.
+    <string name="importStocardMessage">Válassza ki a <i>***.zip</i> Stocard exportot.
 \nAdatinak exportját kérheti e-mailben a support@stocardapp.com címre írva.</string>
     <string name="importVoucherVault">Importálás Voucher Vault-ból</string>
     <string name="wrongValueForBarcodeType">Ez az érték meg megfelelő a vonalkód típushoz</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -161,7 +161,7 @@
     <string name="importLoyaltyCardKeychainMessage">Pilih ekspor <i>LoyaltyCardKeychain.csv</i> Anda dari Loyalty Card Keychain untuk diimpor. 
 \nBuat dari menu Import/Export di Loyalty Card Keychain dengan menekan Export terlebih dahulu.</string>
     <string name="importStocard">Impor dari Stocard</string>
-    <string name="importStocardMessage">Pilih ekspor <i>***-sync.zip</i> Anda dari Stocard untuk diimpor. 
+    <string name="importStocardMessage">Pilih ekspor <i>***.zip</i> Anda dari Stocard untuk diimpor. 
 \nDapatkan dengan mengirim email ke support@stocardapp.com untuk meminta ekspor data Anda.</string>
     <string name="importVoucherVault">Impor dari Voucher Vault</string>
     <string name="importVoucherVaultMessage">Pilih ekspor <i>vouchervault.json</i> Anda dari Vault Voucher untuk diimpor. 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -150,7 +150,7 @@
     <string name="backImageDescription">Immagine posteriore</string>
     <string name="frontImageDescription">Immagine frontale</string>
     <string name="passwordRequired">Si prega di inserire la password</string>
-    <string name="importStocardMessage">Seleziona il tuo file di esportazione <i>***-sync.zip</i> da Stocard per importarlo.
+    <string name="importStocardMessage">Seleziona il tuo file di esportazione <i>***.zip</i> da Stocard per importarlo.
 \nOttienilo inviando un\'e-mail a support@stocardapp.com chiedendo un\'esportazione dei tuoi dati.</string>
     <string name="importStocard">Importa da Stocard</string>
     <string name="turn_flashlight_off">Spegni la torcia</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -151,7 +151,7 @@
     <string name="photos">フォト</string>
     <string name="backImageDescription">裏</string>
     <string name="frontImageDescription">表</string>
-    <string name="importStocardMessage">Stocardでエクスポートした<i>***-sync.zip</i>ファイルを選択してください。
+    <string name="importStocardMessage">Stocardでエクスポートした<i>***.zip</i>ファイルを選択してください。
 \nファイルがない場合、e-mailing support@stocardapp.comにデータのエクスポートを要求してください。</string>
     <string name="importStocard">Stocardからインポート</string>
     <plurals name="selectedCardCount">

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -75,7 +75,7 @@
     <string name="setBarcodeId">Nustatyti brūkšninio kodo reikšmę</string>
     <string name="sameAsCardId">Tokia pat kaip ID</string>
     <string name="barcodeId">Brūkšninio kodo reikšmė</string>
-    <string name="importStocardMessage">Pasirinkite <i>***-sync.zip</i> eksportą iš Stocard, kad galėtumėte importuoti.
+    <string name="importStocardMessage">Pasirinkite <i>***.zip</i> eksportą iš Stocard, kad galėtumėte importuoti.
 \nGaukite susisiekę el. paštu support@stocardapp.com, prašydami eksportuoti jūsų duomenis.</string>
     <string name="importStocard">Importuoti iš Stocard</string>
     <string name="importFidmeMessage">Pasirinkite <i>fidme-export-request-xxxxxx.zip</i> eksportą iš FidMe, kurį norite importuoti, ir po to brūkšninių kodų tipus pasirinkite rankiniu būdu.

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -204,7 +204,7 @@
 \nFailu var izveidot Jūsu FidMe profilā, ejot uz \"Data Protection\" un spiežot \"Extract my data\".</string>
     <string name="importLoyaltyCardKeychain">Importēt no Loyalty Card Keychain</string>
     <string name="importStocard">Importēt no Stocard</string>
-    <string name="importStocardMessage">Importam izvēlieties Jūsu <i>***-sync.zip</i> eksporta failu no Stocard.
+    <string name="importStocardMessage">Importam izvēlieties Jūsu <i>***.zip</i> eksporta failu no Stocard.
 \nFailu var iegūt sūtot e-pastu uz support@stocardapp.com ar pieprasījumu eksportēt Jūsu datus.</string>
     <string name="importVoucherVault">Importēt no Voucher Vault</string>
     <string name="importVoucherVaultMessage">Importam izvēlieties Jūsu <i>vouchervault.json</i> failu no Voucher Vault.

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -146,7 +146,7 @@
     <string name="photos">Bilder</string>
     <string name="backImageDescription">Baksidebilde</string>
     <string name="frontImageDescription">Forsidebilde</string>
-    <string name="importStocardMessage">Velg din <i>***-sync.zip</i>-eksport fra Stocard å importere.
+    <string name="importStocardMessage">Velg din <i>***.zip</i>-eksport fra Stocard å importere.
 \nSkaff den ved å sende e-post til support@stocardapp.com der du etterspør eksport av dataen din.</string>
     <string name="passwordRequired">Skriv inn passordet</string>
     <string name="importStocard">Importer fra Stocard</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -149,7 +149,7 @@
     <string name="backImageDescription">Achterzijde van kaart</string>
     <string name="frontImageDescription">Voorzijde van kaart</string>
     <string name="passwordRequired">Voer het wachtwoord in</string>
-    <string name="importStocardMessage">Kies het te importeren Stocard-exportbestand genaamd <i>***-sync.zip</i>.
+    <string name="importStocardMessage">Kies het te importeren Stocard-exportbestand genaamd <i>***.zip</i>.
 \nStuur een e-mail naar support@stocardapp.com waarin je vraagt om een exportbestand.</string>
     <string name="importStocard">Importeren uit Stocard</string>
     <string name="failedGeneratingShareURL">De te delen link kan niet worden gegenereerd. Meld deze fout.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -115,7 +115,7 @@
     <string name="importVoucherVaultMessage">Wybierz swój <i>vouchervault.json</i> z Voucher Vault, aby zaimportować.
 \nUtwórz go wpierw klikając Eksportuj w Voucher Vault.</string>
     <string name="importVoucherVault">Importuj z Voucher Vault</string>
-    <string name="importStocardMessage">Wybierz swój <i>***-sync.zip</i> z Stocard, aby zaimportować.
+    <string name="importStocardMessage">Wybierz swój <i>***.zip</i> z Stocard, aby zaimportować.
 \nUzyskaj go, wysyłając email na adres support@stocardapp.com, z prośbą o eksport Twoich danych.</string>
     <string name="importStocard">Importuj z Stocard</string>
     <string name="importLoyaltyCardKeychainMessage">Wybierz swój <i>LoyaltyCardKeychain.csv</i> z Loyalty Card Keychain, aby zaimportować.

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -97,7 +97,7 @@
     <string name="sameAsCardId">Igual ao identificador</string>
     <string name="importFidmeMessage">Selecione a exportação <i>fidme-export-request-xxxxxx.zip</i> do FidMe para importar e depois selecione os tipos de código de barras manualmente.
 \nPrimeiro crie a exportação no seu perfil do FidMe escolhendo a opção \"Proteção de dados\" e em seguida pressionando \"Extrair os meus dados\".</string>
-    <string name="importStocardMessage">Selecione a exportação <i>***-sync.zip</i> do Stocard para importar.
+    <string name="importStocardMessage">Selecione a exportação <i>***.zip</i> do Stocard para importar.
 \nObtenha-o através do e-mail support@stocardapp.com solicitando uma exportação dos seus dados.</string>
     <string name="barcodeId">Valor do código de barras</string>
     <string name="wrongValueForBarcodeType">O valor não é válido para o tipo de código de barras selecionado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -150,7 +150,7 @@
     <string name="backImageDescription">Задняя сторона</string>
     <string name="frontImageDescription">Лицевая сторона</string>
     <string name="photos">Фото</string>
-    <string name="importStocardMessage">Выберите для импортирования файл <i>***-sync.zip</i>.
+    <string name="importStocardMessage">Выберите для импортирования файл <i>***.zip</i>.
 \nЭтот файл можно получить по электронной почте от support@stocardapp.com, предварительно запросив экспорт ваших данных.</string>
     <string name="passwordRequired">Введите пароль</string>
     <string name="importStocard">Импорт из Stocard</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -265,7 +265,7 @@
     <string name="settings_landscape_orientation">Na šírku</string>
     <string name="importFidmeMessage">Vyberte svoj <i>fidme-export-request-xxxxxx.zip</i> export zo služby FidMe pre import a potom vyberte typy čiarových kódov ručne.
 \nVytvorte ho z profilu FidMe tak, že najprv vyberiete položku Ochrana údajov a potom stlačíte tlačidlo Extrahovať moje údaje.</string>
-    <string name="importStocardMessage">Vyberte svoj <i>***-sync.zip</i> export zo Stocard pre import.
+    <string name="importStocardMessage">Vyberte svoj <i>***.zip</i> export zo Stocard pre import.
 \nZískate ho zaslaním e-mailu na adresu support@stocardapp.com, v ktorom požiadate o export svojich údajov.</string>
     <string name="currentBalanceSentence">Aktuálny zostatok: <xliff:g>%s</xliff:g></string>
     <string name="copy_to_clipboard_multiple_toast">ID skopírované do schránky</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -221,7 +221,7 @@
     <string name="moveBarcodeToCenterOfScreen">Postavi črtno kodo na sredino zaslona</string>
     <string name="importCatimaMessage">Izberi svoj obstoječ Catima <i>catima.zip</i> izvoz podatkov za uvoz v aplikacijo.
 \nNajprej izvozi podatke v meniju \"Uvozi/Izvozi\" v drugi aplikaciji Catima s pritiskom na izbiro izvozi.</string>
-    <string name="importStocardMessage">Izberi svoj <i>***-sync.zip</i> Stocard izvoz podatkov za uvoz.
+    <string name="importStocardMessage">Izberi svoj <i>***.zip</i> Stocard izvoz podatkov za uvoz.
 \nIzvoz podatkov dobiš s pošiljanjem elektronske pošte na support@stocardapp.com, kjer povprašaš za izvoz svojih podatkov.</string>
     <string name="importVoucherVaultMessage">Izberi svoj <i>vouchervault.json</i> Voucher Vault izvoz podatkov za uvoz.
 \nIzvoz podatkov dobiš s pritiskom na gumb \"Export\" v Voucher Vault first.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -24,7 +24,7 @@
 \nSkapa den från Import/Export-menyn i Loyalty Card Keychain först genom att trycka på Exportera.</string>
     <string name="importVoucherVaultMessage">Välj den exporterade <i>vouchervault.json</i> från Voucher Vault som du vill importera.
 \nSkapa den först genom att trycka på Exportera i Voucher Vault.</string>
-    <string name="importStocardMessage">Välj den exporterade <i>***-sync.zip</i> från Stocard som du vill importera.
+    <string name="importStocardMessage">Välj den exporterade <i>***.zip</i> från Stocard som du vill importera.
 \nSkaffa den först genom att skicka e-post till support@stocardapp.com och be om att få dina data exporterade.</string>
     <string name="enter_group_name">Ange gruppnamn</string>
     <string name="groups">Grupper</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -39,7 +39,7 @@
     <string name="importVoucherVaultMessage">İçe aktarmak için Voucher Vault\'tan dışa aktardığınız <i>vouchervault.json</i> dosyasını seçin.
 \nÖnce Voucher Vault\'ta \"Dışa aktar\" düğmesine basarak bir tane oluşturun.</string>
     <string name="importVoucherVault">Voucher Vault\'tan içe aktar</string>
-    <string name="importStocardMessage">İçe aktarmak için Stocard\'dan dışa aktardığınız <i>***-sync.zip</i> dosyasını seçin.
+    <string name="importStocardMessage">İçe aktarmak için Stocard\'dan dışa aktardığınız <i>***.zip</i> dosyasını seçin.
 \nsupport@stocardapp.com adresine e-posta göndererek verilerinizin dışa aktarılmasını isteyerek edinin.</string>
     <string name="importStocard">Stocard\'dan içe aktar</string>
     <string name="importLoyaltyCardKeychainMessage">İçe aktarmak için Loyalty Card Keychain\'den dışa aktardığınız <i>LoyaltyCardKeychain.csv</i> dosyasını seçin.

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -154,7 +154,7 @@
     <string name="photos">Світлини</string>
     <string name="backImageDescription">Тильна сторона</string>
     <string name="frontImageDescription">Лицьова сторона</string>
-    <string name="importStocardMessage">Виберіть експорт <i> ***-sync.zip </i> зі Stocard для імпорту.
+    <string name="importStocardMessage">Виберіть експорт <i> ***.zip </i> зі Stocard для імпорту.
 \nОтримайте його, надіславши електронного листа support@stocardapp.com з проханням експортувати ваші дані.</string>
     <string name="importStocard">Імпорт із Stocard</string>
     <plurals name="selectedCardCount">

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -140,7 +140,7 @@
     <string name="deleteConfirmation">删除此卡？</string>
     <string name="deleteTitle">移除卡片</string>
     <string name="starImage">最喜欢的星星</string>
-    <string name="importStocardMessage">选择 Stocard 导出文件 <i>****-sync.zip</i>来导入。
+    <string name="importStocardMessage">选择 Stocard 导出文件 <i>****.zip</i>来导入。
 \n发电子邮件给 support@stocardapp.com 请求获得数据导出文件。</string>
     <plurals name="deleteCardsConfirmation">
         <item quantity="other">确定永久删除 <xliff:g>%d</xliff:g> 这些卡片？</item>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -172,7 +172,7 @@
     <string name="importVoucherVaultMessage">選取您自 Voucher Vault 匯出的 <i>vouchervault.json</i> 檔案以進行匯入。
 \n請您先透過 Voucher Vault 進行匯出。</string>
     <string name="importStocard">自 Stocard 中匯入</string>
-    <string name="importStocardMessage">&gt;選取您自 Stocard 匯出的  <i>***-sync.zip</i> 檔案以進行匯入。
+    <string name="importStocardMessage">&gt;選取您自 Stocard 匯出的  <i>***.zip</i> 檔案以進行匯入。
 \n請您寫封 Email 至 support@stocardapp.com 索取您的資料。</string>
     <string name="importLoyaltyCardKeychain">自 Loyalty Card Keychain 中匯入</string>
     <string name="importLoyaltyCardKeychainMessage">選取您自 Loyalty Card Keychain <i>LoyaltyCardKeychain.csv</i> 檔案以進行匯入。

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,7 +194,7 @@
     <string name="importLoyaltyCardKeychainMessage">Select your <i>LoyaltyCardKeychain.csv</i> export from Loyalty Card Keychain to import.
 \nCreate it from the Import/Export menu in Loyalty Card Keychain by pressing Export there first.</string>
     <string name="importStocard">Import from Stocard</string>
-    <string name="importStocardMessage">Select your <i>***-sync.zip</i> export from Stocard to import.
+    <string name="importStocardMessage">Select your <i>***.zip</i> export from Stocard to import.
 \nGet it by e-mailing support@stocardapp.com asking for an export of your data.</string>
     <string name="importVoucherVault">Import from Voucher Vault</string>
     <string name="importVoucherVaultMessage">Select your <i>vouchervault.json</i> export from Voucher Vault to import.


### PR DESCRIPTION
Stocard renamed their exports to no longer contain sync, only your user id.

Also related to #1242. Sadly forgot to do this before making a new release. Oh well.