### PR TITLE
Android 13 per app language support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,11 @@ android {
         lintConfig file('lint.xml')
     }
     namespace 'protect.card_locker'
+
+    androidResources {
+        generateLocaleConfig true
+    }
+
 }
 
 dependencies {

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -1,6 +1,7 @@
 package protect.card_locker;
 
 import android.app.Activity;
+import android.app.LocaleManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -26,7 +27,9 @@ import android.widget.Toast;
 import androidx.annotation.RawRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.app.LocaleManagerCompat;
 import androidx.core.graphics.ColorUtils;
+import androidx.core.os.LocaleListCompat;
 import androidx.exifinterface.media.ExifInterface;
 import androidx.palette.graphics.Palette;
 
@@ -474,6 +477,7 @@ public class Utils {
 
         Locale chosenLocale = settings.getLocale();
 
+        //new API is broken on Android 6 and lower when selecting locales with both language and country, so still keeping this
         Resources res = context.getResources();
         Configuration configuration = res.getConfiguration();
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
@@ -481,10 +485,11 @@ public class Utils {
             return context;
         }
 
-        LocaleList localeList = chosenLocale != null ? new LocaleList(chosenLocale) : LocaleList.getDefault();
-        LocaleList.setDefault(localeList);
-        configuration.setLocales(localeList);
-        return context.createConfigurationContext(configuration);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            AppCompatDelegate.setApplicationLocales(chosenLocale != null ? LocaleListCompat.create(chosenLocale) : LocaleListCompat.getEmptyLocaleList());
+        }
+
+        return context;
     }
 
     @SuppressWarnings("deprecation")

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -1,7 +1,6 @@
 package protect.card_locker;
 
 import android.app.Activity;
-import android.app.LocaleManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -14,22 +13,18 @@ import android.graphics.ImageDecoder;
 import android.graphics.Matrix;
 import android.net.Uri;
 import android.os.Build;
-import android.os.LocaleList;
 import android.provider.MediaStore;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.RawRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
-import androidx.core.app.LocaleManagerCompat;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.os.LocaleListCompat;
 import androidx.exifinterface.media.ExifInterface;
@@ -481,8 +476,7 @@ public class Utils {
 
         Locale chosenLocale = settings.getLocale();
 
-        //new API is broken on Android 6 and lower when selecting locales with both language and country, so still keeping this
-        //TODO: remove lines 482-487 when support for Android 6- gets removed
+        // New API is broken on Android 6 and lower when selecting locales with both language and country, so still keeping this
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             Resources res = context.getResources();
             Configuration configuration = res.getConfiguration();
@@ -490,7 +484,7 @@ public class Utils {
             return context;
         }
 
-        /*Documentation at https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setApplicationLocales(androidx.core.os.LocaleListCompat)
+        /* Documentation at https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setApplicationLocales(androidx.core.os.LocaleListCompat)
         For API levels below that, the developer has two options:
         - They can opt-in to automatic storage handled through the library...
         - The second option is that they can choose to handle storage themselves.

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -510,6 +510,27 @@ public class Utils {
         res.updateConfiguration(configuration, res.getDisplayMetrics());
     }
 
+    public static boolean localeEqualsAfterAdjust(Locale appLocale, Locale systemLocale) {
+        boolean appLocaleHasCountry = !appLocale.getCountry().isEmpty();
+        boolean systemLocaleHasCountry = !systemLocale.getCountry().isEmpty();
+        boolean appLocaleHasScript = !appLocale.getScript().isEmpty();
+        boolean systemLocaleHasScript = !systemLocale.getScript().isEmpty();
+        //app locale: zh-CN, system locale: zh-Hans-CN
+        if (!appLocaleHasScript && systemLocaleHasScript) {
+            if (appLocaleHasCountry && systemLocaleHasCountry) {
+                return appLocale.getLanguage().equals(systemLocale.getLanguage()) &&
+                        appLocale.getCountry().equals(systemLocale.getCountry());
+            } else {
+                return appLocale.getLanguage().equals(systemLocale.getLanguage());
+            }
+        } //app locale: es, system locale: es-ES
+        else if (!appLocaleHasCountry && systemLocaleHasCountry) {
+            return appLocale.getLanguage().equals(systemLocale.getLanguage());
+        } else {
+            return appLocale.equals(systemLocale);
+        }
+    }
+
     static public long getUnixTime() {
         return System.currentTimeMillis() / 1000;
     }

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -478,13 +478,25 @@ public class Utils {
         Locale chosenLocale = settings.getLocale();
 
         //new API is broken on Android 6 and lower when selecting locales with both language and country, so still keeping this
-        Resources res = context.getResources();
-        Configuration configuration = res.getConfiguration();
+        //TODO: remove lines 482-487 when support for Android 6- gets removed
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            Resources res = context.getResources();
+            Configuration configuration = res.getConfiguration();
             setLocalesSdkLessThan24(chosenLocale, configuration, res);
             return context;
         }
 
+        /*Documentation at https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setApplicationLocales(androidx.core.os.LocaleListCompat)
+        For API levels below that, the developer has two options:
+        - They can opt-in to automatic storage handled through the library...
+        - The second option is that they can choose to handle storage themselves.
+        In order to do so they must use this API to initialize locales during app-start up and provide their stored locales.
+        In this case, API should be called before Activity.onCreate() in the activity lifecycle, e.g. in attachBaseContext().
+        Note: Developers should gate this to API versions <33.
+
+        We are handling storage ourselves (courtesy of the in-app language picker), so we take the second approach.
+        So according to docs, we should have the API < 33 check.
+        */
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             AppCompatDelegate.setApplicationLocales(chosenLocale != null ? LocaleListCompat.create(chosenLocale) : LocaleListCompat.getEmptyLocaleList());
         }

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -148,27 +148,27 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                 }
             }
             localePreference.setEntries(entries.toArray(new CharSequence[entryValues.length]));
