### PR TITLE
Make app title translatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,25 @@
+# Android Studio generated (superseded/unused rules commented out)
 *.iml
 .gradle
-local.properties
-.idea/
+/local.properties
+#/.idea/caches
+#/.idea/libraries
+#/.idea/modules.xml
+#/.idea/workspace.xml
+#/.idea/navEditor.xml
+#/.idea/assetWizardSettings.xml
 .DS_Store
-build/
-captures/
-**/release
-**/debug
-app/*.log
+/build
+/captures
+.externalNativeBuild
+.cxx
+#local.properties
+
+# Android extras
+/app/*.log
+/app/build
+/app/release
+/.idea
 
 # Bundle
 /.bundle/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,11 +37,9 @@ android {
                 getDefaultProguardFile("proguard-android.txt"),
                 "proguard-rules.pro"
             )
-            resValue("string", "app_name", "Catima")
         }
         debug {
             applicationIdSuffix = ".debug"
-            resValue("string", "app_name", "Catima Debug")
         }
     }
 

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Catima Debug</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -229,7 +229,6 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         super.onCreate(inputSavedInstanceState);
 
         binding = MainActivityBinding.inflate(getLayoutInflater());
-        setTitle(R.string.app_name);
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbar);
         groupsTabLayout = binding.groups;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="app_name">Catima</string>
     <string name="action_search">Search</string>
     <string name="action_add">Add</string>
     <plurals name="selectedCardCount">


### PR DESCRIPTION
Removes the hardcoded app_name values, removes no longer needed label and setTitle, override `app_name` in Debug build.

Also had to update the `.gitignore` as it wanted to exclude the `debug` string values. For this I created a new Android Studio project, copied over the newly generated `.gitignore` and then added a few things manually under "Android extras" that Catima seems to need.

Fixes #1539, supersedes #1566.