### PR TITLE
Reorganize settings screen

### DIFF
--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Locale;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.DialogFragment;
@@ -99,23 +100,8 @@ public class SettingsActivity extends CatimaAppCompatActivity {
             // Load the preferences from an XML resource
             addPreferencesFromResource(R.xml.preferences);
 
-            // Show pretty names
-            ListPreference localePreference = findPreference(getResources().getString(R.string.settings_key_locale));
-            assert localePreference != null;
-            CharSequence[] entryValues = localePreference.getEntryValues();
-            List<CharSequence> entries = new ArrayList<>();
-            for (CharSequence entry : entryValues) {
-                if (entry.length() == 0) {
-                    entries.add(getResources().getString(R.string.settings_system_locale));
-                } else {
-                    Locale entryLocale = Utils.stringToLocale(entry.toString());
-                    entries.add(entryLocale.getDisplayName(entryLocale));
-                }
-            }
-
-            localePreference.setEntries(entries.toArray(new CharSequence[entryValues.length]));
-
-            Preference themePreference = findPreference(getResources().getString(R.string.settings_key_theme));
+            // Show pretty names and summaries
+            ListPreference themePreference = findPreference(getResources().getString(R.string.settings_key_theme));
             assert themePreference != null;
             themePreference.setOnPreferenceChangeListener((preference, o) -> {
                 if (o.toString().equals(getResources().getString(R.string.settings_key_light_theme))) {
@@ -129,10 +115,16 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                 return true;
             });
 
-            localePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            ListPreference themeColorPreference = findPreference(getResources().getString(R.string.setting_key_theme_color));
+            assert themeColorPreference != null;
+            themeColorPreference.setOnPreferenceChangeListener((preference, o) -> {
                 refreshActivity(true);
                 return true;
             });
+            if (!DynamicColors.isDynamicColorAvailable()) {
+                themeColorPreference.setEntryValues(R.array.color_values_no_dynamic);
+                themeColorPreference.setEntries(R.array.color_value_strings_no_dynamic);
+            }
 
             Preference oledDarkPreference = findPreference(getResources().getString(R.string.settings_key_oled_dark));
             assert oledDarkPreference != null;
@@ -141,16 +133,23 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                 return true;
             });
 
