### PR TITLE
Return to last view after edit

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -98,7 +98,6 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
     ImageView barcodeRenderTarget;
     int mainImageIndex = 0;
     List<ImageType> imageTypes;
-    boolean isBarcodeSupported = true;
 
     static final String STATE_IMAGEINDEX = "imageIndex";
     static final String STATE_FULLSCREEN = "isFullscreen";
@@ -643,12 +642,15 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         fixBottomAppBarImageButtonColor(binding.bottomAppBarUpdateBalanceButton);
         setBottomAppBarButtonState();
 
+        boolean isBarcodeSupported;
         if (format != null && !format.isSupported()) {
             isBarcodeSupported = false;
 
             Toast.makeText(this, getString(R.string.unsupportedBarcodeType), Toast.LENGTH_LONG).show();
         } else if (format == null) {
             isBarcodeSupported = false;
+        } else {
+            isBarcodeSupported = true;
         }
 
         imageTypes = new ArrayList<>();

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -293,7 +293,6 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             bundle.putBoolean(LoyaltyCardEditActivity.BUNDLE_UPDATE, true);
             intent.putExtras(bundle);
             startActivity(intent);
-            finish();
         });
         binding.fabEdit.bringToFront();
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -550,13 +550,18 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         Log.i(TAG, "To view card: " + loyaltyCardId);
 
-        // The brightness value is on a scale from [0, ..., 1], where
-        // '1' is the brightest. We attempt to maximize the brightness
-        // to help barcode readers scan the barcode.
         Window window = getWindow();
         if (window != null) {
+            // Hide the keyboard if still shown (could be the case when returning from edit activity
+            window.setSoftInputMode(
+                    WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN
+            );
+
             WindowManager.LayoutParams attributes = window.getAttributes();
 
+            // The brightness value is on a scale from [0, ..., 1], where
+            // '1' is the brightest. We attempt to maximize the brightness
+            // to help barcode readers scan the barcode.
             if (settings.useMaxBrightnessDisplayingBarcode()) {
                 attributes.screenBrightness = 1F;
             }


### PR DESCRIPTION
Fixes #1425.

This fixes leaving the edit view returning you to the main view instead of the card view (if that's what you were on).

We need to make sure the view activity is properly updated after returning.

| Action | Working | Details |
| - | - | - |
| Press back icon | :heavy_check_mark: | |
| Press back button | :heavy_check_mark: | |
| Save after editing | :heavy_check_mark: | Fixed in 8310f096412d22ad0f8ced67d877b7061b8e43d6 |
| Edit store name | :heavy_check_mark: | |
| Edit store colour | :heavy_check_mark: | |
| Set store image | :heavy_check_mark: | |
| Remove store image | :heavy_check_mark: | |
| Change card ID | :heavy_check_mark: | |
| Change barcode type | :heavy_check_mark: | |
| Removing barcode | :heavy_check_mark:  | |
| Switching from no barcode to barcode | :heavy_check_mark:  | Fixed in 473f8e6b721c7c6d1b2a3de0fb6bc559e4968a8a |
| Setting note | :heavy_check_mark: | More info icon correctly (dis)appears |
| Setting balance | :heavy_check_mark: | Balance icon correctly (dis)appears and value and currency shown is correct |
| Setting photo | :heavy_check_mark: | Even works if no barcode but barcode state doesn't get fixed |