### PR TITLE
Fix crash on configuration changes in DatePickerFragment

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1352,11 +1352,15 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
     public static class DatePickerFragment extends DialogFragment
             implements DatePickerDialog.OnDateSetListener {
 
+        public interface OnDatePickListener {
+            void onDatePicked(@NonNull LoyaltyCardField textFieldToEdit, @NonNull Date newDate);
+        }
+
         private static final String TEXT_FIELD_TO_EDIT_ARGUMENT_KEY = "text_field_to_edit";
         private static final String CURRENT_DATE_ARGUMENT_KEY = "current_date";
         private static final String MIN_DATE_ARGUMENT_KEY = "min_date";
         private static final String MAX_DATE_ARGUMENT_KEY = "max_date";
-        private static final String PICK_DATE_REQUEST_KEY = "pick_date_request_key";
+        private static final String PICK_DATE_REQUEST_KEY = "pick_date_request";
         private static final String NEWLY_PICKED_DATE_ARGUMENT_KEY = "newly_picked_date";
 
         LoyaltyCardField textFieldEdit;
@@ -1374,10 +1378,6 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
             DatePickerFragment fragment = new DatePickerFragment();
             fragment.setArguments(args);
             return fragment;
-        }
-
-        public interface OnDatePickListener {
-            void onDatePicked(@NonNull LoyaltyCardField textFieldToEdit, @NonNull Date newDate);
         }
 
         public static void registerDatePickListener(@NonNull AppCompatActivity activity, @NonNull OnDatePickListener listener) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -387,6 +387,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                 case expiry:
                     formatDateField(this, expiryField, newDate);
                     break;
+                default:
+                    throw new AssertionError("Unexpected field: " + textFieldToEdit);
             }
         });
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -986,6 +986,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                     DialogFragment datePickerFragment = DatePickerFragment.newInstance(
                             loyaltyCardField,
                             (Date) dateField.getTag(),
+                            // if the expiry date is being set, set date picker's minDate to the 'valid from' date
                             loyaltyCardField == LoyaltyCardField.expiry ? (Date) validFromField.getTag() : null,
                             // if the 'valid from' date is being set, set date picker's maxDate to the expiry date
                             loyaltyCardField == LoyaltyCardField.validFrom ? (Date) expiryField.getTag() : null);
@@ -1358,6 +1359,12 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         private static final String PICK_DATE_REQUEST_KEY = "pick_date_request_key";
         private static final String NEWLY_PICKED_DATE_ARGUMENT_KEY = "newly_picked_date";
 
+        LoyaltyCardField textFieldEdit;
+        @Nullable
+        Date minDate;
+        @Nullable
+        Date maxDate;
+
         public static DatePickerFragment newInstance(@NonNull LoyaltyCardField textField, @Nullable Date currentDate, @Nullable Date minDate, @Nullable Date maxDate) {
             Bundle args = new Bundle();
             args.putSerializable(TEXT_FIELD_TO_EDIT_ARGUMENT_KEY, textField);
@@ -1381,12 +1388,6 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                             (LoyaltyCardField) Objects.requireNonNull(result.getSerializable(TEXT_FIELD_TO_EDIT_ARGUMENT_KEY)),
                             (Date) Objects.requireNonNull(result.getSerializable(NEWLY_PICKED_DATE_ARGUMENT_KEY))));
         }
-
-        LoyaltyCardField textFieldEdit;
-        @Nullable
-        Date minDate;
-        @Nullable
-        Date maxDate;
 
         @NonNull
         @Override


### PR DESCRIPTION
Fixes #1201. When you tab in and out of other apps or rotate your screen, the `DatePickerFragment` won't cause crashes anymore.
Let me explain how the fix works:
- `Fragment`s must have a public, no arguments constructor. Any data you want to pass to them must be put in a `Bundle` for Android to be able to persist it across configuration changes (like the situations above).
- Communication between fragments or between an activity and a fragment is performed with `FragmentManager.setFragmentResultListener()` on the activity/fragment that receives the callback and `FragmentManager.setFragmentResult()` on the one that sends the callback. The callback data must fit in a `Bundle`.

In the original code, the date picker directly sets the target text field. Here, the code for setting the text field is put in a callback received by the host activity, and the date picker fragment's only responsibility is receiving input data (the `Date` objects) and sending output data (the picked `Date`). To know which text field to set, I pass in an "identifier" (which conveniently is the `LoyaltyCardField` enum that's already used in the "display date picker" method, so I don't have to create a new enum or something.)