### PR TITLE
Nudge users away from manual entry

### DIFF
--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -343,13 +343,21 @@ public class ScanActivity extends CatimaAppCompatActivity {
     }
 
     public void addManually() {
-        Intent i = new Intent(getApplicationContext(), BarcodeSelectorActivity.class);
-        if (cardId != null) {
-            final Bundle b = new Bundle();
-            b.putString("initialCardId", cardId);
-            i.putExtras(b);
-        }
-        manualAddLauncher.launch(i);
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(ScanActivity.this);
+        builder.setTitle(R.string.add_manually_warning_title);
+        builder.setMessage(R.string.add_manually_warning_message);
+        builder.setPositiveButton(R.string.continue_, (dialog, which) -> {
+            Intent i = new Intent(getApplicationContext(), BarcodeSelectorActivity.class);
+            if (cardId != null) {
+                final Bundle b = new Bundle();
+                b.putString("initialCardId", cardId);
+                i.putExtras(b);
+            }
+            manualAddLauncher.launch(i);
+        });
+        builder.setNegativeButton(R.string.cancel, (dialog, which) -> setScannerActive(true));
+        builder.setOnCancelListener(dialog -> setScannerActive(true));
+        builder.show();
     }
 
     public void addFromImage() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,4 +335,7 @@
     <string name="add_a_card_in_a_different_way">Add a card in a different way</string>
     <string name="field_must_not_be_empty">Field must not be empty</string>
     <string name="manually_enter_barcode_instructions">Enter the ID number or text on your card and press the barcode that looks like the one on your card.</string>
+    <string name="add_manually_warning_title">Scanning is recommended</string>
+    <string name="add_manually_warning_message">For some stores, the barcode value differs from the number written on the card. Because of this, entering a barcode manually may not always work. It is strongly recommended to scan the barcode with your camera instead. Do you still want to continue?</string>
+    <string name="continue_">Continue</string>
 </resources>


### PR DESCRIPTION
Manual entry is an useful feature for when you don't have a card to access. However, some stores use a different card ID than barcode value, causing users to create cards that won't work.

While I don't want to completely remove this feature, I think it is helpful to nudge users towards scanning with the camera if possible to reduce the risk of creating cards that won't work.

This change makes it so that an extra dialog window pops up when users select the "Enter the barcode manually" option under "More options" in the scan activity:

![image](https://github.com/CatimaLoyalty/Android/assets/1885159/1ad7c5ac-79e4-45f0-bb0f-7f825679f902)
