### PR TITLE
Update spending screen to also support receiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Target Android 14
 - Open card icon in gallery on touch
 - Improve design of Photos tab in edit view
+- Update spending screen to also support receiving
 
 ## v2.27.0 - 132 (2024-01-30)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,7 +296,7 @@
     </plurals>
     <string name="welcome">Welcome to Catima</string>
     <string name="importCards">Import cards</string>
-    <string name="updateBalanceTitle">How much did you spend?</string>
+    <string name="updateBalanceTitle">How much did you spend or receive?</string>
     <string name="updateBalanceHint">Enter amount</string>
     <string name="currentBalanceSentence">Current balance: <xliff:g>%s</xliff:g></string>
     <string name="newBalanceSentence">New balance: <xliff:g>%s</xliff:g></string>
@@ -338,4 +338,7 @@
     <string name="add_manually_warning_title">Scanning is recommended</string>
     <string name="add_manually_warning_message">For some stores, the barcode value differs from the number written on the card. Because of this, entering a barcode manually may not always work. It is strongly recommended to scan the barcode with your camera instead. Do you still want to continue?</string>
     <string name="continue_">Continue</string>
+    <string name="spend">Spend</string>
+    <string name="receive">Receive</string>
+    <string name="amountParsingFailed">Invalid amount</string>
 </resources>


### PR DESCRIPTION
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/27b92306-0ea9-45d8-affc-3b96a09d6470) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/f4d90413-f790-41f8-9d9f-3f0cf0f3439d) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/0914340a-4d8f-4e2a-b980-edaaf576c3bc) |
| - | - | - |
| Disables buttons when no amount is filled in | Enables buttons when change is valid |  Shows toast on update |