### PR TITLE
Fix background colour not being set for images in card view

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -123,8 +123,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
         }
 
         inputHolder.mCardIcon.setContentDescription(loyaltyCard.store);
-        Utils.setIconOrTextWithBackground(mContext, loyaltyCard, icon, inputHolder.mCardIcon, inputHolder.mCardText);
-        inputHolder.setIconBackgroundColor(Utils.getHeaderColor(mContext, loyaltyCard));
+        inputHolder.mIconBackgroundColor = Utils.setIconOrTextWithBackground(mContext, loyaltyCard, icon, inputHolder.mCardIcon, inputHolder.mCardText);
 
         inputHolder.toggleCardStateIcon(loyaltyCard.starStatus != 0, loyaltyCard.archiveStatus != 0, itemSelected(inputCursor.getPosition()));
 
@@ -338,11 +337,6 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
             mStarBackground.invalidate();
             mArchivedBackground.invalidate();
 
-        }
-
-        public void setIconBackgroundColor(int color) {
-            mIconBackgroundColor = color;
-            mCardIcon.setBackgroundColor(color);
         }
     }
 

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -748,23 +748,30 @@ public class Utils {
                 .replaceAll("(?<!href=\")\\b(https?://[\\w@#%&+=:?/.-]*[\\w@#%&+=:?/-])", "<a href=\"$1\">$1</a>");
     }
 
-    public static void setIconOrTextWithBackground(Context context, LoyaltyCard loyaltyCard, Bitmap icon, ImageView backgroundOrIcon, TextView textWhenNoImage) {
-        if (icon != null) {
-            Log.d("onResume", "setting icon image");
-            textWhenNoImage.setVisibility(View.GONE);
+    /**
+     * Sets an icon or text with background on the given ImageView and/or TextView, including background colour.
+     *
+     * @param context Android context
+     * @param loyaltyCard Loyalty Card
+     * @param icon Bitmap of the icon to set, or null
+     * @param backgroundOrIcon ImageView to draw the icon and background on to
+     * @param textWhenNoImage TextView to write the loyalty card name into if icon is null
+     * @return background colour
+     */
+    public static int setIconOrTextWithBackground(Context context, LoyaltyCard loyaltyCard, Bitmap icon, ImageView backgroundOrIcon, TextView textWhenNoImage) {
+        int headerColor = getHeaderColor(context, loyaltyCard);
+        backgroundOrIcon.setImageBitmap(icon);
+        backgroundOrIcon.setBackgroundColor(headerColor);
 
-            backgroundOrIcon.setImageBitmap(icon);
-            backgroundOrIcon.setBackgroundColor(Color.TRANSPARENT);
+        if (icon != null) {
+            textWhenNoImage.setVisibility(View.GONE);
         } else {
             textWhenNoImage.setVisibility(View.VISIBLE);
-
-            int headerColor = getHeaderColor(context, loyaltyCard);
-
-            backgroundOrIcon.setImageBitmap(null);
-            backgroundOrIcon.setBackgroundColor(headerColor);
             textWhenNoImage.setText(loyaltyCard.store);
             textWhenNoImage.setTextColor(Utils.needsDarkForeground(headerColor) ? Color.BLACK : Color.WHITE);
         }
+
+        return headerColor;
     }
 
     public static boolean installedFromGooglePlay(Context context) {


### PR DESCRIPTION
| Before | After |
| - | - |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/4f88cd11-4369-4112-a1cb-628eee440207) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/9485c5ff-709c-4213-8620-79a5176600c4) |

See the small margin on the left on the "first day" logo (ignore the background colour, the debug build uses a different theme)