### PR TITLE
Fix content provider permissions conflict

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
         android:description="@string/permissionReadCardsDescription"
         android:icon="@drawable/ic_launcher_foreground"
         android:label="@string/permissionReadCardsLabel"
-        android:name="me.hackerchick.catima.READ_CARDS"
+        android:name="${applicationId}.READ_CARDS"
         android:protectionLevel="dangerous" />
 
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
@@ -166,7 +166,7 @@
             android:name=".contentprovider.CardsContentProvider"
             android:authorities="${applicationId}.contentprovider.cards"
             android:exported="true"
-            android:readPermission="me.hackerchick.catima.READ_CARDS"/>
+            android:readPermission="${applicationId}.READ_CARDS"/>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/docs/CONTENT_PROVIDER.md
+++ b/docs/CONTENT_PROVIDER.md
@@ -4,9 +4,7 @@ Catima implements a [content provider](https://developer.android.com/guide/topic
 
 Since runtime permissions are only available since Android 6.0 (API level 23), the content provider is disabled for older android versions in order to prevent unwanted access to the data.
 
-## Authority
-
-The authority for this content provider: `<package_name>.contentprovider.cards`
+## Package Names
 
 There are 3 release channels, with 2 possible package names:
 
@@ -16,11 +14,17 @@ There are 3 release channels, with 2 possible package names:
 | F-Droid         | me.hackerchick.catima       |
 | Debug Build     | me.hackerchick.catima.debug |
 
+The package names are required for the authority and permissions, as described below.
+
+## Authority
+
+The authority for this content provider: `<package_name>.contentprovider.cards`
+
 ## Permissions
 
 The content provider requires the following permissions:
 
-- `me.hackerchick.catima.READ_CARDS` - in order to access any of the URIs.
+- `<package_name>.READ_CARDS` - in order to access any of the URIs.
 
 ## URIs
 


### PR DESCRIPTION
Fix the permission conflict introduced by #1121

Tested with a debug build of Gadgetbridge + release apk from #1410
 
Fixes #1410
