### PR TITLE
Also scan build.gradle in /app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/app"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I believe this should fix dependabot not notifying for, for example, androidx.preference:preference:1.2.0 having an update?

Also reordered the package-ecosystem alphabetically while I was was it.