### PR TITLE
DB: drop before import & handle errors

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1437,9 +1437,21 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         // This makes the DBHelper set it to the current date
         // So that new and edited card are always on top when sorting by recently used
         if (updateLoyaltyCard) {
-            DBHelper.updateLoyaltyCard(mDatabase, loyaltyCardId, tempLoyaltyCard.store, tempLoyaltyCard.note, tempLoyaltyCard.validFrom, tempLoyaltyCard.expiry, tempLoyaltyCard.balance, tempLoyaltyCard.balanceType, tempLoyaltyCard.cardId, tempLoyaltyCard.barcodeId, tempLoyaltyCard.barcodeType, tempLoyaltyCard.headerColor, tempLoyaltyCard.starStatus, null, tempLoyaltyCard.archiveStatus);
+            try {
+                DBHelper.updateLoyaltyCard(mDatabase, loyaltyCardId, tempLoyaltyCard.store, tempLoyaltyCard.note, tempLoyaltyCard.validFrom, tempLoyaltyCard.expiry, tempLoyaltyCard.balance, tempLoyaltyCard.balanceType, tempLoyaltyCard.cardId, tempLoyaltyCard.barcodeId, tempLoyaltyCard.barcodeType, tempLoyaltyCard.headerColor, tempLoyaltyCard.starStatus, null, tempLoyaltyCard.archiveStatus);
+            } catch (DBHelper.DBException e) {
+                Log.w(TAG, "Could not update loyalty card " + loyaltyCardId);
+                Toast.makeText(this, "Could not update loyalty card", Toast.LENGTH_LONG).show(); // FIXME
+                return;
+            }
         } else {
-            loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, tempLoyaltyCard.store, tempLoyaltyCard.note, tempLoyaltyCard.validFrom, tempLoyaltyCard.expiry, tempLoyaltyCard.balance, tempLoyaltyCard.balanceType, tempLoyaltyCard.cardId, tempLoyaltyCard.barcodeId, tempLoyaltyCard.barcodeType, tempLoyaltyCard.headerColor, 0, null, 0);
+            try {
+                loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, tempLoyaltyCard.store, tempLoyaltyCard.note, tempLoyaltyCard.validFrom, tempLoyaltyCard.expiry, tempLoyaltyCard.balance, tempLoyaltyCard.balanceType, tempLoyaltyCard.cardId, tempLoyaltyCard.barcodeId, tempLoyaltyCard.barcodeType, tempLoyaltyCard.headerColor, 0, null, 0);
+            } catch (DBHelper.DBException e) {
+                Log.w(TAG, "Could not insert loyalty card");
+                Toast.makeText(this, "Could not insert loyalty card", Toast.LENGTH_LONG).show(); // FIXME
+                return;
+            }
         }
 
         try {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -263,7 +263,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
                 Log.d(TAG, "Scaling to " + scale);
 
                 loyaltyCard.zoomLevel = progress;
-                DBHelper.updateLoyaltyCardZoomLevel(database, loyaltyCardId, loyaltyCard.zoomLevel);
+
+                try {
+                    DBHelper.updateLoyaltyCardZoomLevel(database, loyaltyCardId, loyaltyCard.zoomLevel);
+                } catch (DBHelper.DBException e) {
+                    Log.d(TAG, "Could not update zoom level for card " + loyaltyCardId);
+                }
 
                 setScalerGuideline(loyaltyCard.zoomLevel);
 
@@ -669,7 +674,11 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         setFullscreen(isFullscreen);
 
-        DBHelper.updateLoyaltyCardLastUsed(database, loyaltyCard.id);
+        try {
+            DBHelper.updateLoyaltyCardLastUsed(database, loyaltyCard.id);
+        } catch (DBHelper.DBException e) {
+            Log.w(TAG, "Could not update last used for card " + loyaltyCardId);
+        }
 
         invalidateOptionsMenu();
     }
