### PR TITLE
LoyaltyCardViewActivity: RTL fixes for buttons

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -984,22 +984,33 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             return;
         }
 
+        final ImageButton prevButton;
+        final ImageButton nextButton;
+
+        if (getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL) {
+            prevButton = binding.mainRightButton;
+            nextButton = binding.mainLeftButton;
+        } else {
+            prevButton = binding.mainLeftButton;
+            nextButton = binding.mainRightButton;
+        }
+
         // Enable left button if we can go further left
         if (mainImageIndex > 0) {
-            binding.mainLeftButton.setVisibility(View.VISIBLE);
-            binding.mainLeftButton.setOnClickListener(view -> setMainImage(false, false));
+            prevButton.setVisibility(View.VISIBLE);
+            prevButton.setOnClickListener(view -> setMainImage(false, false));
         } else {
-            binding.mainLeftButton.setVisibility(View.INVISIBLE);
-            binding.mainLeftButton.setOnClickListener(null);
+            prevButton.setVisibility(View.INVISIBLE);
+            prevButton.setOnClickListener(null);
         }
 
         // Enable right button if we can go further right
         if (mainImageIndex < (imageTypes.size() - 1)) {
-            binding.mainRightButton.setVisibility(View.VISIBLE);
-            binding.mainRightButton.setOnClickListener(view -> setMainImage(true, false));
+            nextButton.setVisibility(View.VISIBLE);
+            nextButton.setOnClickListener(view -> setMainImage(true, false));
         } else {
-            binding.mainRightButton.setVisibility(View.INVISIBLE);
-            binding.mainRightButton.setOnClickListener(null);
+            nextButton.setVisibility(View.INVISIBLE);
+            nextButton.setOnClickListener(null);
         }
     }
 

--- a/app/src/main/res/layout/loyalty_card_view_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_view_layout.xml
@@ -207,7 +207,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:layoutDirection="ltr"
         android:background="?attr/colorPrimary"
         app:contentInsetLeft="0dp"
         app:contentInsetStart="0dp"
@@ -215,53 +214,70 @@
         app:contentInsetEnd="0dp"
         app:fabAlignmentMode="center">
 
-        <ImageButton
-            android:id="@+id/bottom_app_bar_previous_button"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_gravity="left"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_baseline_chevron_left_24"
-            android:tooltipText="@string/previousCard"
-            android:visibility="gone" />
+            android:layoutDirection="ltr">
 
-        <ImageButton
-            android:id="@+id/bottom_app_bar_info_button"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_gravity="left"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_baseline_info_24"
-            android:tooltipText="@string/showMoreInfo"
-            android:visibility="gone" />
+            <ImageButton
+                android:id="@+id/bottom_app_bar_previous_button"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_baseline_chevron_left_24"
+                android:tooltipText="@string/previousCard"
+                android:visibility="gone" />
 
-        <ImageButton
-            android:id="@+id/bottom_app_bar_next_button"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_gravity="right"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_baseline_chevron_right_24"
-            android:tooltipText="@string/nextCard"
-            android:visibility="gone" />
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="horizontal"
+                android:layoutDirection="locale">
 
-        <ImageButton
-            android:id="@+id/bottom_app_bar_update_balance_button"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_gravity="right"
-            android:background="@android:color/transparent"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:src="@drawable/ic_baseline_shopping_cart_24"
-            android:tooltipText="@string/updateBalance"
-            android:visibility="gone" />
+                <ImageButton
+                    android:id="@+id/bottom_app_bar_info_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:paddingStart="12dp"
+                    android:paddingEnd="12dp"
+                    android:background="@android:color/transparent"
+                    android:src="@drawable/ic_baseline_info_24"
+                    android:tooltipText="@string/showMoreInfo"
+                    android:visibility="gone" />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1" />
+
+                <ImageButton
+                    android:id="@+id/bottom_app_bar_update_balance_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:paddingStart="12dp"
+                    android:paddingEnd="12dp"
+                    android:background="@android:color/transparent"
+                    android:src="@drawable/ic_baseline_shopping_cart_24"
+                    android:tooltipText="@string/updateBalance"
+                    android:visibility="gone" />
+
+            </LinearLayout>
+
+            <ImageButton
+                android:id="@+id/bottom_app_bar_next_button"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_baseline_chevron_right_24"
+                android:tooltipText="@string/nextCard"
+                android:visibility="gone" />
+
+        </LinearLayout>
 
     </com.google.android.material.bottomappbar.BottomAppBar>
 

--- a/app/src/main/res/layout/loyalty_card_view_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_view_layout.xml
@@ -83,7 +83,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginStart="0dp"
-            android:layout_marginEnd="0dp">
+            android:layout_marginEnd="0dp"
+            android:layoutDirection="ltr">
 
             <!-- We don't use these buttons for Talkback -->
             <ImageButton
@@ -206,6 +207,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
+        android:layoutDirection="ltr"
         android:background="?attr/colorPrimary"
         app:contentInsetLeft="0dp"
         app:contentInsetStart="0dp"
@@ -229,7 +231,7 @@
             android:id="@+id/bottom_app_bar_info_button"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_gravity="start"
+            android:layout_gravity="left"
             android:paddingStart="12dp"
             android:paddingEnd="12dp"
             android:background="@android:color/transparent"
@@ -253,7 +255,7 @@
             android:id="@+id/bottom_app_bar_update_balance_button"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_gravity="end"
+            android:layout_gravity="right"
             android:background="@android:color/transparent"
             android:paddingStart="12dp"
             android:paddingEnd="12dp"


### PR DESCRIPTION
Fixes two more RTL bugs.
I can't figure out how to fix it so the cart and info buttons are swapped in RTL, at least not using XML only.
IMO not swapping them is fine, especially with the arrow buttons fixed now at least.

<details>
<summary>before (rtl)</summary>

![Screenshot_20230611_231159](https://github.com/CatimaLoyalty/Android/assets/1260687/472179f7-c2fd-4758-a96c-7782617bf538)

</details>

<details>
<summary>after (ltr + rtl)</summary>

![Screenshot_20230611_230052](https://github.com/CatimaLoyalty/Android/assets/1260687/feb7aaf2-a941-4540-ba20-881d8bf87623)
![Screenshot_20230611_230130](https://github.com/CatimaLoyalty/Android/assets/1260687/4b76f25c-173d-4e24-9a92-a3191cde64f8)

</details>