### PR TITLE
add locales: vi (enabled), kn (disabled), ml (disabled)

### DIFF
--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -91,10 +91,12 @@
         <item>is</item>
         <item>it</item>
         <item>ja</item>
+        <!-- <item>kn</item> -->
         <item>ko</item>
         <!-- <item>lb</item> -->
         <item>lt</item>
         <item>lv</item>
+        <!-- <item>ml</item> -->
         <item>nb-rNO</item>
         <item>nl</item>
         <item>oc</item>
@@ -107,6 +109,7 @@
         <item>sv</item>
         <item>tr</item>
         <item>uk</item>
+        <item>vi</item>
         <item>zh-rTW</item>
         <item>zh-rCN</item>
     </string-array>


### PR DESCRIPTION
This syncs the list in `app/src/main/res/values/settings.xml` with the files in the repo, with the too low translations commented out but listed, as is the case for existing ones now.

I enabled [Vietnamese](https://hosted.weblate.org/projects/catima/catima/vi/) as it's at 95%, which seems good enough to me, especially since the issue seems to be that some terms are simply hard to translate (so it would probably have been 100% otherwise); if you really want it to be 100% before including I can disable it.

[Kannada](https://hosted.weblate.org/projects/catima/catima/kn/) is too low at 19%. [Malayalam](https://hosted.weblate.org/projects/catima/catima/ml/) too at 26%.