### PR TITLE
CI: use OpenJDK 17 from Ubuntu

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+env:
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+
 jobs:
   build:
 
@@ -20,11 +23,11 @@ jobs:
     - name: Fail on bad translations
       run: if grep -ri "&lt;xliff" app/src/main/res/values*/strings.xml; then echo "Invalidly escaped translations found"; exit 1; fi
     - uses: gradle/wrapper-validation-action@v1
-    - name: set up JDK 17
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+    - name: set up OpenJDK 17
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y openjdk-17-jdk-headless
+        sudo update-alternatives --auto java
     - name: Build
       run: ./gradlew assembleRelease
     - name: Check lint


### PR DESCRIPTION
Makes #1350 less frequent. Before, I got the stuck test about 1/7 runs. With this change I needed >20 runs to reproduce.