### PR TITLE
Add Maestro screenshot generation

### DIFF
--- a/maestro/01.yaml
+++ b/maestro/01.yaml
@@ -1,0 +1,54 @@
+appId: me.hackerchick.catima.debug
+name: Generate main screen overview with 8 cards
+---
+- launchApp:
+    appId: "me.hackerchick.catima.debug"
+    clearState: true
+- evalScript: ${output.counter = 0}
+# We only care about cardCount at this moment, but this way we can keep the card list in one script
+- runScript:
+    file: js/01-getCardInfo.js
+    env:
+      INDEX: ${output.counter}
+- repeat:
+    while:
+        true: ${output.counter < output.cardCount}
+    commands:
+      - runScript:
+          file: js/01-getCardInfo.js
+          env:
+            INDEX: ${output.counter}
+      - tapOn:
+          id: "me.hackerchick.catima.debug:id/fabAdd" # Add
+      - tapOn:
+          id: "me.hackerchick.catima.debug:id/fabOtherOptions" # More options
+      - tapOn:
+          id: "android:id/text1"
+          index: 0 # Add a card with no barcode
+      - inputText: 123456
+      - tapOn:
+          id: "android:id/button1" # OK
+      - tapOn:
+          id: "me.hackerchick.catima.debug:id/thumbnail" # Thumbnail
+      - tapOn:
+          id: "android:id/text1"
+          index: 0 # Select color
+      - tapOn:
+          id: "android:id/button3" # Custom
+      # BUG: Erase text twice to work around https://github.com/mobile-dev-inc/maestro/issues/495
+      - repeat:
+          times: 2
+          commands:
+            - tapOn:
+                id: "me.hackerchick.catima.debug:id/cpv_hex"
+            - eraseText
+      - inputText: ${output.cardColor}
+      - tapOn:
+          id: "android:id/button1" # Select
+      - tapOn:
+          id: "me.hackerchick.catima.debug:id/storeNameEdit" # Name
+      - inputText: ${output.cardName}
+      - tapOn:
+          id: "me.hackerchick.catima.debug:id/fabSave" # Save
+      - evalScript: ${output.counter = output.counter + 1}
+- takeScreenshot: "screenshot-01"

--- a/maestro/js/01-getCardInfo.js
+++ b/maestro/js/01-getCardInfo.js
@@ -1,0 +1,34 @@
+const cards = [{
+  name: "Bookshop",
+  color: "673ab7"
+}, {
+  name: "Cafeteria",
+  color: "795548"
+}, {
+  name: "Clothing Store",
+  color: "ff4fa5"
+}, {
+  name: "Department Store",
+  color: "000000"
+}, {
+  name: "Grocery Store",
+  color: "4caf50"
+}, {
+  name: "Pharmacy",
+  color: "00286e"
+}, {
+  name: "Restaurant",
+  color: "59a2be"
+}, {
+  name: "Shoe Store",
+  color: "9c27b0"
+}]
+
+// For some reason Maestro passes this as a string with the value "0.0"
+var index = Math.round(INDEX)
+
+console.log("Returning card " + (index + 1) + " of " + cards.length + " with name " + cards[index]['name'] + " and color " + cards[index]['color'])
+
+output.cardCount = cards.length
+output.cardName = cards[index]['name']
+output.cardColor = cards[index]['color']


### PR DESCRIPTION
This is a PoC of generation screenshots with Maestro.

TODO:
- [ ] Use "Catima" instead of "Catima Debug" app name (use the release APK perhaps?)
- [ ] Generate all 7 other screenshots (TODO: requires dark mode, figure out how)
- [ ] Somehow activate Android demo mode for prettier screenshots (this ensures the screenshots don't show a random timestamp in the title bar)
- [ ] Somehow use different locales
- [ ] Document this or write a script to generate all screenshots

One very big downside of Maestro is that it's slow. **Extremely** slow. It takes a full 6 minutes to generate this one screenshots. Scaling this to all Catima's supported languages may not be reasonable.

You can try the current code as follows:
1. [Install Maestro](https://maestro.mobile.dev/getting-started/installing-maestro) (sadly they don't have properly Linux packages)
2. Manually start an Android Studio emulator (the autostart is broken on Linux: https://github.com/mobile-dev-inc/maestro/issues/1492)
3. Run `maestro test maestro/01.yaml`
4. Wait 6(!) minutes
5. Look at the new `screenshot-01` image that's generated