### PR TITLE
CatimaBarcode: DATA_MATRIX is not always square

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
+++ b/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
@@ -103,11 +103,14 @@ public class BarcodeImageWriterTask implements CompatCallable<Bitmap> {
         switch (format.format()) {
             // 2D barcodes
             case AZTEC:
-            case DATA_MATRIX:
             case MAXICODE:
             case PDF_417:
             case QR_CODE:
                 return MAX_WIDTH_2D;
+
+            // 2D but rectangular versions get blurry otherwise
+            case DATA_MATRIX:
+                return MAX_WIDTH_1D;
 
             // 1D barcodes:
             case CODABAR:

--- a/app/src/main/java/protect/card_locker/CatimaBarcode.java
+++ b/app/src/main/java/protect/card_locker/CatimaBarcode.java
@@ -67,7 +67,6 @@ public class CatimaBarcode {
 
     public boolean isSquare() {
         return mBarcodeFormat == BarcodeFormat.AZTEC
-                || mBarcodeFormat == BarcodeFormat.DATA_MATRIX
                 || mBarcodeFormat == BarcodeFormat.MAXICODE
                 || mBarcodeFormat == BarcodeFormat.QR_CODE;
     }


### PR DESCRIPTION
Following up on https://github.com/CatimaLoyalty/Android/pull/1359#issuecomment-1603359582: `DATA_MATRIX` can be rectangular as well.

I also removed `MAXICODE` since it's not supported.

I tested the changes on my phone. It looks slightly better than before #1359 now IMO. Square versions looked okay too.

<details>
<summary>screenshot: before</summary>

![Screenshot_20230623-002629_Catima](https://github.com/CatimaLoyalty/Android/assets/1260687/bdbd76d9-b584-42c5-b8ab-d2cc9c13eb6b)

</details>

<details>
<summary>screenshot: after #1359</summary>

![Screenshot_20230622-234524_Catima Debug](https://github.com/CatimaLoyalty/Android/assets/1260687/55032c55-c15d-4916-b64c-2c2ac0b426c6)

</details>

<details>
<summary>screenshot: with this fix</summary>

![Screenshot_20230623-002636_Catima Debug](https://github.com/CatimaLoyalty/Android/assets/1260687/a8aa3510-32af-4cc6-bc16-1d862a60cb8c)

</details>

<details>
<summary>screenshot: with second commit too [Edit]</summary>

![Screenshot_20230623-012701_Catima Debug](https://github.com/CatimaLoyalty/Android/assets/1260687/aea5e9f3-1d33-49af-a20a-843ee7789bd9)

</details>