### PR TITLE
add top content padding to dialogs

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -498,6 +498,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                     FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
                     int contentPadding = getResources().getDimensionPixelSize(R.dimen.alert_dialog_content_padding);
                     params.leftMargin = contentPadding;
+                    params.topMargin = contentPadding / 2;
                     params.rightMargin = contentPadding;
 
                     input.setLayoutParams(params);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -346,7 +346,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         TextView infoTextview = new TextView(this);
         infoTextview.setPadding(
                 dialogContentPadding,
-                0,
+                dialogContentPadding / 2,
                 dialogContentPadding,
                 0
         );
@@ -409,6 +409,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         );
         int contentPadding = getResources().getDimensionPixelSize(R.dimen.alert_dialog_content_padding);
         params.leftMargin = contentPadding;
+        params.topMargin = contentPadding / 2;
         params.rightMargin = contentPadding;
 
         LinearLayout layout = new LinearLayout(this);
@@ -601,7 +602,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             cardIdView.setText(loyaltyCard.cardId);
             cardIdView.setTextIsSelectable(true);
             int contentPadding = getResources().getDimensionPixelSize(R.dimen.alert_dialog_content_padding);
-            cardIdView.setPadding(contentPadding, 0, contentPadding, 0);
+            cardIdView.setPadding(contentPadding, contentPadding / 2, contentPadding, 0);
 
             AlertDialog.Builder builder = new MaterialAlertDialogBuilder(LoyaltyCardViewActivity.this);
             builder.setTitle(R.string.cardId);

--- a/app/src/main/java/protect/card_locker/ManageGroupsActivity.java
+++ b/app/src/main/java/protect/card_locker/ManageGroupsActivity.java
@@ -152,6 +152,7 @@ public class ManageGroupsActivity extends CatimaAppCompatActivity implements Gro
         );
         int contentPadding = getResources().getDimensionPixelSize(R.dimen.alert_dialog_content_padding);
         params.leftMargin = contentPadding;
+        params.topMargin = contentPadding / 2;
         params.rightMargin = contentPadding;
         input.setLayoutParams(params);
         container.addView(input);


### PR DESCRIPTION
Following up on https://github.com/CatimaLoyalty/Android/pull/1331#issuecomment-1574118467, this adds top padding to all dialogs. IMO it looks a bit nicer. And it's consistent :)

I didn't want to hardcode a value, but I thought the padding used for left and right was more than the top needed so I divided it by half.

<details>
<summary>screenshots</summary>

![Screenshot_20230603_230835](https://github.com/CatimaLoyalty/Android/assets/1260687/efc23fa7-b43d-4698-91cf-bbdf3dee1034)
![Screenshot_20230603_230901](https://github.com/CatimaLoyalty/Android/assets/1260687/586891a3-08c9-492c-923d-e14931ff441b)

</details>