### PR TITLE
ShortcutHelper: skip outdated cards that no longer exist

### DIFF
--- a/app/src/main/java/protect/card_locker/ShortcutHelper.java
+++ b/app/src/main/java/protect/card_locker/ShortcutHelper.java
@@ -83,6 +83,7 @@ class ShortcutHelper {
         }
 
         LinkedList<ShortcutInfoCompat> finalList = new LinkedList<>();
+        int rank = 0;
 
         // The ranks are now updated; the order in the list is the rank.
         for (int index = 0; index < list.size(); index++) {
@@ -90,11 +91,15 @@ class ShortcutHelper {
 
             LoyaltyCard loyaltyCard = DBHelper.getLoyaltyCard(database, Integer.parseInt(prevShortcut.getId()));
 
-            ShortcutInfoCompat updatedShortcut = createShortcutBuilder(context, loyaltyCard)
-                    .setRank(index)
-                    .build();
+            // skip outdated cards that no longer exist
+            if (loyaltyCard != null) {
+                ShortcutInfoCompat updatedShortcut = createShortcutBuilder(context, loyaltyCard)
+                        .setRank(rank)
+                        .build();
 
-            finalList.addLast(updatedShortcut);
+                finalList.addLast(updatedShortcut);
+                rank++;
+            }
         }
 
         ShortcutManagerCompat.setDynamicShortcuts(context, finalList);


### PR DESCRIPTION
I think this fixes #1413. I can't test it atm (and I can't reproduce the crash either), but I test it later.

This only fixes the NPE. A better fix would skip those cards when trimming the list as well. I can add that later as well.

Not sure if there's maybe a good way to prevent outdated cards from existing to begin with. Maybe we should clear the shortcuts after import and/or on first start; idk.