### PR TITLE
Fix/loyalty card edit activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,7 @@ dependencies {
 // Testing
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.10'
+    testImplementation 'org.robolectric:robolectric:4.10.1'
 }
 
 tasks.withType(SpotBugsTask) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,7 @@ dependencies {
 // Testing
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.10.1'
+    testImplementation 'org.robolectric:robolectric:4.10'
 }
 
 tasks.withType(SpotBugsTask) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1285,12 +1285,10 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                         Callable<Void> callable = callables.next();
 
                         for (int i = 0; i < which; i++) {
-
                             callable = callables.next();
                         }
 
                         try {
-
                             callable.call();
                         }catch(ActivityNotFoundException e){
 
@@ -1298,8 +1296,6 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                                     Toast.LENGTH_SHORT).show();
 
                             e.printStackTrace();
-
-
                         } catch (Exception e) {
                             e.printStackTrace();
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1285,11 +1285,21 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                         Callable<Void> callable = callables.next();
 
                         for (int i = 0; i < which; i++) {
+
                             callable = callables.next();
                         }
 
                         try {
+
                             callable.call();
+                        }catch(ActivityNotFoundException e){
+
+                            Toast.makeText(getApplicationContext(), "Camera disabled",
+                                    Toast.LENGTH_SHORT).show();
+
+                            e.printStackTrace();
+
+
                         } catch (Exception e) {
                             e.printStackTrace();
 
@@ -1617,4 +1627,5 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
             Log.d(TAG, "Could not get currency data for locale info: " + e);
         }
     }
+
 }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1292,7 +1292,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
                             callable.call();
                         }catch(ActivityNotFoundException e){
 
-                            Toast.makeText(getApplicationContext(), "Camera disabled",
+                            Toast.makeText(getApplicationContext(),
+                                    getString(R.string.cameraPermissionDeniedTitle),
                                     Toast.LENGTH_SHORT).show();
 
                             e.printStackTrace();


### PR DESCRIPTION
Pr for [#1211](https://github.com/CatimaLoyalty/Android/issues/1211)


While testing, saw that there was an ActivityNotFoundException before the NoSuchElementException which was the actual exception causing the crash. By catching this one before, it stops the crash. A toast was inserted to explain the camera is disabled.