@@ -770,7 +779,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
             return true;
         } else if (id == R.id.action_star_unstar) {
-            DBHelper.updateLoyaltyCardStarStatus(database, loyaltyCardId, loyaltyCard.starStatus == 0 ? 1 : 0);
+            try {
+                DBHelper.updateLoyaltyCardStarStatus(database, loyaltyCardId, loyaltyCard.starStatus == 0 ? 1 : 0);
+            } catch (DBHelper.DBException e) {
+                Log.w(TAG, "Could not (un)star card " + loyaltyCardId);
+                Toast.makeText(LoyaltyCardViewActivity.this, "Failed to (un)star card", Toast.LENGTH_LONG).show(); // FIXME
+            }
 
             // Re-init loyaltyCard with new data from DB
             onResume();
@@ -778,7 +792,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
             return true;
         } else if (id == R.id.action_archive) {
-            DBHelper.updateLoyaltyCardArchiveStatus(database, loyaltyCardId, 1);
+            try {
+                DBHelper.updateLoyaltyCardArchiveStatus(database, loyaltyCardId, 1);
+            } catch (DBHelper.DBException e) {
+                Log.w(TAG, "Could not archive card " + loyaltyCardId);
+                Toast.makeText(LoyaltyCardViewActivity.this, "Failed to archive card", Toast.LENGTH_LONG).show(); // FIXME
+            }
             Toast.makeText(LoyaltyCardViewActivity.this, R.string.archived, Toast.LENGTH_LONG).show();
 
             // Re-init loyaltyCard with new data from DB
@@ -787,7 +806,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
             return true;
         } else if (id == R.id.action_unarchive) {
-            DBHelper.updateLoyaltyCardArchiveStatus(database, loyaltyCardId, 0);
+            try {
+                DBHelper.updateLoyaltyCardArchiveStatus(database, loyaltyCardId, 0);
+            } catch (DBHelper.DBException e) {
+                Log.w(TAG, "Could not unarchive card " + loyaltyCardId);
+                Toast.makeText(LoyaltyCardViewActivity.this, "Failed to unarchive card", Toast.LENGTH_LONG).show(); // FIXME
+            }
             Toast.makeText(LoyaltyCardViewActivity.this, R.string.unarchived, Toast.LENGTH_LONG).show();
 
             // Re-init loyaltyCard with new data from DB
@@ -802,7 +826,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             builder.setPositiveButton(R.string.confirm, (dialog, which) -> {
                 Log.e(TAG, "Deleting card: " + loyaltyCardId);
 
-                DBHelper.deleteLoyaltyCard(database, LoyaltyCardViewActivity.this, loyaltyCardId);
+                try {
+                    DBHelper.deleteLoyaltyCard(database, LoyaltyCardViewActivity.this, loyaltyCardId);
+                } catch (DBHelper.DBException e) {
+                    Log.e(TAG, "Could not delete card " + loyaltyCardId);
+                    Toast.makeText(LoyaltyCardViewActivity.this, "Failed to delete card", Toast.LENGTH_LONG).show(); // FIXME
+                }
 
                 ShortcutHelper.removeShortcut(LoyaltyCardViewActivity.this, loyaltyCardId);
 

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -164,7 +164,12 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
                     for (LoyaltyCard loyaltyCard : mAdapter.getSelectedItems()) {
                         Log.d(TAG, "Deleting card: " + loyaltyCard.id);
 
-                        DBHelper.deleteLoyaltyCard(mDatabase, MainActivity.this, loyaltyCard.id);
+                        try {
+                            DBHelper.deleteLoyaltyCard(mDatabase, MainActivity.this, loyaltyCard.id);
+                        } catch (DBHelper.DBException e) {
+                            Log.w(TAG, "Could not delete card " + loyaltyCard.id);
+                            Toast.makeText(MainActivity.this, "Failed to delete card", Toast.LENGTH_LONG).show(); // FIXME
+                        }
 
                         ShortcutHelper.removeShortcut(MainActivity.this, loyaltyCard.id);
                     }
@@ -184,7 +189,12 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
             } else if (inputItem.getItemId() == R.id.action_archive) {
                 for (LoyaltyCard loyaltyCard : mAdapter.getSelectedItems()) {
                     Log.d(TAG, "Archiving card: " + loyaltyCard.id);
-                    DBHelper.updateLoyaltyCardArchiveStatus(mDatabase, loyaltyCard.id, 1);
+                    try {
+                        DBHelper.updateLoyaltyCardArchiveStatus(mDatabase, loyaltyCard.id, 1);
+                    } catch (DBHelper.DBException e) {
+                        Log.w(TAG, "Could not archive card " + loyaltyCard.id);
+                        Toast.makeText(MainActivity.this, "Failed to archive card", Toast.LENGTH_LONG).show(); // FIXME
+                    }
                     updateLoyaltyCardList(false);
                     inputMode.finish();
                     invalidateOptionsMenu();
@@ -193,7 +203,12 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
             } else if (inputItem.getItemId() == R.id.action_unarchive) {
                 for (LoyaltyCard loyaltyCard : mAdapter.getSelectedItems()) {
                     Log.d(TAG, "Unarchiving card: " + loyaltyCard.id);
-                    DBHelper.updateLoyaltyCardArchiveStatus(mDatabase, loyaltyCard.id, 0);
+                    try {
+                        DBHelper.updateLoyaltyCardArchiveStatus(mDatabase, loyaltyCard.id, 0);
+                    } catch (DBHelper.DBException e) {
+                        Log.w(TAG, "Could not unarchive card " + loyaltyCard.id);
+                        Toast.makeText(MainActivity.this, "Failed to unarchive card", Toast.LENGTH_LONG).show(); // FIXME
+                    }
                     updateLoyaltyCardList(false);
                     inputMode.finish();
                     invalidateOptionsMenu();
@@ -202,7 +217,12 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
             } else if (inputItem.getItemId() == R.id.action_star) {
                 for (LoyaltyCard loyaltyCard : mAdapter.getSelectedItems()) {
                     Log.d(TAG, "Starring card: " + loyaltyCard.id);
-                    DBHelper.updateLoyaltyCardStarStatus(mDatabase, loyaltyCard.id, 1);
+                    try {
+                        DBHelper.updateLoyaltyCardStarStatus(mDatabase, loyaltyCard.id, 1);
+                    } catch (DBHelper.DBException e) {
+                        Log.w(TAG, "Could not star card " + loyaltyCard.id);
+                        Toast.makeText(MainActivity.this, "Failed to star card", Toast.LENGTH_LONG).show(); // FIXME
+                    }
                     updateLoyaltyCardList(false);
                     inputMode.finish();
                 }
@@ -210,7 +230,12 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
             } else if (inputItem.getItemId() == R.id.action_unstar) {
                 for (LoyaltyCard loyaltyCard : mAdapter.getSelectedItems()) {
                     Log.d(TAG, "Unstarring card: " + loyaltyCard.id);
-                    DBHelper.updateLoyaltyCardStarStatus(mDatabase, loyaltyCard.id, 0);
+                    try {
+                        DBHelper.updateLoyaltyCardStarStatus(mDatabase, loyaltyCard.id, 0);
+                    } catch (DBHelper.DBException e) {
+                        Log.w(TAG, "Could not unstar card " + loyaltyCard.id);
+                        Toast.makeText(MainActivity.this, "Failed to unstar card", Toast.LENGTH_LONG).show(); // FIXME
+                    }
                     updateLoyaltyCardList(false);
                     inputMode.finish();
                 }

--- a/app/src/main/java/protect/card_locker/ManageGroupActivity.java
+++ b/app/src/main/java/protect/card_locker/ManageGroupActivity.java
@@ -34,6 +34,8 @@ public class ManageGroupActivity extends CatimaAppCompatActivity implements Mana
     private SQLiteDatabase mDatabase;
     private ManageGroupCursorAdapter mAdapter;
 
+    private static final String TAG = "Catima";
+
     private final String SAVE_INSTANCE_ADAPTER_STATE = "adapterState";
     private final String SAVE_INSTANCE_CURRENT_GROUP_NAME = "currentGroupName";
 
@@ -127,7 +129,13 @@ public class ManageGroupActivity extends CatimaAppCompatActivity implements Mana
 
             mAdapter.commitToDatabase();
             if (!currentGroupName.equals(mGroup._id)) {
-                DBHelper.updateGroup(mDatabase, mGroup._id, currentGroupName);
+                try {
+                    DBHelper.updateGroup(mDatabase, mGroup._id, currentGroupName);
+                } catch (DBHelper.DBException e) {
+                    Log.w(TAG, "Could not update group");
+                    Toast.makeText(getApplicationContext(), "Failed to update group", Toast.LENGTH_LONG).show(); // FIXME
+                    return;
+                }
             }
             Toast.makeText(getApplicationContext(), R.string.group_updated, Toast.LENGTH_SHORT).show();
             finish();

--- a/app/src/main/java/protect/card_locker/ManageGroupsActivity.java
+++ b/app/src/main/java/protect/card_locker/ManageGroupsActivity.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 import android.text.InputType;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -166,7 +167,14 @@ public class ManageGroupsActivity extends CatimaAppCompatActivity implements Gro
                 return;
             }
 
-            DBHelper.insertGroup(mDatabase, sanitizeAddGroupNameField(input.getText()));
+            String groupName = sanitizeAddGroupNameField(input.getText());
+            try {
+                DBHelper.insertGroup(mDatabase, groupName);
+            } catch (DBHelper.DBException e) {
+                Log.w(TAG, "Could not insert group " + groupName);
+                Toast.makeText(getApplicationContext(), "Failed to insert group", Toast.LENGTH_LONG).show(); // FIXME
+                return;
+            }
             updateGroupList();
         });
         builder.setNegativeButton(getString(R.string.cancel), (dialog, which) -> dialog.cancel());
@@ -239,7 +247,13 @@ public class ManageGroupsActivity extends CatimaAppCompatActivity implements Gro
         builder.setMessage(groupName);
 
         builder.setPositiveButton(getString(R.string.ok), (dialog, which) -> {
-            DBHelper.deleteGroup(mDatabase, groupName);
+            try {
+                DBHelper.deleteGroup(mDatabase, groupName);
+            } catch (DBHelper.DBException e) {
+                Log.w(TAG, "Could not delete group " + groupName);
+                Toast.makeText(getApplicationContext(), "Failed to delete group", Toast.LENGTH_LONG).show(); // FIXME
+                return;
+            }
             updateGroupList();
             // Delete may change ordering, so invalidate
             invalidateHomescreenActiveTab();

--- a/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
@@ -39,7 +39,7 @@ import protect.card_locker.ZipUtils;
  * A header is expected for the each table showing the names of the columns.
  */
 public class CatimaImporter implements Importer {
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, InterruptedException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, InterruptedException, DBHelper.DBException {
         InputStream bufferedInputStream = new BufferedInputStream(input);
         bufferedInputStream.mark(100);
 
@@ -71,7 +71,7 @@ public class CatimaImporter implements Importer {
         input.close();
     }
 
-    public void importCSV(Context context, SQLiteDatabase database, InputStream input) throws IOException, FormatException, InterruptedException {
+    public void importCSV(Context context, SQLiteDatabase database, InputStream input) throws IOException, FormatException, InterruptedException, DBHelper.DBException {
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
 
         int version = parseVersion(bufferedReader);
@@ -87,7 +87,7 @@ public class CatimaImporter implements Importer {
         }
     }
 
-    public void parseV1(SQLiteDatabase database, BufferedReader input) throws IOException, FormatException, InterruptedException {
+    public void parseV1(SQLiteDatabase database, BufferedReader input) throws IOException, FormatException, InterruptedException, DBHelper.DBException {
         final CSVParser parser = new CSVParser(input, CSVFormat.RFC4180.builder().setHeader().build());
 
         try {
@@ -105,7 +105,7 @@ public class CatimaImporter implements Importer {
         }
     }
 
-    public void parseV2(Context context, SQLiteDatabase database, BufferedReader input) throws IOException, FormatException, InterruptedException {
+    public void parseV2(Context context, SQLiteDatabase database, BufferedReader input) throws IOException, FormatException, InterruptedException, DBHelper.DBException {
         int part = 0;
         StringBuilder stringPart = new StringBuilder();
 
@@ -168,7 +168,7 @@ public class CatimaImporter implements Importer {
         }
     }
 
-    public void parseV2Groups(SQLiteDatabase database, String data) throws IOException, FormatException, InterruptedException {
+    public void parseV2Groups(SQLiteDatabase database, String data) throws IOException, FormatException, InterruptedException, DBHelper.DBException {
         // Parse groups
         final CSVParser groupParser = new CSVParser(new StringReader(data), CSVFormat.RFC4180.builder().setHeader().build());
 
@@ -193,7 +193,7 @@ public class CatimaImporter implements Importer {
         }
     }
 
-    public void parseV2Cards(Context context, SQLiteDatabase database, String data) throws IOException, FormatException, InterruptedException {
+    public void parseV2Cards(Context context, SQLiteDatabase database, String data) throws IOException, FormatException, InterruptedException, DBHelper.DBException {
         // Parse cards
         final CSVParser cardParser = new CSVParser(new StringReader(data), CSVFormat.RFC4180.builder().setHeader().build());
 
@@ -277,7 +277,7 @@ public class CatimaImporter implements Importer {
      * session.
      */
     private void importLoyaltyCard(SQLiteDatabase database, CSVRecord record)
-            throws FormatException {
+            throws FormatException, DBHelper.DBException {
         int id = CSVHelpers.extractInt(DBHelper.LoyaltyCardDbIds.ID, record);
 
         String store = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.STORE, record, "");
@@ -381,7 +381,7 @@ public class CatimaImporter implements Importer {
      * Import a single group into the database using the given
      * session.
      */
-    private void importGroup(SQLiteDatabase database, CSVRecord record) throws FormatException {
+    private void importGroup(SQLiteDatabase database, CSVRecord record) throws FormatException, DBHelper.DBException {
         String id = CSVHelpers.extractString(DBHelper.LoyaltyCardDbGroups.ID, record, null);
 
         if (id == null) {

--- a/app/src/main/java/protect/card_locker/importexport/FidmeImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/FidmeImporter.java
@@ -31,7 +31,7 @@ import protect.card_locker.Utils;
  * A header is expected for the each table showing the names of the columns.
  */
 public class FidmeImporter implements Importer {
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException, DBHelper.DBException {
         // We actually retrieve a .zip file
         ZipInputStream zipInputStream = new ZipInputStream(input, password);
 
@@ -77,7 +77,7 @@ public class FidmeImporter implements Importer {
      * session.
      */
     private void importLoyaltyCard(Context context, SQLiteDatabase database, CSVRecord record)
-            throws FormatException {
+            throws FormatException, DBHelper.DBException {
         // A loyalty card export from Fidme contains the following fields:
         // Retailer (store name)
         // Program (program name)

--- a/app/src/main/java/protect/card_locker/importexport/Importer.java
+++ b/app/src/main/java/protect/card_locker/importexport/Importer.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 
+import protect.card_locker.DBHelper;
 import protect.card_locker.FormatException;
 
 /**
@@ -23,5 +24,5 @@ public interface Importer {
      * @throws IOException
      * @throws FormatException
      */
-    void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, InterruptedException, JSONException, ParseException;
+    void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, InterruptedException, JSONException, ParseException, DBHelper.DBException;
 }

--- a/app/src/main/java/protect/card_locker/importexport/MultiFormatImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/MultiFormatImporter.java
@@ -8,6 +8,8 @@ import net.lingala.zip4j.exception.ZipException;
 
 import java.io.InputStream;
 
+import protect.card_locker.DBHelper;
+
 public class MultiFormatImporter {
     private static final String TAG = "Catima";
 
@@ -17,6 +19,8 @@ public class MultiFormatImporter {
      * <p>
      * The input stream is not closed, and doing so is the
      * responsibility of the caller.
+     * <p>
+     * NB: this deletes all existing data!
      *
      * @return ImportExportResult.Success if the database was successfully imported,
      * or another result otherwise. If no Success, no data was written to
@@ -43,6 +47,7 @@ public class MultiFormatImporter {
         String error = null;
         if (importer != null) {
             database.beginTransaction();
+            DBHelper.clearDatabase(database);
             try {
                 importer.importData(context, database, input, password);
                 database.setTransactionSuccessful();

--- a/app/src/main/java/protect/card_locker/importexport/StocardImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/StocardImporter.java
@@ -42,7 +42,7 @@ import protect.card_locker.ZipUtils;
 public class StocardImporter implements Importer {
     private static final String TAG = "Catima";
 
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException, DBHelper.DBException {
         HashMap<String, HashMap<String, Object>> loyaltyCardHashMap = new HashMap<>();
         HashMap<String, HashMap<String, Object>> providers = new HashMap<>();
 

--- a/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
@@ -36,7 +36,7 @@ import protect.card_locker.Utils;
  * A header is expected for the each table showing the names of the columns.
  */
 public class VoucherVaultImporter implements Importer {
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException, DBHelper.DBException {
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
 
         StringBuilder sb = new StringBuilder();

--- a/app/src/test/java/protect/card_locker/DatabaseTest.java
+++ b/app/src/test/java/protect/card_locker/DatabaseTest.java
@@ -8,6 +8,7 @@ import android.graphics.Color;
 
 import com.google.zxing.BarcodeFormat;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,9 +43,12 @@ public class DatabaseTest {
     @Test
     public void addRemoveOneGiftCard() {
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
         LoyaltyCard loyaltyCard = DBHelper.getLoyaltyCard(mDatabase, 1);
@@ -62,21 +66,30 @@ public class DatabaseTest {
         assertEquals(0, loyaltyCard.starStatus);
         assertEquals(0, loyaltyCard.archiveStatus);
 
-        result = DBHelper.deleteLoyaltyCard(mDatabase, mActivity, 1);
-        assertTrue(result);
+        try {
+            DBHelper.deleteLoyaltyCard(mDatabase, mActivity, 1);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
         assertNull(DBHelper.getLoyaltyCard(mDatabase, 1));
     }
 
     @Test
     public void updateGiftCard() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
-        result = DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, null, new BigDecimal("10.00"), Currency.getInstance("EUR"), "cardId1", null, CatimaBarcode.fromBarcode(BarcodeFormat.AZTEC), DEFAULT_HEADER_COLOR, 0, null, 0);
-        assertTrue(result);
+        try {
+            DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, null, new BigDecimal("10.00"), Currency.getInstance("EUR"), "cardId1", null, CatimaBarcode.fromBarcode(BarcodeFormat.AZTEC), DEFAULT_HEADER_COLOR, 0, null, 0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
         LoyaltyCard loyaltyCard = DBHelper.getLoyaltyCard(mDatabase, 1);
@@ -97,13 +110,19 @@ public class DatabaseTest {
 
     @Test
     public void updateGiftCardOnlyStar() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
-        result = DBHelper.updateLoyaltyCardStarStatus(mDatabase, 1, 1);
-        assertTrue(result);
+        try {
+            DBHelper.updateLoyaltyCardStarStatus(mDatabase, 1, 1);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
         LoyaltyCard loyaltyCard = DBHelper.getLoyaltyCard(mDatabase, 1);
@@ -126,17 +145,23 @@ public class DatabaseTest {
     public void updateMissingGiftCard() {
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
 
-        boolean result = DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, null, new BigDecimal("0"), null, "cardId1",
-                null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null, 0);
-        assertEquals(false, result);
+        try {
+            DBHelper.updateLoyaltyCard(mDatabase, 1, "store1", "note1", null, null, new BigDecimal("0"), null, "cardId1",
+                    null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null, 0);
+            Assert.fail(); // FIXME
+        } catch (DBHelper.DBException e) {
+        }
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
     }
 
     @Test
     public void emptyGiftCardValues() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "", "", null, null, new BigDecimal("0"), null, "", null, null, null, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "", "", null, null, new BigDecimal("0"), null, "", null, null, null, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
         LoyaltyCard loyaltyCard = DBHelper.getLoyaltyCard(mDatabase, 1);
@@ -162,10 +187,12 @@ public class DatabaseTest {
         // Add the gift cards in reverse order, to ensure
         // that they are sorted
         for (int index = CARDS_TO_ADD - 1; index >= 0; index--) {
-            long id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, null, new BigDecimal("0"), null, "cardId" + index,
+            try {
+                DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, null, new BigDecimal("0"), null, "cardId" + index,
                     null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 0, null,0);
-            boolean result = (id != -1);
-            assertTrue(result);
+            } catch (DBHelper.DBException e) {
+                Assert.fail(); // FIXME
+            }
         }
 
         assertEquals(CARDS_TO_ADD, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -208,14 +235,20 @@ public class DatabaseTest {
         // that they are sorted
         for (int index = CARDS_TO_ADD - 1; index >= 0; index--) {
             if (index == CARDS_TO_ADD - 1) {
-                id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, null, new BigDecimal("0"), null, "cardId" + index,
+                try {
+                    id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, null, new BigDecimal("0"), null, "cardId" + index,
                         null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 1, null,0);
+                } catch (DBHelper.DBException e) {
+                    Assert.fail(); // FIXME
+                }
             } else {
-                id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, null, new BigDecimal("0"), null, "cardId" + index,
+                try {
+                    id = DBHelper.insertLoyaltyCard(mDatabase, "store" + index, "note" + index, null, null, new BigDecimal("0"), null, "cardId" + index,
                         null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), index, 0, null,0);
+                } catch (DBHelper.DBException e) {
+                    Assert.fail(); // FIXME
+                }
             }
-            boolean result = (id != -1);
-            assertTrue(result);
         }
 
         assertEquals(CARDS_TO_ADD, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -292,17 +325,22 @@ public class DatabaseTest {
     @Test
     public void addRemoveOneGroup() {
         assertEquals(0, DBHelper.getGroupCount(mDatabase));
-        long id = DBHelper.insertGroup(mDatabase, "group one");
-        boolean result = (id != -1);
-        assertTrue(result);
+        try {
+            DBHelper.insertGroup(mDatabase, "group one");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getGroupCount(mDatabase));
 
         Group group = DBHelper.getGroup(mDatabase, "group one");
         assertNotNull(group);
         assertEquals("group one", group._id);
 
-        result = DBHelper.deleteGroup(mDatabase, "group one");
-        assertTrue(result);
+        try {
+            DBHelper.deleteGroup(mDatabase, "group one");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(0, DBHelper.getGroupCount(mDatabase));
         assertNull(DBHelper.getGroup(mDatabase, "group one"));
     }
@@ -311,15 +349,20 @@ public class DatabaseTest {
     public void updateGroup() {
         // Create card
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
         // Create group
-        long groupId = DBHelper.insertGroup(mDatabase, "group one");
-        result = (groupId != -1);
-        assertTrue(result);
+        try {
+            DBHelper.insertGroup(mDatabase, "group one");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getGroupCount(mDatabase));
 
         // Add card to group
@@ -335,8 +378,11 @@ public class DatabaseTest {
         assertEquals(1, DBHelper.getGroupCardCount(mDatabase, "group one"));
 
         // Rename group
-        result = DBHelper.updateGroup(mDatabase, "group one", "group one renamed");
-        assertTrue(result);
+        try {
+            DBHelper.updateGroup(mDatabase, "group one", "group one renamed");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getGroupCount(mDatabase));
 
         // Group one no longer exists
@@ -360,25 +406,32 @@ public class DatabaseTest {
     public void updateMissingGroup() {
         assertEquals(0, DBHelper.getGroupCount(mDatabase));
 
-        boolean result = DBHelper.updateGroup(mDatabase, "group one", "new name");
-        assertEquals(false, result);
+        try {
+            DBHelper.updateGroup(mDatabase, "group one", "new name");
+            Assert.fail(); // FIXME
+        } catch (DBHelper.DBException e) {
+        }
         assertEquals(0, DBHelper.getGroupCount(mDatabase));
     }
 
     @Test
     public void emptyGroupValues() {
-        long id = DBHelper.insertGroup(mDatabase, "");
-        boolean result = (id != -1);
-        assertFalse(result);
+        try {
+            DBHelper.insertGroup(mDatabase, "");
+            Assert.fail(); // FIXME
+        } catch (DBHelper.DBException e) {
+        }
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
     }
 
     @Test
     public void duplicateGroupName() {
         assertEquals(0, DBHelper.getGroupCount(mDatabase));
-        long id = DBHelper.insertGroup(mDatabase, "group one");
-        boolean result = (id != -1);
-        assertTrue(result);
+        try {
+            DBHelper.insertGroup(mDatabase, "group one");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getGroupCount(mDatabase));
 
         Group group = DBHelper.getGroup(mDatabase, "group one");
@@ -386,27 +439,36 @@ public class DatabaseTest {
         assertEquals("group one", group._id);
 
         // Should fail on duplicate
-        long id2 = DBHelper.insertGroup(mDatabase, "group one");
-        boolean result2 = (id2 != -1);
-        assertFalse(result2);
+        try {
+            DBHelper.insertGroup(mDatabase, "group one");
+            Assert.fail(); // FIXME
+        } catch (DBHelper.DBException e) {
+        }
         assertEquals(1, DBHelper.getGroupCount(mDatabase));
     }
 
     @Test
     public void updateGroupDuplicate() {
-        long id = DBHelper.insertGroup(mDatabase, "group one");
-        boolean result = (id != -1);
-        assertTrue(result);
+        try {
+            DBHelper.insertGroup(mDatabase, "group one");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getGroupCount(mDatabase));
 
-        long id2 = DBHelper.insertGroup(mDatabase, "group two");
-        boolean result2 = (id2 != -1);
-        assertTrue(result2);
+        try {
+            DBHelper.insertGroup(mDatabase, "group two");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(2, DBHelper.getGroupCount(mDatabase));
 
         // Should fail when trying to rename group two to one
-        boolean result3 = DBHelper.updateGroup(mDatabase, "group two", "group one");
-        assertFalse(result3);
+        try {
+            DBHelper.updateGroup(mDatabase, "group two", "group one");
+            Assert.fail(); // FIXME
+        } catch (DBHelper.DBException e) {
+        }
         assertEquals(2, DBHelper.getGroupCount(mDatabase));
 
         // Rename failed so both should still be the same
@@ -423,20 +485,27 @@ public class DatabaseTest {
     public void cardAddAndRemoveGroups() {
         // Create card
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
         // Create two groups to only one card
         assertEquals(0, DBHelper.getGroupCount(mDatabase));
-        long gid = DBHelper.insertGroup(mDatabase, "one");
-        boolean gresult = (gid != -1);
-        assertTrue(gresult);
+        try {
+            DBHelper.insertGroup(mDatabase, "one");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
-        long gid2 = DBHelper.insertGroup(mDatabase, "two");
-        boolean gresult2 = (gid2 != -1);
-        assertTrue(gresult2);
+        try {
+            DBHelper.insertGroup(mDatabase, "two");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         assertEquals(2, DBHelper.getGroupCount(mDatabase));
 
@@ -515,12 +584,15 @@ public class DatabaseTest {
 
     @Test
     public void updateGiftCardOnlyBalance() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 
-        result = DBHelper.updateLoyaltyCardBalance(mDatabase, 1, new BigDecimal(60));
+        boolean result = DBHelper.updateLoyaltyCardBalance(mDatabase, 1, new BigDecimal(60));
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
 

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -11,6 +11,7 @@ import android.os.Looper;
 
 import com.google.zxing.BarcodeFormat;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,9 +79,11 @@ public class ImportExportTest {
         for (int index = cardsToAdd; index > 0; index--) {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
-            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0);
-            boolean result = (id != -1);
-            assertTrue(result);
+            try {
+                DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0);
+            } catch (DBHelper.DBException e) {
+                Assert.fail(); // FIXME
+            }
         }
 
         assertEquals(cardsToAdd, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -92,26 +95,33 @@ public class ImportExportTest {
         for (int index = cardsToAdd; index > 4; index--) {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
-            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 1, null,0);
-            boolean result = (id != -1);
-            assertTrue(result);
+            try {
+                DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 1, null,0);
+            } catch (DBHelper.DBException e) {
+                Assert.fail(); // FIXME
+            }
         }
         for (int index = cardsToAdd - 5; index > 0; index--) {
             String storeName = String.format("store, \"%4d", index);
             String note = String.format("note, \"%4d", index);
             //if index is even
-            long id = DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0);
-            boolean result = (id != -1);
-            assertTrue(result);
+            try {
+                DBHelper.insertLoyaltyCard(mDatabase, storeName, note, null, null, new BigDecimal(String.valueOf(index)), null, BARCODE_DATA, null, BARCODE_TYPE, index, 0, null,0);
+            } catch (DBHelper.DBException e) {
+                Assert.fail(); // FIXME
+            }
         }
         assertEquals(cardsToAdd, DBHelper.getLoyaltyCardCount(mDatabase));
     }
 
     @Test
     public void addLoyaltyCardsWithExpiryNeverPastTodayFuture() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "No Expiry", "", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
-        boolean result = (id != -1);
-        assertTrue(result);
+        long id = -1;
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "No Expiry", "", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null, 0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, (int) id);
         assertEquals("No Expiry", card.store);
@@ -126,9 +136,11 @@ public class ImportExportTest {
         assertEquals(Integer.valueOf(0), card.headerColor);
         assertEquals(0, card.starStatus);
 
-        id = DBHelper.insertLoyaltyCard(mDatabase, "Past", "", null, new Date((long) 1), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
-        result = (id != -1);
-        assertTrue(result);
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "Past", "", null, new Date((long) 1), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null, 0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         card = DBHelper.getLoyaltyCard(mDatabase, (int) id);
         assertEquals("Past", card.store);
@@ -143,9 +155,11 @@ public class ImportExportTest {
         assertEquals(Integer.valueOf(0), card.headerColor);
         assertEquals(0, card.starStatus);
 
-        id = DBHelper.insertLoyaltyCard(mDatabase, "Today", "", null, new Date(), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
-        result = (id != -1);
-        assertTrue(result);
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "Today", "", null, new Date(), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         card = DBHelper.getLoyaltyCard(mDatabase, (int) id);
         assertEquals("Today", card.store);
@@ -163,9 +177,11 @@ public class ImportExportTest {
 
         // This will break after 19 January 2038
         // If someone is still maintaining this code base by then: I love you
-        id = DBHelper.insertLoyaltyCard(mDatabase, "Future", "", null, new Date(2147483648000L), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
-        result = (id != -1);
-        assertTrue(result);
+        try {
+            id = DBHelper.insertLoyaltyCard(mDatabase, "Future", "", null, new Date(2147483648000L), new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, 0, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         card = DBHelper.getLoyaltyCard(mDatabase, (int) id);
         assertEquals("Future", card.store);
@@ -187,9 +203,11 @@ public class ImportExportTest {
         // Add in reverse order to test sorting
         for (int index = groupsToAdd; index > 0; index--) {
             String groupName = String.format("group, \"%4d", index);
-            long id = DBHelper.insertGroup(mDatabase, groupName);
-            boolean result = (id != -1);
-            assertTrue(result);
+            try {
+                DBHelper.insertGroup(mDatabase, groupName);
+            } catch (DBHelper.DBException e) {
+                Assert.fail(); // FIXME
+            }
         }
 
         assertEquals(groupsToAdd, DBHelper.getGroupCount(mDatabase));
@@ -797,9 +815,18 @@ public class ImportExportTest {
         HashMap<Integer, Bitmap> loyaltyCardIconImages = new HashMap<>();
 
         // Create card 1
-        int loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 1", "Note 1", new Date(1601510400), new Date(1618053234), new BigDecimal("100"), Currency.getInstance("USD"), "1234", "5432", CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), 1, 0, null,0);
+        int loyaltyCardId = -1;
+        try {
+            loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 1", "Note 1", new Date(1601510400), new Date(1618053234), new BigDecimal("100"), Currency.getInstance("USD"), "1234", "5432", CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), 1, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         loyaltyCardHashMap.put(loyaltyCardId, DBHelper.getLoyaltyCard(mDatabase, loyaltyCardId));
-        DBHelper.insertGroup(mDatabase, "One");
+        try {
+            DBHelper.insertGroup(mDatabase, "One");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         List<Group> groups = Arrays.asList(DBHelper.getGroup(mDatabase, "One"));
         DBHelper.setLoyaltyCardGroups(mDatabase, loyaltyCardId, groups);
         loyaltyCardGroups.put(loyaltyCardId, groups);
@@ -811,7 +838,11 @@ public class ImportExportTest {
         loyaltyCardIconImages.put(loyaltyCardId, bitmap1);
 
         // Create card 2
-        loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 2", "", null, null, new BigDecimal(0), null, "123456", null, null, 2, 1, null,0);
+        try {
+            loyaltyCardId = (int) DBHelper.insertLoyaltyCard(mDatabase, "Card 2", "", null, null, new BigDecimal(0), null, "123456", null, null, 2, 1, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         loyaltyCardHashMap.put(loyaltyCardId, DBHelper.getLoyaltyCard(mDatabase, loyaltyCardId));
 
         // Export everything

--- a/app/src/test/java/protect/card_locker/ImportURITest.java
+++ b/app/src/test/java/protect/card_locker/ImportURITest.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 
 import com.google.zxing.BarcodeFormat;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,7 +41,11 @@ public class ImportURITest {
         // Generate card
         Date date = new Date();
 
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "This note contains evil symbols like & and = that will break the parser if not escaped right $#!%()*+;:á", date, date, new BigDecimal("100"), null, BarcodeFormat.UPC_E.toString(), BarcodeFormat.UPC_A.toString(), CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), Color.BLACK, 1, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "This note contains evil symbols like & and = that will break the parser if not escaped right $#!%()*+;:á", date, date, new BigDecimal("100"), null, BarcodeFormat.UPC_E.toString(), BarcodeFormat.UPC_A.toString(), CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), Color.BLACK, 1, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         // Get card
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
@@ -70,7 +75,11 @@ public class ImportURITest {
     @Test
     public void ensureNoCrashOnMissingHeaderFields() throws InvalidObjectException, UnsupportedEncodingException {
         // Generate card
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("EUR"), BarcodeFormat.UPC_A.toString(), null, CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), null, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("EUR"), BarcodeFormat.UPC_A.toString(), null, CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), null, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         // Get card
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import com.google.zxing.BarcodeFormat;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,7 +100,11 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapterEmptyNote() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null, 0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -114,7 +119,11 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapterWithNote() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -129,10 +138,14 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapterStarring() {
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeA", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,1));
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeB", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,1));
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeC", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0));
-        assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeD", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0));
+        try {
+            assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeA", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,1));
+            assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeB", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,1));
+            assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeC", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0));
+            assertNotEquals(-1, DBHelper.insertLoyaltyCard(mDatabase, "storeD", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0));
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         assertEquals(4, DBHelper.getLoyaltyCardCount(mDatabase));
 
@@ -180,7 +193,11 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter0Points() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -195,7 +212,11 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter0EUR() {
-        DBHelper.insertLoyaltyCard(mDatabase,"store", "", null, null, new BigDecimal("0"), Currency.getInstance("EUR"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase,"store", "", null, null, new BigDecimal("0"), Currency.getInstance("EUR"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -210,7 +231,11 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter100Points() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("100"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
@@ -225,7 +250,11 @@ public class LoyaltyCardCursorAdapterTest {
 
     @Test
     public void TestCursorAdapter10USD() {
-        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -37,6 +37,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.client.android.Intents;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -371,7 +372,11 @@ public class LoyaltyCardViewActivityTest {
             SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
             if (!newCard) {
-                DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+                try {
+                    DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+                } catch (DBHelper.DBException e) {
+                    Assert.fail(); // FIXME
+                }
             }
 
             activityController.start();
@@ -610,7 +615,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -628,7 +637,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -646,7 +659,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -670,7 +687,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -708,7 +729,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -740,7 +765,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -764,7 +793,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -814,7 +847,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -854,7 +891,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -885,7 +926,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -918,7 +963,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -954,7 +1003,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -989,7 +1042,11 @@ public class LoyaltyCardViewActivityTest {
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -1034,7 +1091,12 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -1053,7 +1115,12 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -1072,7 +1139,12 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -1090,7 +1162,12 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -1109,7 +1186,11 @@ public class LoyaltyCardViewActivityTest {
         final Context context = activity.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -1138,7 +1219,13 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
+
         activityController.start();
         activityController.visible();
         activityController.resume();
@@ -1172,7 +1259,12 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();
@@ -1266,7 +1358,12 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
         SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         activityController.start();
         activityController.visible();

--- a/app/src/test/java/protect/card_locker/MainActivityTest.java
+++ b/app/src/test/java/protect/card_locker/MainActivityTest.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import com.google.android.material.tabs.TabLayout;
 import com.google.zxing.BarcodeFormat;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -95,7 +96,12 @@ public class MainActivityTest {
         assertEquals(0, list.getAdapter().getItemCount());
 
         SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         assertEquals(View.VISIBLE, helpSection.getVisibility());
         assertEquals(View.GONE, noMatchingCardsText.getVisibility());
@@ -130,10 +136,15 @@ public class MainActivityTest {
         assertEquals(0, list.getAdapter().getItemCount());
 
         SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "storeB", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
-        DBHelper.insertLoyaltyCard(database, "storeA", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
-        DBHelper.insertLoyaltyCard(database, "storeD", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0);
-        DBHelper.insertLoyaltyCard(database, "storeC", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0);
+
+        try {
+            DBHelper.insertLoyaltyCard(database, "storeB", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+            DBHelper.insertLoyaltyCard(database, "storeA", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+            DBHelper.insertLoyaltyCard(database, "storeD", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0);
+            DBHelper.insertLoyaltyCard(database, "storeC", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 1, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
 
         assertEquals(View.VISIBLE, helpSection.getVisibility());
         assertEquals(View.GONE, noMatchingCardsText.getVisibility());
@@ -177,7 +188,11 @@ public class MainActivityTest {
         assertEquals(0, groupTabs.getTabCount());
 
         // Having at least one group should create two tabs: One all and one for each group
-        DBHelper.insertGroup(database, "One");
+        try {
+            DBHelper.insertGroup(database, "One");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         activityController.pause();
         activityController.resume();
         assertEquals(2, groupTabs.getTabCount());
@@ -185,7 +200,11 @@ public class MainActivityTest {
         assertEquals("One", groupTabs.getTabAt(1).getText().toString());
 
         // Adding another group should have it added to the end
-        DBHelper.insertGroup(database, "Alphabetical two");
+        try {
+            DBHelper.insertGroup(database, "Alphabetical two");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         activityController.pause();
         activityController.resume();
         assertEquals(3, groupTabs.getTabCount());
@@ -194,7 +213,11 @@ public class MainActivityTest {
         assertEquals("Alphabetical two", groupTabs.getTabAt(2).getText().toString());
 
         // Removing a group should also change the list
-        DBHelper.deleteGroup(database, "Alphabetical two");
+        try {
+            DBHelper.deleteGroup(database, "Alphabetical two");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         activityController.pause();
         activityController.resume();
         assertEquals(2, groupTabs.getTabCount());
@@ -202,7 +225,11 @@ public class MainActivityTest {
         assertEquals("One", groupTabs.getTabAt(1).getText().toString());
 
         // Removing the last group should make the tabs disappear
-        DBHelper.deleteGroup(database, "One");
+        try {
+            DBHelper.deleteGroup(database, "One");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         activityController.pause();
         activityController.resume();
         assertEquals(0, groupTabs.getTabCount());
@@ -224,10 +251,19 @@ public class MainActivityTest {
         TabLayout groupTabs = mainActivity.findViewById(R.id.groups);
 
         SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "The First Store", "Initial note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
-        DBHelper.insertLoyaltyCard(database, "The Second Store", "Secondary note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
 
-        DBHelper.insertGroup(database, "Group one");
+        try {
+            DBHelper.insertLoyaltyCard(database, "The First Store", "Initial note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+            DBHelper.insertLoyaltyCard(database, "The Second Store", "Secondary note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), Color.BLACK, 0, null,0);
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
+
+        try {
+            DBHelper.insertGroup(database, "Group one");
+        } catch (DBHelper.DBException e) {
+            Assert.fail(); // FIXME
+        }
         List<Group> groups = new ArrayList<>();
         groups.add(DBHelper.getGroup(database, "Group one"));
         DBHelper.setLoyaltyCardGroups(database, 1, groups);


### PR DESCRIPTION
- [x] drop data before importing
- [x] make sure all (database) errors are handled properly
  - [x] add `DBException` class
  - [x] throw `DBException` in DB functions
  - [x] catch `DBException` instead of mostly ignoring return values
- [x] make sure unit tests pass
- [ ] superficial testing
  - [x] add/edit card/group works normally
  - [ ] import/export
- [ ] warn user about data being dropped
- [ ] FIXMEs
  - [ ] remove toasts considered unnecessary (some should never happen)
  - [ ] make sure toasts are called with the right context parameter
  - [ ] translate untranslated strings
  - [ ] improve error messages
  - [ ] confirm control flow is still correct
  - [ ] `Assert.fail()`: add error messages?
- [ ] review
- [ ] more testing

#1333 should be rebased on this.

---

### Nice to have

- [x]  python script to merge two exports? https://github.com/obfusk/catimerge