### PR TITLE
Make header colour code more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased - 125
+
+- Deal more gracefully with missing header colours
+
 ## v2.24.0 - 124 (2023-06-10)
 
 - Support selecting exactly which details to view in card overview

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -213,7 +213,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
 
         inputHolder.mCardIcon.setContentDescription(loyaltyCard.store);
         Utils.setIconOrTextWithBackground(mContext, loyaltyCard, icon, inputHolder.mCardIcon, inputHolder.mCardText);
-        inputHolder.setIconBackgroundColor(loyaltyCard.headerColor != null ? loyaltyCard.headerColor : androidx.appcompat.R.attr.colorPrimary);
+        inputHolder.setIconBackgroundColor(Utils.getHeaderColor(mContext, loyaltyCard));
 
         inputHolder.toggleCardStateIcon(loyaltyCard.starStatus != 0, loyaltyCard.archiveStatus != 0, itemSelected(inputCursor.getPosition()));
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -853,10 +853,9 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
             }
         }
 
-        // Generate random header color
         if (tempLoyaltyCard.headerColor == null) {
-            // Select a random color to start out with.
-            updateTempState(LoyaltyCardField.headerColor, Utils.getRandomHeaderColor(this));
+            // If name is set, pick colour relevant for name. Otherwise pick randomly
+            updateTempState(LoyaltyCardField.headerColor, tempLoyaltyCard.store.isEmpty() ? Utils.getRandomHeaderColor(this) : Utils.getHeaderColor(this, tempLoyaltyCard));
         }
 
         // Update from intent
@@ -928,7 +927,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
     protected void setColorFromIcon() {
         Object icon = thumbnail.getTag();
         if (icon != null && (icon instanceof Bitmap)) {
-            int headerColor = Utils.getHeaderColorFromImage((Bitmap) icon, tempLoyaltyCard.headerColor != null ? tempLoyaltyCard.headerColor : androidx.appcompat.R.attr.colorPrimary);
+            int headerColor = Utils.getHeaderColorFromImage((Bitmap) icon, Utils.getHeaderColor(this, tempLoyaltyCard));
 
             updateTempState(LoyaltyCardField.headerColor, headerColor);
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -613,12 +613,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             dialog.show();
         });
 
-        int backgroundHeaderColor;
-        if (loyaltyCard.headerColor != null) {
-            backgroundHeaderColor = loyaltyCard.headerColor;
-        } else {
-            backgroundHeaderColor = LetterBitmap.getDefaultColor(this, loyaltyCard.store);
-        }
+        int backgroundHeaderColor = Utils.getHeaderColor(this, loyaltyCard);
 
         // Also apply colours to UI elements
         int darkenedColor = ColorUtils.blendARGB(backgroundHeaderColor, Color.BLACK, 0.1f);

--- a/app/src/main/java/protect/card_locker/ShortcutHelper.java
+++ b/app/src/main/java/protect/card_locker/ShortcutHelper.java
@@ -145,7 +145,7 @@ class ShortcutHelper {
         if (iconBitmap == null) {
             iconBitmap = Utils.generateIcon(context, loyaltyCard, true).getLetterTile();
         } else {
-            iconBitmap = createAdaptiveBitmap(iconBitmap, loyaltyCard.headerColor == null ? PADDING_COLOR : loyaltyCard.headerColor);
+            iconBitmap = createAdaptiveBitmap(iconBitmap, Utils.getHeaderColor(context, loyaltyCard));
         }
 
         IconCompat icon = IconCompat.createWithAdaptiveBitmap(iconBitmap);

--- a/app/src/main/java/protect/card_locker/ShortcutHelper.java
+++ b/app/src/main/java/protect/card_locker/ShortcutHelper.java
@@ -33,7 +33,6 @@ class ShortcutHelper {
     private static final int ADAPTIVE_BITMAP_SIZE = 108 * ADAPTIVE_BITMAP_SCALE;
     private static final int ADAPTIVE_BITMAP_VISIBLE_SIZE = 72 * ADAPTIVE_BITMAP_SCALE;
     private static final int ADAPTIVE_BITMAP_IMAGE_SIZE = ADAPTIVE_BITMAP_VISIBLE_SIZE + 5 * ADAPTIVE_BITMAP_SCALE;
-    private static final int PADDING_COLOR = Color.argb(255, 255, 255, 255);
     private static final int PADDING_COLOR_OVERLAY = Color.argb(127, 0, 0, 0);
 
     /**

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -603,7 +603,7 @@ public class Utils {
         } else {
             textWhenNoImage.setVisibility(View.VISIBLE);
 
-            int headerColor = loyaltyCard.headerColor != null ? loyaltyCard.headerColor : LetterBitmap.getDefaultColor(context, loyaltyCard.store);
+            int headerColor = getHeaderColor(context, loyaltyCard);
 
             backgroundOrIcon.setImageBitmap(null);
             backgroundOrIcon.setBackgroundColor(headerColor);
@@ -625,5 +625,9 @@ public class Utils {
         } catch (Throwable ignored) {
             return false;
         }
+    }
+
+    public static int getHeaderColor(Context context, LoyaltyCard loyaltyCard) {
+        return loyaltyCard.headerColor != null ? loyaltyCard.headerColor : LetterBitmap.getDefaultColor(context, loyaltyCard.store);
     }
 }


### PR DESCRIPTION
Fixes #1361

- Ensure a header colour is picked for the main screen
- Simplify all different header colour code pickers into a single code path