### PR TITLE
fixed Transliterated app name for hi

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,11 +37,11 @@ android {
                 getDefaultProguardFile("proguard-android.txt"),
                 "proguard-rules.pro"
             )
-
+            resValue("string", "app_name", "Catima")
         }
         debug {
             applicationIdSuffix = ".debug"
-
+            resValue("string", "app_name", "Catima Debug")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,11 +37,11 @@ android {
                 getDefaultProguardFile("proguard-android.txt"),
                 "proguard-rules.pro"
             )
-            resValue("string", "app_name", "Catima")
+
         }
         debug {
             applicationIdSuffix = ".debug"
-            resValue("string", "app_name", "Catima Debug")
+
         }
     }
 

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -7,6 +7,7 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.database.CursorIndexOutOfBoundsException;
 import android.database.sqlite.SQLiteDatabase;
 import android.graphics.Bitmap;
@@ -40,6 +41,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import protect.card_locker.databinding.ContentMainBinding;
@@ -75,7 +77,7 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
 
     private ActivityResultLauncher<Intent> mBarcodeScannerLauncher;
     private ActivityResultLauncher<Intent> mSettingsLauncher;
-    getSupportActionBar().setTitle(getResources().getString(R.string.app_name));
+
 
     private ActionMode.Callback mCurrentActionModeCallback = new ActionMode.Callback() {
         @Override
@@ -234,6 +236,8 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbar);
         groupsTabLayout = binding.groups;
+        // Set the action bar title based on the app's locale
+        updateActionBarTitle();
         contentMainBinding = ContentMainBinding.bind(binding.include.getRoot());
 
         mDatabase = new DBHelper(this).getWritableDatabase();
@@ -603,12 +607,33 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
 
                     return true;
                 }
+
             });
         }
+
+        // Set the localized title for the search item
+        MenuItem searchMenuItem = inputMenu.findItem(R.id.action_search);
+        searchMenuItem.setTitle(getString(R.string.app_name));
 
         return super.onCreateOptionsMenu(inputMenu);
     }
 
+    private void updateActionBarTitle() {
+        // Get the current locale of the app
+        Configuration config = getResources().getConfiguration();
+        Locale currentLocale = config.locale;
+
+        // Get the app name/title based on the current locale
+        String appName;
+        if (currentLocale.getLanguage().equals("hi")) {
+            appName = getString(R.string.app_name); // Use Hindi app title
+        } else {
+            appName = getString(R.string.app_name); // Use default (English) app title
+        }
+
+        // Set the action bar title
+        getSupportActionBar().setTitle(appName);
+    }
     @Override
     public boolean onOptionsItemSelected(MenuItem inputItem) {
         int id = inputItem.getItemId();

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -75,6 +75,7 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
 
     private ActivityResultLauncher<Intent> mBarcodeScannerLauncher;
     private ActivityResultLauncher<Intent> mSettingsLauncher;
+    getSupportActionBar().setTitle(getResources().getString(R.string.app_name));
 
     private ActionMode.Callback mCurrentActionModeCallback = new ActionMode.Callback() {
         @Override

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
     <string name="storeName">नाम</string>
-    <string name="app_name">कैटीमा — वफादारी कार्ड वॉलेट</string>
+    <string name="app_name">कैटीमा </string>
     <string name="note">नोट</string>
     <string name="cardId">कार्ड आईडी</string>
     <string name="star">पसंदीदा में जोड़ें</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
     <string name="storeName">नाम</string>
+    <string name="app_name">कैटीमा — वफादारी कार्ड वॉलेट</string>
     <string name="note">नोट</string>
     <string name="cardId">कार्ड आईडी</string>
     <string name="star">पसंदीदा में जोड़ें</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="action_search">Search</string>
+    <string name="app_name">Catima</string>
     <string name="action_add">Add</string>
     <plurals name="selectedCardCount">
         <item quantity="one"><xliff:g>%d</xliff:g> selected</item>


### PR DESCRIPTION
this PR fixes #1539  here i've Modified Android Gradle build to dynamically set Hindi app name, improving localization while maintaining default name for other locales.

<b>Expected Output: </b>
These changes are compatible with users' phone system language as well as their personal preference language. Additionally, here are some screenshots of the working application.


![de6cc416-2149-4513-9b10-6f2c1f1cc71b](https://github.com/CatimaLoyalty/Android/assets/95123298/afd341cd-11b7-4d6d-8157-2897710a5224)

this is our app icon in the App drawer is working according to  users' phone system language.
![74e2d1bc-b935-41c5-ab75-a8efd16f50ca](https://github.com/CatimaLoyalty/Android/assets/95123298/c6c0afef-eb8b-4fca-bc61-5019dd0315d9)


For the default English language, it is displaying as 'Catima Debug.' This may be due to the fact that I opened it in the debugging section. I checked and found that it is being directly shown from the 'gradleResValue' file, so I believe it is appearing through Gradle. I didn't edit the 'gradleResValue' file, so I believe it should work properly in our main app.

![cc7f5bac-41d1-4404-9323-137ca7ea6ee9](https://github.com/CatimaLoyalty/Android/assets/95123298/dd312797-25f5-4659-ad0a-1d8c2d006788)
