### PR TITLE
Fix RB failure

### DIFF
--- a/docs/RELEASE_STEPS.md
+++ b/docs/RELEASE_STEPS.md
@@ -5,8 +5,9 @@
 2. Merge Weblate pull request
 3. Update `CHANGELOG.md` with the new version name and the release date
 4. Update `app/build.gradle.kts` with the new `versionCode` and `versionName`
-5. Build a new .apk: `KEYSTORE=/path/to/keystore KEYSTORE_ALIAS=catima ./build.sh`
-6. Upload the APK to Google Play Open Testing
-7. Push the version update: `git add CHANGELOG.md app/build.gradle.kts && git commit -m "Release Catima <VERSION>" && git push`
-8. Create a new release on GitHub and attach the `app-release.apk` and `SHA256SUMS` files
-9. After the release has been approved on Google Play Production, update the metadata there: `bundle exec fastlane supply --version_code <VERSION_CODE>`
+5. Create a commit for the new release: `git add CHANGELOG.md app/build.gradle.kts && git commit -m "Release Catima <VERSION>"`
+6. Build a new .apk: `KEYSTORE=/path/to/keystore KEYSTORE_ALIAS=catima ./build.sh`
+7. Upload the APK to Google Play Open Testing
+8. Push the version update commit: `git push`
+9. Create a new release on GitHub and attach the `app-release.apk` and `SHA256SUMS` files
+10. After the release has been approved on Google Play Production, update the metadata there: `bundle exec fastlane supply --version_code <VERSION_CODE>`


### PR DESCRIPTION
AGP 8.3 includes the commit hash in the build metadata, so for the official build to be reproducible it needs to be on the same commit as third-party builds. This commit reorders the instructions to ensure I will create the commit before building and thus fixes an RB failure in AGP 8.3+.

@obfusk I heard through @IzzySoft that you found an RB failure in Catima. As I understood it, Catima 2.28.0 is not reproducible because the commit hash differs as I always build the .apk file before creating the commit (but after changing the files), right? Am I correct in understanding this should fix Catima RB?

I haven't been able to find info on this in the AGP release notes (maybe I missed it), but do you know if it also tracks the dirty state? If so I'll have to be extra careful to not have any uncommitted fastlane changes or so hanging around too, so this would be good to know.