### PR TITLE
add null checks for getWindow()

### DIFF
--- a/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
+++ b/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
+import android.view.Window;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -30,15 +31,18 @@ public class CatimaAppCompatActivity extends AppCompatActivity {
         super.onPostCreate(savedInstanceState);
         // material 3 designer does not consider status bar colors
         // XXX changing this in onCreate causes issues with the splash screen activity, so doing this here
-        boolean darkMode = Utils.isDarkModeEnabled(this);
-        if (Build.VERSION.SDK_INT >= 23) {
-            View decorView = getWindow().getDecorView();
-            WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(getWindow(), decorView);
-            wic.setAppearanceLightStatusBars(!darkMode);
-            getWindow().setStatusBarColor(Color.TRANSPARENT);
-        } else {
-            // icons are always white back then
-            getWindow().setStatusBarColor(darkMode ? Color.TRANSPARENT : Color.argb(127, 0, 0, 0));
+        Window window = getWindow();
+        if (window != null) {
+            boolean darkMode = Utils.isDarkModeEnabled(this);
+            if (Build.VERSION.SDK_INT >= 23) {
+                View decorView = window.getDecorView();
+                WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(window, decorView);
+                wic.setAppearanceLightStatusBars(!darkMode);
+                window.setStatusBarColor(Color.TRANSPARENT);
+            } else {
+                // icons are always white back then
+                window.setStatusBarColor(darkMode ? Color.TRANSPARENT : Color.argb(127, 0, 0, 0));
+            }
         }
         // XXX android 9 and below has a nasty rendering bug if the theme was patched earlier
         Utils.postPatchColors(this);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -20,7 +20,6 @@ import android.text.method.DigitsKeyListener;
 import android.text.style.ForegroundColorSpan;
 import android.text.util.Linkify;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -42,17 +41,14 @@ import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.FileProvider;
 import androidx.core.graphics.BlendModeColorFilterCompat;
 import androidx.core.graphics.BlendModeCompat;
 import androidx.core.graphics.ColorUtils;
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
-import androidx.core.widget.TextViewCompat;
 
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -638,10 +634,10 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         // Set bottomAppBar and system navigation bar color
         binding.bottomAppBar.setBackgroundColor(darkenedColor);
-        if (Build.VERSION.SDK_INT >= 27) {
-            WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(getWindow(), binding.getRoot());
+        if (window != null && Build.VERSION.SDK_INT >= 27) {
+            WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(window, binding.getRoot());
             wic.setAppearanceLightNavigationBars(Utils.needsDarkForeground(darkenedColor));
-            getWindow().setNavigationBarColor(darkenedColor);
+            window.setNavigationBarColor(darkenedColor);
         }
 
         int complementaryColor = Utils.getComplementaryColor(darkenedColor);
@@ -1066,10 +1062,14 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
             // Set Android to fullscreen mode
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                getWindow().setDecorFitsSystemWindows(false);
-                if (getWindow().getInsetsController() != null) {
-                    getWindow().getInsetsController().hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
-                    getWindow().getInsetsController().setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                Window window = getWindow();
+                if (window != null) {
+                    window.setDecorFitsSystemWindows(false);
+                    WindowInsetsController wic = window.getInsetsController();
+                    if (wic != null) {
+                        wic.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+                        wic.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                    }
                 }
             } else {
                 setFullscreenModeSdkLessThan30();
@@ -1096,10 +1096,14 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
             // Unset fullscreen mode
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                getWindow().setDecorFitsSystemWindows(true);
-                if (getWindow().getInsetsController() != null) {
-                    getWindow().getInsetsController().show(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
-                    getWindow().getInsetsController().setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_DEFAULT);
+                Window window = getWindow();
+                if (window != null) {
+                    window.setDecorFitsSystemWindows(true);
+                    WindowInsetsController wic = window.getInsetsController();
+                    if (wic != null) {
+                        wic.show(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+                        wic.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_DEFAULT);
+                    }
                 }
             } else {
                 unsetFullscreenModeSdkLessThan30();
@@ -1111,19 +1115,25 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
     @SuppressWarnings("deprecation")
     private void unsetFullscreenModeSdkLessThan30() {
-        getWindow().getDecorView().setSystemUiVisibility(
-                getWindow().getDecorView().getSystemUiVisibility()
-                        & ~View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                        & ~View.SYSTEM_UI_FLAG_FULLSCREEN
-        );
+        Window window = getWindow();
+        if (window != null) {
+            window.getDecorView().setSystemUiVisibility(
+                    window.getDecorView().getSystemUiVisibility()
+                            & ~View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                            & ~View.SYSTEM_UI_FLAG_FULLSCREEN
+            );
+        }
     }
 
     @SuppressWarnings("deprecation")
     private void setFullscreenModeSdkLessThan30() {
-        getWindow().getDecorView().setSystemUiVisibility(
-                getWindow().getDecorView().getSystemUiVisibility()
-                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                        | View.SYSTEM_UI_FLAG_FULLSCREEN
-        );
+        Window window = getWindow();
+        if (window != null) {
+            window.getDecorView().setSystemUiVisibility(
+                    window.getDecorView().getSystemUiVisibility()
+                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                            | View.SYSTEM_UI_FLAG_FULLSCREEN
+            );
+        }
     }
 }

--- a/app/src/main/java/protect/card_locker/UCropWrapper.java
+++ b/app/src/main/java/protect/card_locker/UCropWrapper.java
@@ -7,6 +7,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
+import android.view.Window;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
@@ -27,15 +28,18 @@ public class UCropWrapper extends UCropActivity {
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         boolean darkMode = Utils.isDarkModeEnabled(this);
+        Window window = getWindow();
         // setup status bar to look like the rest of the app
         if (Build.VERSION.SDK_INT >= 23) {
-            View decorView = getWindow().getDecorView();
-            WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(getWindow(), decorView);
-            wic.setAppearanceLightStatusBars(!darkMode);
+            if (window != null) {
+                View decorView = window.getDecorView();
+                WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(window, decorView);
+                wic.setAppearanceLightStatusBars(!darkMode);
+            }
         } else {
             // icons are always white back then
-            if (!darkMode) {
-                getWindow().setStatusBarColor(ColorUtils.compositeColors(Color.argb(127, 0, 0, 0), getWindow().getStatusBarColor()));
+            if (window != null && !darkMode) {
+                window.setStatusBarColor(ColorUtils.compositeColors(Color.argb(127, 0, 0, 0), window.getStatusBarColor()));
             }
         }
 

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -22,6 +22,7 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.Window;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -673,10 +674,13 @@ public class Utils {
         activity.findViewById(android.R.id.content).setBackgroundColor(typedValue.data);
 
         if (Build.VERSION.SDK_INT >= 27) {
-            View decorView = activity.getWindow().getDecorView();
-            WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(activity.getWindow(), decorView);
-            wic.setAppearanceLightNavigationBars(!isDarkModeEnabled(activity));
-            activity.getWindow().setNavigationBarColor(typedValue.data);
+            Window window = activity.getWindow();
+            if (window != null) {
+                View decorView = window.getDecorView();
+                WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(window, decorView);
+                wic.setAppearanceLightNavigationBars(!isDarkModeEnabled(activity));
+                window.setNavigationBarColor(typedValue.data);
+            }
         }
     }
 


### PR DESCRIPTION
Following up on https://github.com/CatimaLoyalty/Android/pull/1547/files#r1349352117:

It seems `getWindow()` can return `null`: [the docs](https://developer.android.com/reference/android/app/Activity#getWindow()) say "The current window, or null if the activity is not visual."

I'm not entirely sure what "visual" means here (presumably not merely the same as "visible") and was unable to find out under what circumstances it can be null by searching the docs.

It seems e.g. [nextcloud added this check as well](https://github.com/nextcloud/android/pull/2225) so it seems prudent to do so just in case (and at least consistently do so instead of checking it in one place but not everywhere).

And Android doesn't actually guarantee that `onPostCreate()` runs before `onResume()`, so I also made a change to ensure the nav bar colour is only set once.