-            //make locale picker preference in sync with system settings
+            // Make locale picker preference in sync with system settings
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                Locale chosenLocale = AppCompatDelegate.getApplicationLocales().get(0);
-                if (chosenLocale == null) {
-                    //corresponds to "System"
+                Locale sysLocale = AppCompatDelegate.getApplicationLocales().get(0);
+                if (sysLocale == null) {
+                    // Corresponds to "System"
                     localePreference.setValue("");
                 } else {
-                    //need to set preference's value to one of localePreference.getEntryValues() to match the locale.
-                    //Locale.toLanguageTag() theoretically should be one of the values in localePreference.getEntryValues()...
-                    //but it doesn't work for some locales. so trying something more heavyweight.
+                    // Need to set preference's value to one of localePreference.getEntryValues() to match the locale.
+                    // Locale.toLanguageTag() theoretically should be one of the values in localePreference.getEntryValues()...
+                    // But it doesn't work for some locales. so trying something more heavyweight.
 
-                    //Obtain all locales supported by the app.
-                    List<Locale> supportedLocales = Arrays.stream(localePreference.getEntryValues())
+                    // Obtain all locales supported by the app.
+                    List<Locale> appLocales = Arrays.stream(localePreference.getEntryValues())
                             .map(Objects::toString)
                             .map(Utils::stringToLocale)
                             .collect(Collectors.toList());
-                    //Get the app locale that best matches the system one
-                    Locale bestMatchLocale = Utils.getBestMatchLocale(supportedLocales, chosenLocale);
-                    //Get its index in supported locales
-                    int index = supportedLocales.indexOf(bestMatchLocale);
-                    //Set preference value to entry value at that index
+                    // Get the app locale that best matches the system one
+                    Locale bestMatchLocale = Utils.getBestMatchLocale(appLocales, sysLocale);
+                    // Get its index in supported locales
+                    int index = appLocales.indexOf(bestMatchLocale);
+                    // Set preference value to entry value at that index
                     localePreference.setValue(localePreference.getEntryValues()[index].toString());
                 }
             }
@@ -180,7 +180,7 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                     return true;
                 }
                 String newLocale = (String) newValue;
