### PR TITLE
Update Settings screen to use Material You design

### DIFF
--- a/app/src/main/res/drawable/dialog_bg_monet.xml
+++ b/app/src/main/res/drawable/dialog_bg_monet.xml
@@ -1,0 +1,24 @@
+<layer-list xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="?attr/colorSurface" />
+            <corners
+                android:bottomLeftRadius="28dp"
+                android:bottomRightRadius="28dp"
+                android:topLeftRadius="28dp"
+                android:topRightRadius="28dp" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@color/m3_popupmenu_overlay_color"
+                tools:ignore="PrivateResource" />
+            <corners
+                android:bottomLeftRadius="28dp"
+                android:bottomRightRadius="28dp"
+                android:topLeftRadius="28dp"
+                android:topRightRadius="28dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/preference_material_switch.xml
+++ b/app/src/main/res/layout/preference_material_switch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.materialswitch.MaterialSwitch xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@null"
+    android:clickable="false"
+    android:focusable="false" />

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -27,8 +27,16 @@
         <item name="colorOnSurfaceInverse">@color/md_theme_dark_inverseOnSurface</item>
         <item name="colorSurfaceInverse">@color/md_theme_dark_inverseSurface</item>
         <item name="colorPrimaryInverse">@color/md_theme_dark_primaryInverse</item>
+        <item name="materialAlertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog.Monet</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog.Monet</item>
 
         <item name="windowActionModeOverlay">true</item>
+    </style>
+
+    <style name="ThemeOverlay.App.MaterialAlertDialog.Monet" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="alertDialogStyle">@style/MaterialAlertDialog.Material3</item>
+        <item name="dialogCornerRadius">28dp</item>
+        <item name="android:background">@drawable/dialog_bg_monet</item>
     </style>
 
     <!-- note that this is not used directly, these are used to patch the active theme runtime with

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -27,8 +27,17 @@
         <item name="colorOnSurfaceInverse">@color/md_theme_light_inverseOnSurface</item>
         <item name="colorSurfaceInverse">@color/md_theme_light_inverseSurface</item>
         <item name="colorPrimaryInverse">@color/md_theme_light_primaryInverse</item>
+        <item name="materialAlertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog.Monet</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog.Monet</item>
 
         <item name="windowActionModeOverlay">true</item>
+
+    </style>
+
+    <style name="ThemeOverlay.App.MaterialAlertDialog.Monet" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="alertDialogStyle">@style/MaterialAlertDialog.Material3</item>
+        <item name="dialogCornerRadius">28dp</item>
+        <item name="android:background">@drawable/dialog_bg_monet</item>
     </style>
 
     <style name="AppTheme.NoActionBar" parent="AppTheme">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,6 +25,7 @@
             app:singleLineTitle="false" />
 
         <SwitchPreferenceCompat
+            android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="false"
             android:key="@string/settings_key_oled_dark"
             android:title="@string/settings_oled_dark"
@@ -52,6 +53,7 @@
             app:singleLineTitle="false" />
 
         <SwitchPreferenceCompat
+            android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="true"
             android:key="@string/settings_key_display_barcode_max_brightness"
             android:title="@string/settings_display_barcode_max_brightness"
@@ -68,6 +70,7 @@
             app:singleLineTitle="false" />
 
         <SwitchPreferenceCompat
+            android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="true"
             android:key="@string/settings_key_keep_screen_on"
             android:title="@string/settings_keep_screen_on"
@@ -75,11 +78,14 @@
             app:singleLineTitle="false" />
 
         <SwitchPreferenceCompat
+            android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="true"
             android:key="@string/settings_key_disable_lockscreen_while_viewing_card"
             android:title="@string/settings_disable_lockscreen_while_viewing_card"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>
+


### PR DESCRIPTION
This pull request fixes #1263
# Problem solved
Switches and Dialogs in Settings don't have Material You style applied. 
# How was the problem solved
- Introduced custom layout `preference_material_switch.xml` for Material 3 switch and applied it to switches in Settings
- Introduced new drawable `dialog_bg_monet.xml` that applies theme color and rounded edges to the Dialog
- Added new style `ThemeOverlay.App.MaterialAlertDialog.Monet` that applies Material 3 style (fonts and layout) and the color from the custom drawable to Dialog  for day and night themes and applied it for `materialAlertDialogTheme` and `alertDialogTheme`
# How to verify
- Open the app
- Go to settings, verify switches
- Tap any `ListPreference` element, verify dialog


By making a contribution to this project, I certify that:

The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file.

I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Rei Hikari <me@pokeghost.org>