-            ListPreference colorPreference = findPreference(getResources().getString(R.string.setting_key_theme_color));
-            assert colorPreference != null;
-            colorPreference.setOnPreferenceChangeListener((preference, o) -> {
+            ListPreference localePreference = findPreference(getResources().getString(R.string.settings_key_locale));
+            assert localePreference != null;
+            CharSequence[] entryValues = localePreference.getEntryValues();
+            List<CharSequence> entries = new ArrayList<>();
+            for (CharSequence entry : entryValues) {
+                if (entry.length() == 0) {
+                    entries.add(getResources().getString(R.string.settings_system_locale));
+                } else {
+                    Locale entryLocale = Utils.stringToLocale(entry.toString());
+                    entries.add(entryLocale.getDisplayName(entryLocale));
+                }
+            }
+            localePreference.setEntries(entries.toArray(new CharSequence[entryValues.length]));
+            localePreference.setOnPreferenceChangeListener((preference, newValue) -> {
                 refreshActivity(true);
                 return true;
             });
-            if (!DynamicColors.isDynamicColorAvailable()) {
-                colorPreference.setEntryValues(R.array.color_values_no_dynamic);
-                colorPreference.setEntries(R.array.color_value_strings_no_dynamic);
-            }
 
             // Disable content provider on SDK < 23 since dangerous permissions
             // are granted at install-time

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -55,7 +55,6 @@
     <string name="thumbnailDescription">صورة مصغرة</string>
     <string name="starImage">نجم مفضل</string>
     <string name="settings">اعدادات</string>
-    <string name="settings_category_title_ui">واجهة المستخدم</string>
     <string name="settings_light_theme">فاتح</string>
     <string name="settings_dark_theme">داكن</string>
     <string name="settings_card_orientation">اتجاه الباركود</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -90,7 +90,6 @@
     <string name="settings_light_theme">Светла</string>
     <string name="settings_system_theme">Системна</string>
     <string name="settings_theme">Тема</string>
-    <string name="settings_category_title_ui">Потребителски интерфейс</string>
     <string name="settings">Настройки</string>
     <string name="starImage">Звезда за любимо</string>
     <string name="thumbnailDescription">Миниатюра</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -24,7 +24,6 @@
     <string name="settings_light_theme">সাদাটে থিম</string>
     <string name="settings_system_theme">যন্ত্রর থিম</string>
     <string name="settings_theme">থিম</string>
-    <string name="settings_category_title_ui">বিভাগ শিরোনাম</string>
     <string name="starImage">তারা ছবি</string>
     <string name="importCatima">ক্যাতিনা আগম</string>
     <string name="importLoyaltyCardKeychain">আমদানি লয়্যালটি কার্ড কীচেন</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -24,7 +24,6 @@
     <string name="settings_light_theme">Svjetlo</string>
     <string name="settings_system_theme">Sistem</string>
     <string name="settings_theme">Tema</string>
-    <string name="settings_category_title_ui">Korisničko okruženje</string>
     <string name="starImage">Omiljena zvijezda</string>
     <string name="importCatima">Uvezi iz Catima</string>
     <string name="importLoyaltyCardKeychain">Uvezi iz Loyalty Card Keychain</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -85,7 +85,6 @@
     <string name="settings_light_theme">Světlý</string>
     <string name="settings_system_theme">Podle systému</string>
     <string name="settings_theme">Vzhled</string>
-    <string name="settings_category_title_ui">Uživatelské rozhraní</string>
     <string name="settings">Nastavení</string>
     <string name="card">Karta</string>
     <string name="balanceSentence">Zůstatek: <xliff:g>%s</xliff:g></string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -48,7 +48,6 @@
     <string name="settings_dark_theme">Mørk</string>
     <string name="settings_light_theme">Lys</string>
     <string name="settings_theme">Tema</string>
-    <string name="settings_category_title_ui">Brugergrænseflade</string>
     <string name="settings">Indstillinger</string>
     <string name="starImage">Favorit stjerne</string>
     <string name="thumbnailDescription">Miniaturebillede til kort</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,7 +50,6 @@
     <string name="copy_to_clipboard_toast">ID in die Zwischenablage kopiert</string>
     <string name="thumbnailDescription">Vorschaubild</string>
     <string name="settings">Einstellungen</string>
-    <string name="settings_category_title_ui">Benutzeroberfläche</string>
     <string name="settings_display_barcode_max_brightness">Displayhelligkeit in der Barcodeansicht erhöhen</string>
     <string name="exportSuccessful">Daten exportiert</string>
     <string name="importSuccessful">Daten importiert</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -46,7 +46,6 @@
     <string name="copy_to_clipboard_toast">Ο κωδικός αντιγράφτηκε στο πρόχειρο</string>
     <string name="thumbnailDescription">Μικρογραφία</string>
     <string name="settings">Ρυθμίσεις</string>
-    <string name="settings_category_title_ui">Διεπαφή χρήστη</string>
     <string name="settings_dark_theme">Σκοτεινό</string>
     <string name="settings_light_theme">Φωτεινό</string>
     <string name="settings_system_theme">Σύστημα</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -5,7 +5,6 @@
     <string name="noBarcode">Sen strekokodo</string>
     <string name="barcodeType">Tipo de strekokodo</string>
     <string name="cardId">Identigilo de karto</string>
-    <string name="settings_category_title_ui">Fasado</string>
     <string name="settings">Agordoj</string>
     <string name="selectBarcodeTitle">Elekti strekokodon</string>
     <string name="debug_version_fmt">Versio: <xliff:g id="version">%s</xliff:g></string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -43,7 +43,6 @@
     <string name="about_title_fmt">Acerca de <xliff:g id="app_name">%s</xliff:g></string>
     <string name="debug_version_fmt">Versión: <xliff:g id="version">%s</xliff:g></string>
     <string name="settings">Ajustes</string>
-    <string name="settings_category_title_ui">Interfaz de usuario</string>
     <string name="settings_display_barcode_max_brightness">Iluminar vista del código de barras</string>
     <string name="exportSuccessful">Datos exportados</string>
     <string name="importSuccessful">Datos importados</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -72,7 +72,6 @@
     <string name="settings_light_theme">Vaalea</string>
     <string name="settings_system_theme">Järjestelmän oletus</string>
     <string name="settings_theme">Teema</string>
-    <string name="settings_category_title_ui">Käyttöliittymä</string>
     <string name="settings">Asetukset</string>
     <string name="starImage">Suosikkitähti</string>
     <string name="thumbnailDescription">Pienoiskuva</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -46,7 +46,6 @@
     <string name="copy_to_clipboard_toast">Identifiant copié dans le presse-papiers</string>
     <string name="thumbnailDescription">Miniature</string>
     <string name="settings">Paramètres</string>
-    <string name="settings_category_title_ui">Interface utilisateur</string>
     <string name="settings_display_barcode_max_brightness">Augmenter la luminosité du code-barres</string>
     <string name="exportSuccessful">Données exportées</string>
     <string name="importSuccessful">Données importées</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -68,7 +68,6 @@
     <string name="cameraPermissionDeniedTitle">हम कैमरा तक पहुँच नहीं सकते</string>
     <string name="noCameraPermissionDirectToSystemSetting">बारकोड स्कैन करने के लिए,को आपके कैमरा का इस्तेमाल करना होगा। इजाज़त कि व्यवस्था (सेटिंग) बदलने के लिए यहाँ दबायें।</string>
     <string name="importOptionApplicationExplanation">फाइल खोलने के लिए कोई भी ऐप या अपना पसंदिता फाइल मैनेजर का इस्तेमाल करे।</string>
-    <string name="settings_category_title_ui">उपयोक्‍ता अंतरापृष्‍ठ (यूजर इंटरफ़ेस)</string>
     <string name="settings_theme">विषय</string>
     <string name="barcodeType">बारकोड का प्रकार</string>
     <string name="barcodeNoBarcode">कोई बारकोड नहीं है</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -60,7 +60,6 @@
     <string name="addManually">Ručno upiši ID</string>
     <string name="thumbnailDescription">Sličica</string>
     <string name="starImage">Omiljena zvijezda</string>
-    <string name="settings_category_title_ui">Korisničko sučelje</string>
     <string name="exportSuccessful">Podaci su izvezeni</string>
     <string name="settings_keep_screen_on">Ostavi ekran uključen</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Spriječi zaključavanje ekrana</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -96,7 +96,6 @@
     <string name="copy_to_clipboard_toast">Azonosító vágólapra másolva</string>
     <string name="starImage">Kedvencek csillag</string>
     <string name="settings">Beállítások</string>
-    <string name="settings_category_title_ui">Felhasználói felület</string>
     <string name="settings_theme">Téma</string>
     <string name="settings_system_theme">Rendszer</string>
     <string name="settings_light_theme">Világos</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -29,7 +29,6 @@
     <string name="barcodeNoBarcode">Tidak ada barcode</string>
     <string name="cancel">Batalkan</string>
     <string name="importExport">Impor/Ekspor</string>
-    <string name="settings_category_title_ui">Tampilan Pengguna</string>
     <string name="settings_theme">Tema</string>
     <string name="all">Semua</string>
     <string name="leaveWithoutSaveTitle">Keluar</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -59,7 +59,6 @@
     <string name="settings_theme">Þema</string>
     <string name="app_license">Copylefted frítt hugbúnaður, leyfi GPLv3+</string>
     <string name="noBarcodeFound">Nei strikamerkið var komist</string>
-    <string name="settings_category_title_ui">Notandi tengi</string>
     <string name="settings_system_theme">Kerfi</string>
     <string name="settings_dark_theme">Dökk</string>
     <string name="settings_display_barcode_max_brightness">Bjartari strikamerkið skoða</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -52,7 +52,6 @@
     <string name="copy_to_clipboard_toast">Codice copiato negli appunti</string>
     <string name="thumbnailDescription">Miniatura</string>
     <string name="settings">Impostazioni</string>
-    <string name="settings_category_title_ui">Interfaccia utente</string>
     <string name="settings_theme">Tema</string>
     <string name="settings_system_theme">Sistema</string>
     <string name="settings_light_theme">Chiaro</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -60,7 +60,6 @@
     <string name="settings_light_theme">ライト</string>
     <string name="settings_system_theme">システムに従う</string>
     <string name="settings_theme">テーマ</string>
-    <string name="settings_category_title_ui">外観</string>
     <string name="settings">設定</string>
     <string name="starImage">お気に入りのスター</string>
     <string name="thumbnailDescription">サムネイル</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -11,7 +11,6 @@
     <string name="about_title_fmt"><xliff:g id="app_name">%s</xliff:g> 정보</string>
     <string name="settings_system_theme">시스템</string>
     <string name="settings_theme">테마</string>
-    <string name="settings_category_title_ui">사용자 인터페이스</string>
     <string name="settings">설정</string>
     <string name="enterBarcodeInstructions">ID를 입력하고 아래에서 바코드 유형을 선택하거나 \"바코드가 없습니다\"를 선택하십시오.</string>
     <string name="selectBarcodeTitle">바코드 선택</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -128,7 +128,6 @@
     <string name="settings_light_theme">Šviesi</string>
     <string name="settings_system_theme">Sistemos</string>
     <string name="settings_theme">Tema</string>
-    <string name="settings_category_title_ui">Vartotojo sąsaja</string>
     <string name="settings">Nustatymai</string>
     <string name="starImage">Mėgstamiausia žvaigždė</string>
     <string name="thumbnailDescription">Miniatiūra</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -61,7 +61,6 @@
     <string name="thumbnailDescription">Sīktēls</string>
     <string name="starImage">Izlases zvaigzne</string>
     <string name="settings">Iestatījumi</string>
-    <string name="settings_category_title_ui">Interfeiss</string>
     <string name="settings_theme">Tēma</string>
     <string name="settings_system_theme">Sistēmas</string>
     <string name="settings_light_theme">Gaiša</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -49,7 +49,6 @@
     <string name="copy_to_clipboard_toast">ID kopiert til utklippstavle</string>
     <string name="thumbnailDescription">Miniatyrbilde</string>
     <string name="settings">Innstillinger</string>
-    <string name="settings_category_title_ui">Brukergrensesnitt</string>
     <string name="settings_display_barcode_max_brightness">Lysere strekkodevisning</string>
     <string name="exportSuccessful">Data eksportert</string>
     <string name="importSuccessful">Data importert</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -54,7 +54,6 @@
     <string name="copy_to_clipboard_toast">De kaart-id is gekopieerd naar het klembord</string>
     <string name="thumbnailDescription">Miniatuurvoorbeeld</string>
     <string name="settings">Instellingen</string>
-    <string name="settings_category_title_ui">Vormgeving</string>
     <string name="settings_theme">Thema</string>
     <string name="settings_system_theme">Systeem</string>
     <string name="settings_light_theme">Licht</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -49,7 +49,6 @@
         <item quantity="other"><xliff:g>%d</xliff:g> seleccionadas</item>
     </plurals>
     <string name="settings">Paramètres</string>
-    <string name="settings_category_title_ui">Interfàcia utilizaire</string>
     <string name="settings_theme">Tèma</string>
     <string name="noGiftCards">Clicatz lo boton + per apondre una carta o n’importar una menú ⋮</string>
     <string name="noMatchingGiftCards">Cap de resultat. Ensajatz de modificar vòstra recèrca.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -52,7 +52,6 @@
     <string name="copy_to_clipboard_toast">Skopiowano ID do schowka</string>
     <string name="thumbnailDescription">Miniaturka</string>
     <string name="settings">Ustawienia</string>
-    <string name="settings_category_title_ui">Interfejs użytkownika</string>
     <string name="settings_theme">Motyw</string>
     <string name="settings_system_theme">Systemowy</string>
     <string name="settings_light_theme">Jasny</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -57,7 +57,6 @@
     <string name="all">Todos</string>
     <string name="deleteConfirmationGroup">Eliminar o grupo\?</string>
     <string name="settings">Configurações</string>
-    <string name="settings_category_title_ui">Interface do utilizador</string>
     <string name="settings_theme">Tema</string>
     <string name="settings_system_theme">Sistema</string>
     <string name="settings_light_theme">Claro</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -43,7 +43,6 @@
     <string name="importOptionApplicationTitle">Utilizați o altă aplicație</string>
     <string name="starImage">Steaua preferată</string>
     <string name="settings">Setări</string>
-    <string name="settings_category_title_ui">Interfață utilizator</string>
     <string name="intent_import_card_from_url_share_text">Vreau să împărtășesc o carte cu tine</string>
     <string name="moveUp">Mutarea în sus</string>
     <string name="editCardTitle">Editare card</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -54,7 +54,6 @@
     <string name="copy_to_clipboard_toast">Номер скопирован в буфер обмена</string>
     <string name="thumbnailDescription">Логотип</string>
     <string name="settings">Настройки</string>
-    <string name="settings_category_title_ui">Внешний вид</string>
     <string name="settings_theme">Тема</string>
     <string name="settings_system_theme">Системная</string>
     <string name="settings_light_theme">Светлая</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -46,7 +46,6 @@
     <string name="copy_to_clipboard_toast">ID skopírované do schránky</string>
     <string name="thumbnailDescription">Miniatúra</string>
     <string name="settings">Nastavenia</string>
-    <string name="settings_category_title_ui">Používateľské prostredie</string>
     <string name="settings_display_barcode_max_brightness">Zvýšiť jas pri zobrazení čiarového kódu </string>
     <string name="deleteTitle">Odstrániť kartu</string>
     <string name="deleteConfirmation">Naozaj chcete túto kartu odstrániť?</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -46,7 +46,6 @@
     <string name="copy_to_clipboard_toast">ID številka je kopirana v odložišče</string>
     <string name="thumbnailDescription">Sličica</string>
     <string name="settings">Nastavitve</string>
-    <string name="settings_category_title_ui">Uporabniški vmesnik</string>
     <string name="settings_display_barcode_max_brightness">Povečaj osvetljenost prikaza črtne kode</string>
     <string name="deleteTitle">Odstrani kartico zvestobe</string>
     <string name="deleteConfirmation">Prosim potrdite, če želite izbrisati to kartico\?</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -77,7 +77,6 @@
     <string name="settings_dark_theme">Mörkt</string>
     <string name="settings_light_theme">Ljust</string>
     <string name="settings_theme">Tema</string>
-    <string name="settings_category_title_ui">Användargränssnitt</string>
     <string name="settings">Inställningar</string>
     <string name="thumbnailDescription">Miniatyrbild</string>
     <string name="copy_to_clipboard_toast">ID:t kopierat till Urklipp</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -100,7 +100,6 @@
     <string name="settings_light_theme">Açık</string>
     <string name="settings_system_theme">Sistem</string>
     <string name="settings_theme">Tema</string>
-    <string name="settings_category_title_ui">Kullanıcı arayüzü</string>
     <string name="settings">Ayarlar</string>
     <string name="starImage">Sık kullanılan yıldız</string>
     <string name="thumbnailDescription">Küçük resim</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -79,7 +79,6 @@
     <string name="settings_light_theme">Світла</string>
     <string name="settings_system_theme">Системна</string>
     <string name="settings_theme">Тема</string>
-    <string name="settings_category_title_ui">Інтерфейс користувача</string>
     <string name="settings">Налаштування</string>
     <string name="starImage">Улюблена зірка</string>
     <string name="thumbnailDescription">Ескіз</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -74,7 +74,6 @@
     <string name="settings_dark_theme">暗色</string>
     <string name="settings_light_theme">浅色</string>
     <string name="settings_theme">主题</string>
-    <string name="settings_category_title_ui">用户界面</string>
     <string name="settings">设置</string>
     <string name="thumbnailDescription">缩略图</string>
     <string name="copy_to_clipboard_toast">已复制卡号到剪贴板</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -143,7 +143,6 @@
     <string name="settings_theme">主題</string>
     <string name="thumbnailDescription">縮圖</string>
     <string name="noGroupCards">此群組為空</string>
-    <string name="settings_category_title_ui">用戶界面</string>
     <string name="settings_light_theme">淺色</string>
     <string name="settings_dark_theme">深色</string>
     <string name="settings_display_barcode_max_brightness">調高條碼介面螢幕亮度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,7 +92,6 @@
     <string name="thumbnailDescription">Thumbnail</string>
     <string name="starImage">Favorite star</string>
     <string name="settings">Settings</string>
-    <string name="settings_category_title_ui">User interface</string>
     <string name="settings_theme">Theme</string>
     <string name="settings_key_theme" translatable="false">pref_theme</string>
     <string name="settings_system_theme">System</string>
@@ -113,10 +112,13 @@
     <string name="settings_key_lock_on_opening_orientation" translatable="false">lock_on_opening</string>
     <string name="settings_key_max_font_size_scale" translatable="false">pref_max_font_size_scale</string>
     <string name="settings_display_barcode_max_brightness">Brighten barcode view</string>
+    <string name="settings_display_barcode_max_brightness_summary">Necessary for some scanners to work</string>
     <string name="settings_key_display_barcode_max_brightness" translatable="false">pref_display_card_max_brightness</string>
     <string name="settings_keep_screen_on">Keep screen on</string>
+    <string name="settings_keep_screen_on_summary">Disables screen timeout while viewing a card</string>
     <string name="settings_key_keep_screen_on" translatable="false">pref_keep_screen_on</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Prevent screen lock</string>
+    <string name="settings_disable_lockscreen_while_viewing_card_summary">Disables screen lock while viewing a card</string>
     <string name="settings_allow_content_provider_read_title">Allow other apps to access my data</string>
     <string name="settings_allow_content_provider_read_summary">Apps will still have to request permission to be granted access</string>
     <string name="settings_key_disable_lockscreen_while_viewing_card" translatable="false">pref_disable_lockscreen_while_viewing_card</string>
@@ -225,6 +227,7 @@
     <string name="turn_flashlight_off">Turn flashlight off</string>
     <string name="settings_locale">Language</string>
     <string name="settings_oled_dark">Pure black background for dark theme</string>
+    <string name="settings_oled_dark_summary">Reduces battery usage on OLED displays</string>
     <string name="settings_key_locale" translatable="false">pref_locale</string>
     <string name="settings_system_locale">System</string>
     <string name="selectColor">Select color</string>
@@ -326,4 +329,7 @@
     <string name="sharedpreference_card_details_show_balance" translatable="false">sharedpreference_card_details_show_balance</string>
     <string name="sharedpreference_card_details_show_validity" translatable="false">sharedpreference_card_details_show_validity</string>
     <string name="sharedpreference_card_details_show_name_below_thumbnail" translatable="false">sharedpreference_card_details_show_name_below_thumbnail</string>
+    <string name="settings_category_title_cards">Cards</string>
+    <string name="settings_category_title_general">General</string>
+    <string name="settings_category_title_privacy">Privacy</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
-        android:title="@string/settings_category_title_ui"
+        android:title="@string/settings_category_title_general"
         app:iconSpaceReserved="false">
 
         <ListPreference
@@ -13,7 +13,8 @@
             android:key="@string/settings_key_theme"
             android:title="@string/settings_theme"
             app:iconSpaceReserved="false"
-            app:singleLineTitle="false" />
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
 
         <ListPreference
             android:key="@string/setting_key_theme_color"
@@ -22,12 +23,14 @@
             android:entries="@array/color_value_strings"
             android:entryValues="@array/color_values"
             app:iconSpaceReserved="false"
-            app:singleLineTitle="false" />
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
             android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="false"
             android:key="@string/settings_key_oled_dark"
+            android:summary="@string/settings_oled_dark_summary"
             android:title="@string/settings_oled_dark"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
@@ -39,12 +42,19 @@
             android:key="@string/settings_key_locale"
             android:title="@string/settings_locale"
             app:iconSpaceReserved="false"
-            app:singleLineTitle="false" />
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/settings_category_title_cards"
+        app:iconSpaceReserved="false">
 
         <SwitchPreferenceCompat
             android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="true"
             android:key="@string/settings_key_display_barcode_max_brightness"
+            android:summary="@string/settings_display_barcode_max_brightness_summary"
             android:title="@string/settings_display_barcode_max_brightness"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
@@ -56,12 +66,14 @@
             android:key="@string/settings_key_card_orientation"
             android:title="@string/settings_card_orientation"
             app:iconSpaceReserved="false"
-            app:singleLineTitle="false" />
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
             android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="true"
             android:key="@string/settings_key_keep_screen_on"
+            android:summary="@string/settings_keep_screen_on_summary"
             android:title="@string/settings_keep_screen_on"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
@@ -70,9 +82,15 @@
             android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="true"
             android:key="@string/settings_key_disable_lockscreen_while_viewing_card"
+            android:summary="@string/settings_disable_lockscreen_while_viewing_card_summary"
             android:title="@string/settings_disable_lockscreen_while_viewing_card"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/settings_category_title_privacy"
+        app:iconSpaceReserved="false">
 
         <SwitchPreferenceCompat
             android:widgetLayout="@layout/preference_material_switch"
@@ -84,6 +102,5 @@
             app:singleLineTitle="false" />
 
     </PreferenceCategory>
-
 </PreferenceScreen>
 


### PR DESCRIPTION
Fixes #1024 

I'm not completely sure about these sentences, they feel chaotic because:
- Some show the current value (like "System")
- Some state what the function does ("Reduces X, Disables Y")
- Some explain the use of the feature ("Necessary for")
- Some give reassuring extra info ("Apps will still have to")

But I'm not sure how to fix it or if it is actually just fine?

<details><summary>Before</summary>
<img src="https://github.com/CatimaLoyalty/Android/assets/1885159/906ce634-04ea-4f44-937d-f30921c43a27">
</details> 

<details><summary>After</summary>
<img src="https://github.com/CatimaLoyalty/Android/assets/1885159/cc62895a-b99f-404b-87c3-ad8080e04ee2"> <img src="https://github.com/CatimaLoyalty/Android/assets/1885159/cdc5ec20-da81-4634-ad46-f569d58cc173">
</details> 