### PR TITLE
merge imports

### DIFF
--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -364,6 +364,14 @@ public class DBHelper extends SQLiteOpenHelper {
                 whereAttrs(LoyaltyCardDbFTS.ID), withArgs(id));
     }
 
+    public static int getMaxLoyaltyCardId(final SQLiteDatabase database) {
+        Cursor data = database.rawQuery("SELECT IFNULL(MAX(" + LoyaltyCardDbIds.ID + "), 0) FROM " + LoyaltyCardDbIds.TABLE, null, null);
+        data.moveToFirst();
+        int maxId = data.getInt(0);
+        data.close();
+        return maxId;
+    }
+
     public static long insertLoyaltyCard(
             final SQLiteDatabase database, final String store, final String note, final Date validFrom,
             final Date expiry, final BigDecimal balance, final Currency balanceType, final String cardId,

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -58,6 +58,8 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import protect.card_locker.preferences.Settings;
 
@@ -378,6 +380,23 @@ public class Utils {
         cardImageFileNameBuilder.append(".png");
 
         return cardImageFileNameBuilder.toString();
+    }
+
+    static public String getRenamedCardImageFileName(final String fileName, final long idOffset) {
+        Pattern pattern = Pattern.compile("^(card_)(\\d+)(_(?:front|back|icon)\\.png)$");
+        Matcher matcher = pattern.matcher(fileName);
+        if (matcher.matches()) {
+            StringBuilder cardImageFileNameBuilder = new StringBuilder();
+            cardImageFileNameBuilder.append(matcher.group(1));
+            try {
+                cardImageFileNameBuilder.append(Integer.parseInt(matcher.group(2)) + idOffset);
+            } catch (NumberFormatException _e) {
+                return null;
+            }
+            cardImageFileNameBuilder.append(matcher.group(3));
+            return cardImageFileNameBuilder.toString();
+        }
+        return null;
     }
 
     static public void saveCardImage(Context context, Bitmap bitmap, String fileName) throws FileNotFoundException {

--- a/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Currency;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import protect.card_locker.CatimaBarcode;
 import protect.card_locker.DBHelper;
@@ -39,7 +40,7 @@ import protect.card_locker.ZipUtils;
  * A header is expected for the each table showing the names of the columns.
  */
 public class CatimaImporter implements Importer {
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, InterruptedException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password, Set<String> newImageFiles, int maxLoyaltyCardId) throws IOException, FormatException, InterruptedException {
         InputStream bufferedInputStream = new BufferedInputStream(input);
         bufferedInputStream.mark(100);
 
@@ -57,6 +58,7 @@ public class CatimaImporter implements Importer {
                 importCSV(context, database, zipInputStream);
             } else if (fileName.endsWith(".png")) {
                 Utils.saveCardImage(context, ZipUtils.readImage(zipInputStream), fileName);
+                newImageFiles.add(fileName);
             } else {
                 throw new FormatException("Unexpected file in import: " + fileName);
             }

--- a/app/src/main/java/protect/card_locker/importexport/FidmeImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/FidmeImporter.java
@@ -17,6 +17,7 @@ import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
+import java.util.Set;
 
 import protect.card_locker.CatimaBarcode;
 import protect.card_locker.DBHelper;
@@ -31,7 +32,7 @@ import protect.card_locker.Utils;
  * A header is expected for the each table showing the names of the columns.
  */
 public class FidmeImporter implements Importer {
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password, Set<String> newImageFiles, int maxLoyaltyCardId) throws IOException, FormatException, JSONException, ParseException {
         // We actually retrieve a .zip file
         ZipInputStream zipInputStream = new ZipInputStream(input, password);
 

--- a/app/src/main/java/protect/card_locker/importexport/Importer.java
+++ b/app/src/main/java/protect/card_locker/importexport/Importer.java
@@ -8,6 +8,7 @@ import org.json.JSONException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
+import java.util.Set;
 
 import protect.card_locker.FormatException;
 
@@ -23,5 +24,5 @@ public interface Importer {
      * @throws IOException
      * @throws FormatException
      */
-    void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, InterruptedException, JSONException, ParseException;
+    void importData(Context context, SQLiteDatabase database, InputStream input, char[] password, Set<String> newImageFiles, int maxLoyaltyCardId) throws IOException, FormatException, InterruptedException, JSONException, ParseException;
 }

--- a/app/src/main/java/protect/card_locker/importexport/MultiFormatImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/MultiFormatImporter.java
@@ -75,6 +75,10 @@ public class MultiFormatImporter {
             Log.e(TAG, error);
         }
 
+        for (String fileName : newImageFiles) {
+            context.deleteFile(fileName);
+        }
+
         return new ImportExportResult(ImportExportResultType.GenericFailure, error);
     }
 }

--- a/app/src/main/java/protect/card_locker/importexport/MultiFormatImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/MultiFormatImporter.java
@@ -7,6 +7,10 @@ import android.util.Log;
 import net.lingala.zip4j.exception.ZipException;
 
 import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import protect.card_locker.DBHelper;
 
 public class MultiFormatImporter {
     private static final String TAG = "Catima";
@@ -41,11 +45,17 @@ public class MultiFormatImporter {
         }
 
         String error = null;
+        Set<String> newImageFiles = new HashSet<>();
         if (importer != null) {
             database.beginTransaction();
             try {
-                importer.importData(context, database, input, password);
+                int maxLoyaltyCardId = DBHelper.getMaxLoyaltyCardId(database);
+                Log.d(TAG, "Current max loyalty card id: " + maxLoyaltyCardId);
+                importer.importData(context, database, input, password, newImageFiles, maxLoyaltyCardId);
                 database.setTransactionSuccessful();
+                for (String fileName : newImageFiles) {
+                    Log.d(TAG, "New image file: " + fileName);
+                }
                 return new ImportExportResult(ImportExportResultType.Success);
             } catch (ZipException e) {
                 if (e.getType().equals(ZipException.Type.WRONG_PASSWORD)) {

--- a/app/src/main/java/protect/card_locker/importexport/StocardImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/StocardImporter.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.HashMap;
+import java.util.Set;
 
 import protect.card_locker.CatimaBarcode;
 import protect.card_locker.DBHelper;
@@ -42,7 +43,7 @@ import protect.card_locker.ZipUtils;
 public class StocardImporter implements Importer {
     private static final String TAG = "Catima";
 
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password, Set<String> newImageFiles, int maxLoyaltyCardId) throws IOException, FormatException, JSONException, ParseException {
         HashMap<String, HashMap<String, Object>> loyaltyCardHashMap = new HashMap<>();
         HashMap<String, HashMap<String, Object>> providers = new HashMap<>();
 
@@ -233,14 +234,20 @@ public class StocardImporter implements Importer {
             long loyaltyCardInternalId = DBHelper.insertLoyaltyCard(database, store, note, null, null, BigDecimal.valueOf(0), null, cardId, null, barcodeType, headerColor, 0, null,0);
 
             if (cardIcon != null) {
-                Utils.saveCardImage(context, cardIcon, (int) loyaltyCardInternalId, ImageLocationType.icon);
+                String fileName = Utils.getCardImageFileName((int) loyaltyCardInternalId, ImageLocationType.icon);
+                Utils.saveCardImage(context, cardIcon, fileName);
+                newImageFiles.add(fileName);
             }
 
             if (loyaltyCardData.containsKey("frontImage")) {
-                Utils.saveCardImage(context, (Bitmap) loyaltyCardData.get("frontImage"), (int) loyaltyCardInternalId, ImageLocationType.front);
+                String fileName = Utils.getCardImageFileName((int) loyaltyCardInternalId, ImageLocationType.front);
+                Utils.saveCardImage(context, (Bitmap) loyaltyCardData.get("frontImage"), fileName);
+                newImageFiles.add(fileName);
             }
             if (loyaltyCardData.containsKey("backImage")) {
-                Utils.saveCardImage(context, (Bitmap) loyaltyCardData.get("backImage"), (int) loyaltyCardInternalId, ImageLocationType.back);
+                String fileName = Utils.getCardImageFileName((int) loyaltyCardInternalId, ImageLocationType.back);
+                Utils.saveCardImage(context, (Bitmap) loyaltyCardData.get("backImage"), fileName);
+                newImageFiles.add(fileName);
             }
         }
 

--- a/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/VoucherVaultImporter.java
@@ -21,6 +21,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Currency;
 import java.util.Date;
+import java.util.Set;
 import java.util.TimeZone;
 
 import protect.card_locker.CatimaBarcode;
@@ -36,7 +37,7 @@ import protect.card_locker.Utils;
  * A header is expected for the each table showing the names of the columns.
  */
 public class VoucherVaultImporter implements Importer {
-    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password) throws IOException, FormatException, JSONException, ParseException {
+    public void importData(Context context, SQLiteDatabase database, InputStream input, char[] password, Set<String> newImageFiles, int maxLoyaltyCardId) throws IOException, FormatException, JSONException, ParseException {
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
 
         StringBuilder sb = new StringBuilder();

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -201,7 +201,12 @@ public class ImportExportTest {
      * where the smallest card's index is 1
      */
     private void checkLoyaltyCards() {
+        checkLoyaltyCards(false);
+    }
+
+    private void checkLoyaltyCards(boolean dups) {
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
+        boolean first = true;
         int index = 1;
 
         while (cursor.moveToNext()) {
@@ -222,7 +227,16 @@ public class ImportExportTest {
             assertEquals(Integer.valueOf(index), card.headerColor);
             assertEquals(0, card.starStatus);
 
-            index++;
+            if (dups) {
+                if (first) {
+                    first = false;
+                } else {
+                    first = true;
+                    index++;
+                }
+            } else {
+                index++;
+            }
         }
         cursor.close();
     }
@@ -500,9 +514,9 @@ public class ImportExportTest {
         result = MultiFormatImporter.importData(activity.getApplicationContext(), mDatabase, inData, DataFormat.Catima, null);
         assertEquals(ImportExportResultType.Success, result.resultType());
 
-        assertEquals(NUM_CARDS, DBHelper.getLoyaltyCardCount(mDatabase));
+        assertEquals(NUM_CARDS * 2, DBHelper.getLoyaltyCardCount(mDatabase));
 
-        checkLoyaltyCards();
+        checkLoyaltyCards(true);
 
         // Clear the database for the next format under test
         TestHelpers.getEmptyDb(activity);
@@ -764,7 +778,7 @@ public class ImportExportTest {
         // Import the CSV data
         result = MultiFormatImporter.importData(activity.getApplicationContext(), mDatabase, inputStream, DataFormat.Catima, null);
         assertEquals(ImportExportResultType.Success, result.resultType());
-        assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
+        assertEquals(2, DBHelper.getLoyaltyCardCount(mDatabase));
 
         LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
 


### PR DESCRIPTION
Replaces #1389.

This renumbers IDs -- both from the CSV and in the image file names -- that are present in the imported data, to make sure they do not conflict with the existing data.

It also removes the newly added image files if the import fails, which is now safe since there are no conflicts with existing IDs.

Only the Catima importer has to deal with IDs being present in the imported data; all other importers create new IDs, so they are not affected.

I'm not really handling duplicate group names, but errors from `DBHelper.insertGroup()` are ignored and I think it makes sense to just effectively merge groups with identical names anyway; we do need to deal with that when we have proper group IDs.