### PR TITLE
Switch to using photo picker

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,8 +94,6 @@ dependencies {
     }
 // AndroidX
     implementation 'androidx.activity:activity:1.7.1'
-    implementation 'androidx.activity:activity-compose:1.7.1'
-    implementation 'androidx.activity:activity-ktx:1.7.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.exifinterface:exifinterface:1.3.6'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,18 @@ android {
 }
 
 dependencies {
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
 // AndroidX
+    implementation 'androidx.activity:activity:1.7.1'
+    implementation 'androidx.activity:activity-compose:1.7.1'
+    implementation 'androidx.activity:activity-ktx:1.7.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.exifinterface:exifinterface:1.3.6'

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -258,13 +258,13 @@ public class ScanActivity extends CatimaAppCompatActivity {
         }
     }
 
-        private void showCameraPermissionMissingText ( boolean show){
-            customBarcodeScannerBinding.cameraPermissionDeniedLayout.cameraPermissionDeniedClickableArea.setOnClickListener(show ? v -> {
-                navigateToSystemPermissionSetting();
-            } : null);
-            customBarcodeScannerBinding.cardInputContainer.setBackgroundColor(show ? obtainThemeAttribute(com.google.android.material.R.attr.colorSurface) : Color.TRANSPARENT);
-            customBarcodeScannerBinding.cameraPermissionDeniedLayout.getRoot().setVisibility(show ? View.VISIBLE : View.GONE);
-        }
+    private void showCameraPermissionMissingText ( boolean show){
+        customBarcodeScannerBinding.cameraPermissionDeniedLayout.cameraPermissionDeniedClickableArea.setOnClickListener(show ? v -> {
+            navigateToSystemPermissionSetting();
+        } : null);
+        customBarcodeScannerBinding.cardInputContainer.setBackgroundColor(show ? obtainThemeAttribute(com.google.android.material.R.attr.colorSurface) : Color.TRANSPARENT);
+        customBarcodeScannerBinding.cameraPermissionDeniedLayout.getRoot().setVisibility(show ? View.VISIBLE : View.GONE);
+    }
 
     private void scaleScreen() {
         DisplayMetrics displayMetrics = new DisplayMetrics();

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
@@ -19,6 +20,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.PickVisualMediaRequest;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
@@ -64,6 +66,7 @@ public class ScanActivity extends CatimaAppCompatActivity {
     private ActivityResultLauncher<Intent> manualAddLauncher;
     // can't use the pre-made contract because that launches the file manager for image type instead of gallery
     private ActivityResultLauncher<Intent> photoPickerLauncher;
+    private ActivityResultLauncher<PickVisualMediaRequest> pickMedia;
 
     private void extractIntentFields(Intent intent) {
         final Bundle b = intent.getExtras();
@@ -87,6 +90,7 @@ public class ScanActivity extends CatimaAppCompatActivity {
 
         manualAddLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> handleActivityResult(Utils.SELECT_BARCODE_REQUEST, result.getResultCode(), result.getData()));
         photoPickerLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> handleActivityResult(Utils.BARCODE_IMPORT_FROM_IMAGE_FILE, result.getResultCode(), result.getData()));
+        pickMedia = registerForActivityResult(new ActivityResultContracts.PickVisualMedia(),result -> handleActivityResult(Utils.BARCODE_IMPORT_FROM_IMAGE_FILE, result != null? Activity.RESULT_OK : Activity.RESULT_CANCELED, new Intent().setData(result)));
         customBarcodeScannerBinding.addFromImage.setOnClickListener(this::addFromImage);
         customBarcodeScannerBinding.addManually.setOnClickListener(this::addManually);
 
@@ -226,28 +230,41 @@ public class ScanActivity extends CatimaAppCompatActivity {
     }
 
     private void addFromImageAfterPermission() {
-        Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
-        photoPickerIntent.setType("image/*");
-        Intent contentIntent = new Intent(Intent.ACTION_GET_CONTENT);
-        contentIntent.setType("image/*");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Use the new photo picker on devices where it is available
+            try {
+                // Registers a photo picker activity launcher in single-select mode.
+                pickMedia.launch(new PickVisualMediaRequest.Builder()
+                        .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE)
+                        .build());
+            } catch (ActivityNotFoundException e) {
+                Toast.makeText(getApplicationContext(), R.string.failedLaunchingPhotoPicker, Toast.LENGTH_LONG).show();
+                Log.e(TAG, "No activity found to handle intent", e);
+            }
+        } else {
+            Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
+            photoPickerIntent.setType("image/*");
+            Intent contentIntent = new Intent(Intent.ACTION_GET_CONTENT);
+            contentIntent.setType("image/*");
 
-        Intent chooserIntent = Intent.createChooser(photoPickerIntent, getString(R.string.addFromImage));
-        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { contentIntent });
-        try {
-            photoPickerLauncher.launch(chooserIntent);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(getApplicationContext(), R.string.failedLaunchingPhotoPicker, Toast.LENGTH_LONG).show();
-            Log.e(TAG, "No activity found to handle intent", e);
+            Intent chooserIntent = Intent.createChooser(photoPickerIntent, getString(R.string.addFromImage));
+            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[]{contentIntent});
+            try {
+                photoPickerLauncher.launch(chooserIntent);
+            } catch (ActivityNotFoundException e) {
+                Toast.makeText(getApplicationContext(), R.string.failedLaunchingPhotoPicker, Toast.LENGTH_LONG).show();
+                Log.e(TAG, "No activity found to handle intent", e);
+            }
         }
     }
 
