### PR TITLE
make checkBox_reverse font size match sort type radio buttons

### DIFF
--- a/app/src/main/res/layout/sorting_option.xml
+++ b/app/src/main/res/layout/sorting_option.xml
@@ -15,7 +15,7 @@
             android:layout_marginLeft="20dp"
             android:paddingLeft="20dp"
             android:text="@string/reverse"
-            android:textSize="19sp"/>
+            android:textSize="16sp"/>
 
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Currently, the "...in reversed order" checkbox has a larger font size than the radio buttons above it. It looks cleaner to me with the font sizes matched. I don't know how the font size for the radio buttons is determined by `MaterialAlertDialogBuilder.setSingleChoiceItems()`, so I tried a few sizes and `16sp` looks identical to me.

![Screenshot_20230530-185727_Catima cleaned](https://github.com/CatimaLoyalty/Android/assets/1260687/d48f051e-2edc-4bcd-912c-d62e2d10cba1)