### PR TITLE
Open card icon in gallery on touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased - 133
 
 - Target Android 14
+- Open card icon in gallery on touch
 
 ## v2.27.0 - 132 (2024-01-30)
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -109,22 +109,25 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             return;
         }
 
+        ImageType imageType = imageTypes.get(mainImageIndex);
+
         // If the barcode is shown, switch to fullscreen layout
-        if (imageTypes.get(mainImageIndex) == ImageType.BARCODE) {
+        if (imageType == ImageType.BARCODE) {
             setFullscreen(true);
             return;
         }
 
         // If this is an image, open it in the gallery.
-        openCurrentMainImageInGallery();
+        openImageInGallery(imageType);
     }
 
-    private void openCurrentMainImageInGallery() {
-        ImageType wantedImageType = imageTypes.get(mainImageIndex);
-
+    private void openImageInGallery(ImageType imageType) {
         File file = null;
 
-        switch (wantedImageType) {
+        switch (imageType) {
+            case ICON:
+                file = Utils.retrieveCardImageAsFile(this, loyaltyCardId, ImageLocationType.icon);
+                break;
             case IMAGE_FRONT:
                 file = Utils.retrieveCardImageAsFile(this, loyaltyCardId, ImageLocationType.front);
                 break;
@@ -172,6 +175,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
     enum ImageType {
         NONE,
+        ICON,
         BARCODE,
         IMAGE_FRONT,
         IMAGE_BACK
@@ -299,7 +303,13 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         binding.bottomAppBarNextButton.setOnClickListener(view -> prevNextCard(true));
         binding.bottomAppBarUpdateBalanceButton.setOnClickListener(view -> showBalanceUpdateDialog());
 
-        binding.iconContainer.setOnClickListener(view -> Toast.makeText(LoyaltyCardViewActivity.this, R.string.icon_header_click_text, Toast.LENGTH_LONG).show());
+        binding.iconContainer.setOnClickListener(view -> {
+            if (Utils.retrieveCardImage(this, loyaltyCard.id, ImageLocationType.icon) != null) {
+                openImageInGallery(ImageType.ICON);
+            } else {
+                Toast.makeText(LoyaltyCardViewActivity.this, R.string.icon_header_click_text, Toast.LENGTH_LONG).show();
+            }
+        });
         binding.iconContainer.setOnLongClickListener(view -> {
             Intent intent = new Intent(getApplicationContext(), LoyaltyCardEditActivity.class);
             Bundle bundle = new Bundle();


### PR DESCRIPTION
If a card icon exists, open it in the gallery, like is done with photos.

While the intended behaviour was for users to use the card icon only as a general... icon and use the photos tab in the card edit screen to set photos, a 2 star review I just got on Google Play makes it clear some people put pictures in there they want to be able to zoom.

While the usage seems limited, as icons are quite small, a simple tap wasn't bound to anything except telling the user to long-press anyway so this was very easy to add and felt logical enough to support for consistency with photos.