-    private void showCameraPermissionMissingText(boolean show) {
-        customBarcodeScannerBinding.cameraPermissionDeniedLayout.cameraPermissionDeniedClickableArea.setOnClickListener(show ? v -> {
-            navigateToSystemPermissionSetting();
-        } : null);
-        customBarcodeScannerBinding.cardInputContainer.setBackgroundColor(show ? obtainThemeAttribute(com.google.android.material.R.attr.colorSurface) : Color.TRANSPARENT);
-        customBarcodeScannerBinding.cameraPermissionDeniedLayout.getRoot().setVisibility(show ? View.VISIBLE : View.GONE);
-    }
+        private void showCameraPermissionMissingText ( boolean show){
+            customBarcodeScannerBinding.cameraPermissionDeniedLayout.cameraPermissionDeniedClickableArea.setOnClickListener(show ? v -> {
+                navigateToSystemPermissionSetting();
+            } : null);
+            customBarcodeScannerBinding.cardInputContainer.setBackgroundColor(show ? obtainThemeAttribute(com.google.android.material.R.attr.colorSurface) : Color.TRANSPARENT);
+            customBarcodeScannerBinding.cameraPermissionDeniedLayout.getRoot().setVisibility(show ? View.VISIBLE : View.GONE);
+        }
 
     private void scaleScreen() {
         DisplayMetrics displayMetrics = new DisplayMetrics();


### PR DESCRIPTION
To solve the issue #1261 
I apply the logic that is explained here: https://developer.android.com/training/data-storage/shared/photopicker#java

First, I need to look for situations in which the user is allowed to select an image from their gallery or files directory. I found that the user is allowed to select an image in three main cases:

1. When creating a card and an icon or image can be defined, or in the Photos tab (to define the front and back image).
2. When editing a card and an icon or image can be defined, or in the Photos tab (to define the front and back image).
3. When extracting a barcode or QR code.

After identify these cases I search the code that display the gallery or the file directory and I adapt that code to use the new photo picker approach instead the old one (Only if the Android version of the phone is superior to Android R (11), because if I want to apply this approach to old versions of android, I need to enable the automatic installation of the backported photo picker module through Google Play services and the issue says that is better to not install things without the permission of the user and I agree with that).

Basically, I add some dependencies of androidx and edit the next functions:
* addFromImageAfterPermission() - In the ScanActivity
* selectImageFromGallery(int type) - In the LoyaltyCardEditActivity

If the phone had an Android version oldest than 11 then the old code is executed, if not then the new photo picker is used.
 