### PR TITLE
Fix parse of import URI with trailing slash

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportURIHelper.java
+++ b/app/src/main/java/protect/card_locker/ImportURIHelper.java
@@ -46,8 +46,11 @@ public class ImportURIHelper {
     }
 
     private boolean isImportUri(Uri uri) {
+        // Remove trailing slash added by some browsers (if it exists)
+        final String uriPath = uri.getPath().replaceAll("/$", "");
+
         for (int i = 0; i < hosts.length; i++) {
-            if (uri.getHost().equals(hosts[i]) && uri.getPath().equals(paths[i])) {
+            if (uri.getHost().equals(hosts[i]) && uriPath.equals(paths[i])) {
                 return true;
             }
         }

--- a/app/src/test/java/protect/card_locker/ImportURITest.java
+++ b/app/src/test/java/protect/card_locker/ImportURITest.java
@@ -98,6 +98,37 @@ public class ImportURITest {
     }
 
     @Test
+    public void parseWithTrailingSlash() throws InvalidObjectException, UnsupportedEncodingException {
+        // Generate card
+        DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("EUR"), BarcodeFormat.UPC_A.toString(), null, CatimaBarcode.fromBarcode(BarcodeFormat.QR_CODE), null, 0, null,0);
+
+        // Get card
+        LoyaltyCard card = DBHelper.getLoyaltyCard(mDatabase, 1);
+
+        // Card to URI, with a trailing slash
+        Uri cardUri = importURIHelper.toUri(card).buildUpon().path("/share/").build();
+        assertEquals("/share/", cardUri.getPath());
+
+        // Parse URI
+        LoyaltyCard parsedCard = importURIHelper.parse(cardUri);
+
+        // Compare everything
+        assertEquals(card.store, parsedCard.store);
+        assertEquals(card.note, parsedCard.note);
+        assertEquals(card.validFrom, parsedCard.validFrom);
+        assertEquals(card.expiry, parsedCard.expiry);
+        assertEquals(card.balance, parsedCard.balance);
+        assertEquals(card.balanceType, parsedCard.balanceType);
+        assertEquals(card.cardId, parsedCard.cardId);
+        assertEquals(card.barcodeId, parsedCard.barcodeId);
+        assertEquals(card.barcodeType.format(), parsedCard.barcodeType.format());
+        assertNull(parsedCard.headerColor);
+        // No export of starStatus for export URL foreseen therefore 0 will be imported
+        assertEquals(0, parsedCard.starStatus);
+        assertEquals(0, parsedCard.archiveStatus);
+    }
+
+    @Test
     public void failToParseInvalidUri() {
         try {
             importURIHelper.parse(Uri.parse("https://example.com/test"));


### PR DESCRIPTION
Some browsers such as firefox will add a trailing slash to the path. When clicking the "Open in app" button after, Catima would fail to recognize the path.