-                //if newLocale is empty, that means "System" was selected
+                // If newLocale is empty, that means "System" was selected
                 AppCompatDelegate.setApplicationLocales(newLocale.isEmpty() ? LocaleListCompat.getEmptyLocaleList() : LocaleListCompat.create(Utils.stringToLocale(newLocale)));
                 return true;
             });

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -174,7 +174,7 @@ public class SettingsActivity extends CatimaAppCompatActivity {
             }
 
             localePreference.setOnPreferenceChangeListener((preference, newValue) -> {
-                //See corresponding comment in Utils.updateBaseContextLocale for Android 6- notes
+                // See corresponding comment in Utils.updateBaseContextLocale for Android 6- notes
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
                     refreshActivity(true);
                     return true;

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -168,7 +168,8 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                     for (int i = 0; i < supportedLocales.size(); i++) {
                         Locale localeToCompare = supportedLocales.get(i);
                         //If found, set preference value to entry value at that index
-                        if (chosenLocale.equals(localeToCompare)) {
+                        //Android 13 settings seems to "force" the user to select country of locale, but many app-supported locales only have language, not country
+                        if (Utils.localeEqualsAfterAdjust(localeToCompare, chosenLocale)) {
                             localePreference.setValue(localePreference.getEntryValues()[i].toString());
                             break;
                         }

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -177,7 +177,13 @@ public class SettingsActivity extends CatimaAppCompatActivity {
             }
 
             localePreference.setOnPreferenceChangeListener((preference, newValue) -> {
-                refreshActivity(true);
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                    refreshActivity(true);
+                    return true;
+                }
+                String newLocale = (String) newValue;
+                //if newLocale is empty, that means "System" was selected
+                AppCompatDelegate.setApplicationLocales(newLocale.isEmpty() ? LocaleListCompat.getEmptyLocaleList() : LocaleListCompat.create(Utils.stringToLocale(newLocale)));
                 return true;
             });
 

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -164,16 +164,12 @@ public class SettingsActivity extends CatimaAppCompatActivity {
                             .map(Objects::toString)
                             .map(Utils::stringToLocale)
                             .collect(Collectors.toList());
-                    //Find the locale that's selected in settings and get its index in supported locales
-                    for (int i = 0; i < supportedLocales.size(); i++) {
-                        Locale localeToCompare = supportedLocales.get(i);
-                        //If found, set preference value to entry value at that index
-                        //Android 13 settings seems to "force" the user to select country of locale, but many app-supported locales only have language, not country
-                        if (Utils.localeEqualsAfterAdjust(localeToCompare, chosenLocale)) {
-                            localePreference.setValue(localePreference.getEntryValues()[i].toString());
-                            break;
-                        }
-                    }
+                    //Get the app locale that best matches the system one
+                    Locale bestMatchLocale = Utils.getBestMatchLocale(supportedLocales, chosenLocale);
+                    //Get its index in supported locales
+                    int index = supportedLocales.indexOf(bestMatchLocale);
+                    //Set preference value to entry value at that index
+                    localePreference.setValue(localePreference.getEntryValues()[index].toString());
                 }
             }
 

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -177,6 +177,7 @@ public class SettingsActivity extends CatimaAppCompatActivity {
             }
 
             localePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                //See corresponding comment in Utils.updateBaseContextLocale for Android 6- notes
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
                     refreshActivity(true);
                     return true;

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '8.1.0' apply false
+    id 'com.android.application' version '8.1.1' apply false
     id 'com.github.spotbugs' version "5.1.3" apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.application' version '8.1.0' apply false
     id 'com.github.spotbugs' version "5.1.3" apply false
 }
 


### PR DESCRIPTION
Here's my take on #991. I tested my implementation on multiple emulators from Android 5 to 13 and everything seems to work fine (including keeping the preference and A13 system settings in sync too).
P.S: I noticed you have enabled support for Java 8+ APIs in the app via core library desugaring (which means you can freely use Java 8+ stuff without encountering compatibility problems with low Android versions)... but you aren't actually using them, which is a shame. (Java 8's `java.time` APIs are *miles* better than the legacy `Date`/`Calendar`, for instance, not to mention the functional programming potential with the Java standard library (`Stream`, `Optional`, etc.)).