### PR TITLE
Make it possible to view password on export/import dialogs

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.FrameLayout;
+import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -21,6 +22,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputLayout;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -121,16 +123,19 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
             builder.setTitle(R.string.exportPassword);
 
             FrameLayout container = new FrameLayout(ImportExportActivity.this);
-            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-            params.leftMargin = 50;
-            params.rightMargin = 50;
+
+            final TextInputLayout textInputLayout = new TextInputLayout(ImportExportActivity.this);
+            textInputLayout.setEndIconMode(TextInputLayout.END_ICON_PASSWORD_TOGGLE);
+            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            params.setMargins(50, 10, 50, 0);
+            textInputLayout.setLayoutParams(params);
 
             final EditText input = new EditText(ImportExportActivity.this);
             input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-            input.setLayoutParams(params);
             input.setHint(R.string.exportPasswordHint);
 
-            container.addView(input);
+            textInputLayout.addView(input);
+            container.addView(textInputLayout);
             builder.setView(container);
             builder.setPositiveButton(R.string.ok, (dialogInterface, i) -> {
                 exportPassword = input.getText().toString();
@@ -143,7 +148,6 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
             });
             builder.setNegativeButton(R.string.cancel, (dialogInterface, i) -> dialogInterface.cancel());
             builder.show();
-
         });
 
         // Check that there is a file manager available
@@ -315,9 +319,21 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
         builder.setTitle(R.string.passwordRequired);
 
-        final EditText input = new EditText(this);
+        FrameLayout container = new FrameLayout(ImportExportActivity.this);
+
+        final TextInputLayout textInputLayout = new TextInputLayout(ImportExportActivity.this);
+        textInputLayout.setEndIconMode(TextInputLayout.END_ICON_PASSWORD_TOGGLE);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.setMargins(50, 10, 50, 0);
+        textInputLayout.setLayoutParams(params);
+
+        final EditText input = new EditText(ImportExportActivity.this);
         input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-        builder.setView(input);
+        input.setHint(R.string.exportPasswordHint);
+
+        textInputLayout.addView(input);
+        container.addView(textInputLayout);
+        builder.setView(container);
 
         builder.setPositiveButton(R.string.ok, (dialogInterface, i) -> {
             openFileForImport(uri, input.getText().toString().toCharArray());


### PR DESCRIPTION
| Export | Import |
| - | - |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/c17778da-0fb3-4656-b79b-ae36c512ebdd) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/16547b4a-9d43-45b7-a12d-05bc5be42dff) |

Fixes #1766