### PR TITLE
Fix navigation bar button colors

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -640,7 +640,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         binding.bottomAppBar.setBackgroundColor(darkenedColor);
         if (Build.VERSION.SDK_INT >= 27) {
             WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(getWindow(), binding.getRoot());
-            wic.setAppearanceLightNavigationBars(false);
+            wic.setAppearanceLightNavigationBars(Utils.needsDarkForeground(darkenedColor));
             getWindow().setNavigationBarColor(darkenedColor);
         }
 


### PR DESCRIPTION
Turns out the implementation in #1547 did still have a bug. That's on me for assuming consistent behaviour in Android.

| Before | After |
| - | - |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/95db77f0-01b4-4e22-9079-21a5e2b581a5) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/6f9e4309-7902-4a8f-a06f-8386451fbe9a) |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/17453118-4b96-4672-a0f0-604e578eb3b0) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/fbee8d50-e25b-437c-ba82-1e4149c43439) |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/bfb013ce-6e82-410f-9987-967b9bf065ed) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/dba025ec-d46a-4d84-9f8a-c7f459ea0c17) |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/53ad1709-7a34-4fa5-9361-7f7c79376048) |  ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/38b909f9-0906-4fde-be79-8fc9f6213547) |