### PR TITLE
about_activity: make _sub layout consistent (fixes RTL)

### DIFF
--- a/app/src/main/res/layout/about_activity.xml
+++ b/app/src/main/res/layout/about_activity.xml
@@ -128,11 +128,10 @@
 
                 <TextView
                     android:id="@+id/translate_sub"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:padding="2dp"
                     android:text="@string/translate_platform"
-                    android:layout_marginEnd="20dp"
                     android:textSize="16sp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/translate_main"/>
@@ -169,11 +168,10 @@
 
                 <TextView
                     android:id="@+id/license_sub"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:padding="2dp"
                     android:text="@string/app_license"
-                    android:layout_marginEnd="20dp"
                     android:textSize="16sp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/license_main"/>


### PR DESCRIPTION
Fixes #1362.

<details>
<summary>screenshots</summary>

![Screenshot_20230610_164201](https://github.com/CatimaLoyalty/Android/assets/1260687/4a4ed38e-25fc-456c-8311-be62cf3c0dc9)
![Screenshot_20230610_164530](https://github.com/CatimaLoyalty/Android/assets/1260687/64764e7f-7e97-4f68-95a9-232dce6b8b8a)

</details>