### PR TITLE
Fix incorrect UI updates when toggling showing archive if all cards in group are in archive

### DIFF
--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
     private View mNoGroupCardsText;
     private TabLayout groupsTabLayout;
 
-    private Runnable mSwapLoyaltyCardListCursor;
+    private Runnable mUpdateLoyaltyCardListRunnable;
 
     private ActivityResultLauncher<Intent> mBarcodeScannerLauncher;
     private ActivityResultLauncher<Intent> mSettingsLauncher;
@@ -236,13 +236,8 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
 
         mDatabase = new DBHelper(this).getWritableDatabase();
 
-        mSwapLoyaltyCardListCursor = () -> {
-            Group group = null;
-            if (mGroup != null) {
-                group = (Group) mGroup;
-            }
-
-            mAdapter.swapCursor(DBHelper.getLoyaltyCardCursor(mDatabase, mFilter, group, mOrder, mOrderDirection, mAdapter.showingArchivedCards() ? DBHelper.LoyaltyCardArchiveFilter.All : DBHelper.LoyaltyCardArchiveFilter.Unarchived));
+        mUpdateLoyaltyCardListRunnable = () -> {
+            updateLoyaltyCardList(false);
         };
 
         groupsTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
@@ -277,7 +272,7 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         mNoGroupCardsText = contentMainBinding.noGroupCardsText;
         mCardList = contentMainBinding.list;
 
-        mAdapter = new LoyaltyCardCursorAdapter(this, null, this, mSwapLoyaltyCardListCursor);
+        mAdapter = new LoyaltyCardCursorAdapter(this, null, this, mUpdateLoyaltyCardListRunnable);
         mCardList.setAdapter(mAdapter);
         registerForContextMenu(mCardList);
 
@@ -432,7 +427,12 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
     }
 
     private void updateLoyaltyCardList(boolean updateCount) {
-        mSwapLoyaltyCardListCursor.run();
+        Group group = null;
+        if (mGroup != null) {
+            group = (Group) mGroup;
+        }
+
+        mAdapter.swapCursor(DBHelper.getLoyaltyCardCursor(mDatabase, mFilter, group, mOrder, mOrderDirection, mAdapter.showingArchivedCards() ? DBHelper.LoyaltyCardArchiveFilter.All : DBHelper.LoyaltyCardArchiveFilter.Unarchived));
 
         if (updateCount) {
             updateLoyaltyCardCount();


### PR DESCRIPTION
The callback used by the display options menu bypassed the card counter. This used to work fine as the visible count used to remain the same but when toggling the visibility of archived cards was added to the display menu this caused the UI to get stuck with a wrong idea of how many cards are visible.

Fixes #1525