### PR TITLE
CI: on retry, stop gradle daemon and timeout

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Check lint
       run: ./gradlew lintRelease
     - name: Run unit tests
-      run: timeout 5m ./gradlew testReleaseUnitTest || ./gradlew testReleaseUnitTest
+      run: timeout 5m ./gradlew testReleaseUnitTest || { ./gradlew --stop && timeout 5m ./gradlew testReleaseUnitTest; }
     - name: SpotBugs
       run: ./gradlew spotbugsRelease
     - name: Archive test results


### PR DESCRIPTION
Another attempt to handle the stuck unit test better.