### PR TITLE
PDF import + multiple barcode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased - 134
+
+- Support for scanning PDF files for barcodes
+- Support for image files with multiple barcodes
+
 ## v2.28.0 - 133 (2024-03-08)
 
 - Target Android 14

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
+                <data android:mimeType="application/pdf" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/protect/card_locker/BarcodeValues.java
+++ b/app/src/main/java/protect/card_locker/BarcodeValues.java
@@ -3,10 +3,15 @@ package protect.card_locker;
 public class BarcodeValues {
     private final String mFormat;
     private final String mContent;
+    private String mNote;
 
     public BarcodeValues(String format, String content) {
         mFormat = format;
         mContent = content;
+    }
+
+    public void setNote(String note) {
+        mNote = note;
     }
 
     public String format() {
@@ -17,7 +22,5 @@ public class BarcodeValues {
         return mContent;
     }
 
-    public boolean isEmpty() {
-        return mFormat == null && mContent == null;
-    }
+    public String note() { return mNote; }
 }

--- a/app/src/main/java/protect/card_locker/BarcodeValuesListDisambiguatorCallback.java
+++ b/app/src/main/java/protect/card_locker/BarcodeValuesListDisambiguatorCallback.java
@@ -1,0 +1,6 @@
+package protect.card_locker;
+
+public interface BarcodeValuesListDisambiguatorCallback {
+    void onUserChoseBarcode(BarcodeValues barcodeValues);
+    void onUserDismissedSelector();
+}

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -646,11 +646,22 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                     Log.d("barcode card id editor", "barcode and card id editor picker returned without an intent");
                     return;
                 }
-                BarcodeValues barcodeValues = Utils.parseSetBarcodeActivityResult(Utils.BARCODE_SCAN, result.getResultCode(), intent, getApplicationContext());
 
-                cardId = barcodeValues.content();
-                barcodeType = barcodeValues.format();
-                barcodeId = "";
+                List<BarcodeValues> barcodeValuesList = Utils.parseSetBarcodeActivityResult(Utils.BARCODE_SCAN, result.getResultCode(), intent, getApplicationContext());
+
+                Utils.makeUserChooseBarcodeFromList(this, barcodeValuesList, new BarcodeValuesListDisambiguatorCallback() {
+                    @Override
+                    public void onUserChoseBarcode(BarcodeValues barcodeValues) {
+                        cardId = barcodeValues.content();
+                        barcodeType = barcodeValues.format();
+                        barcodeId = "";
+                    }
+
+                    @Override
+                    public void onUserDismissedSelector() {
+
+                    }
+                });
             }
         });
 

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -467,38 +467,20 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         String receivedAction = intent.getAction();
         String receivedType = intent.getType();
 
-        // Check if an image was shared to us
+        // Check if an image or file was shared to us
         if (Intent.ACTION_SEND.equals(receivedAction)) {
-            if (!receivedType.startsWith("image/")) {
+            BarcodeValues barcodeValues;
+
+            if (receivedType.startsWith("image/")) {
+                barcodeValues = Utils.retrieveBarcodeFromImage(this, intent.getParcelableExtra(Intent.EXTRA_STREAM));
+            } else if (receivedType.equals("application/pdf")) {
+                barcodeValues = Utils.retrieveBarcodeFromPdf(this, intent.getParcelableExtra(Intent.EXTRA_STREAM));
+            } else {
                 Log.e(TAG, "Wrong mime-type");
                 return;
             }
 
-            BarcodeValues barcodeValues;
-            Bitmap bitmap;
-
-            Uri data = intent.getParcelableExtra(Intent.EXTRA_STREAM);
-            if (data == null) {
-                Toast.makeText(this, R.string.errorReadingImage, Toast.LENGTH_LONG).show();
-                finish();
-                return;
-            }
-
-            try {
-                bitmap = Utils.retrieveImageFromUri(this, data);
-            } catch (IOException e) {
-                Log.e(TAG, "Error getting data from image file");
-                e.printStackTrace();
-                Toast.makeText(this, R.string.errorReadingImage, Toast.LENGTH_LONG).show();
-                finish();
-                return;
-            }
-
-            barcodeValues = Utils.getBarcodeFromBitmap(bitmap);
-
             if (barcodeValues.isEmpty()) {
-                Log.i(TAG, "No barcode found in image file");
-                Toast.makeText(this, R.string.noBarcodeFound, Toast.LENGTH_LONG).show();
                 finish();
                 return;
             }

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -275,14 +275,24 @@ public class ScanActivity extends CatimaAppCompatActivity {
     private void handleActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
 
-        BarcodeValues barcodeValues = Utils.parseSetBarcodeActivityResult(requestCode, resultCode, intent, this);
+        List<BarcodeValues> barcodeValuesList = Utils.parseSetBarcodeActivityResult(requestCode, resultCode, intent, this);
 
-        if (barcodeValues.isEmpty()) {
+        if (barcodeValuesList.isEmpty()) {
             setScannerActive(true);
             return;
         }
 
-        returnResult(barcodeValues.content(), barcodeValues.format());
+        Utils.makeUserChooseBarcodeFromList(this, barcodeValuesList, new BarcodeValuesListDisambiguatorCallback() {
+            @Override
+            public void onUserChoseBarcode(BarcodeValues barcodeValues) {
+                returnResult(barcodeValues.content(), barcodeValues.format());
+            }
+
+            @Override
+            public void onUserDismissedSelector() {
+                setScannerActive(true);
+            }
+        });
     }
 
     private void addWithoutBarcode() {

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -41,6 +41,7 @@ import androidx.exifinterface.media.ExifInterface;
 import androidx.palette.graphics.Palette;
 
 import com.google.android.material.color.DynamicColors;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.BinaryBitmap;
 import com.google.zxing.LuminanceSource;
 import com.google.zxing.MultiFormatReader;
@@ -48,6 +49,8 @@ import com.google.zxing.NotFoundException;
 import com.google.zxing.RGBLuminanceSource;
 import com.google.zxing.Result;
 import com.google.zxing.common.HybridBinarizer;
+import com.google.zxing.multi.GenericMultipleBarcodeReader;
+import com.google.zxing.multi.MultipleBarcodeReader;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -66,6 +69,7 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Currency;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -134,13 +138,13 @@ public class Utils {
         return ColorUtils.calculateLuminance(backgroundColor) > LUMINANCE_MIDPOINT;
     }
 
-    static public BarcodeValues retrieveBarcodeFromImage(Context context, Uri uri) {
+    static public List<BarcodeValues> retrieveBarcodesFromImage(Context context, Uri uri) {
         Log.i(TAG, "Received image file with possible barcode");
 
         if (uri == null) {
             Log.e(TAG, "Uri did not contain any data");
             Toast.makeText(context, R.string.errorReadingImage, Toast.LENGTH_LONG).show();
-            return new BarcodeValues(null, null);
+            return new ArrayList<>();
         }
 
         Bitmap bitmap;
@@ -150,29 +154,26 @@ public class Utils {
             Log.e(TAG, "Error getting data from image file");
             e.printStackTrace();
             Toast.makeText(context, R.string.errorReadingImage, Toast.LENGTH_LONG).show();
-            return new BarcodeValues(null, null);
+            return new ArrayList<>();
         }
 
-        BarcodeValues barcodeFromBitmap = getBarcodeFromBitmap(bitmap);
+        List<BarcodeValues> barcodesFromBitmap = getBarcodesFromBitmap(bitmap);
 
-        if (barcodeFromBitmap.isEmpty()) {
+        if (barcodesFromBitmap.isEmpty()) {
             Log.i(TAG, "No barcode found in image file");
             Toast.makeText(context, R.string.noBarcodeFound, Toast.LENGTH_LONG).show();
         }
 
-        Log.i(TAG, "Read barcode id: " + barcodeFromBitmap.content());
-        Log.i(TAG, "Read format: " + barcodeFromBitmap.format());
-
-        return barcodeFromBitmap;
+        return barcodesFromBitmap;
     }
 
-    static public BarcodeValues retrieveBarcodeFromPdf(Context context, Uri uri) {
+    static public List<BarcodeValues> retrieveBarcodesFromPdf(Context context, Uri uri) {
         Log.i(TAG, "Received PDF file with possible barcode");
 
         if (uri == null) {
             Log.e(TAG, "Uri did not contain any data");
             Toast.makeText(context, R.string.errorReadingFile, Toast.LENGTH_LONG).show();
-            return new BarcodeValues(null, null);
+            return new ArrayList<>();
         }
 
         ParcelFileDescriptor parcelFileDescriptor;
@@ -183,11 +184,11 @@ public class Utils {
         } catch (IOException e) {
             Log.e(TAG, "Could not read file in uri");
             Toast.makeText(context, R.string.errorReadingFile, Toast.LENGTH_LONG).show();
-            return new BarcodeValues(null, null);
+            return new ArrayList<>();
         }
 
         // Loop over all pages to find a barcode
-        BarcodeValues barcodeFromBitmap;
+        List<BarcodeValues> barcodesFromPdfPages = new ArrayList<>();
         Bitmap renderedPage;
         for (int i = 0; i < renderer.getPageCount(); i++) {
             PdfRenderer.Page page = renderer.openPage(i);
@@ -195,20 +196,16 @@ public class Utils {
             page.render(renderedPage, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY);
             page.close();
 
-            barcodeFromBitmap = getBarcodeFromBitmap(renderedPage);
-
-            if (!barcodeFromBitmap.isEmpty()) {
-                // We found a barcode, stop scanning
-                renderer.close();
-                return barcodeFromBitmap;
-            }
+            barcodesFromPdfPages.addAll(getBarcodesFromBitmap(renderedPage));
         }
         renderer.close();
 
-        Log.i(TAG, "No barcode found in image file");
-        Toast.makeText(context, R.string.noBarcodeFound, Toast.LENGTH_LONG).show();
+        if (barcodesFromPdfPages.isEmpty()) {
+            Log.i(TAG, "No barcode found in pdf file");
+            Toast.makeText(context, R.string.noBarcodeFound, Toast.LENGTH_LONG).show();
+        }
 
-        return new BarcodeValues(null, null);
+        return barcodesFromPdfPages;
     }
 
     /**
@@ -222,20 +219,20 @@ public class Utils {
      * @param context
      * @return BarcodeValues
      */
-    static public BarcodeValues parseSetBarcodeActivityResult(int requestCode, int resultCode, Intent intent, Context context) {
+    static public List<BarcodeValues> parseSetBarcodeActivityResult(int requestCode, int resultCode, Intent intent, Context context) {
         String contents;
         String format;
 
         if (resultCode != Activity.RESULT_OK) {
-            return new BarcodeValues(null, null);
+            return new ArrayList<>();
         }
 
         if (requestCode == Utils.BARCODE_IMPORT_FROM_IMAGE_FILE) {
-            return retrieveBarcodeFromImage(context, intent.getData());
+            return retrieveBarcodesFromImage(context, intent.getData());
         }
 
         if (requestCode == Utils.BARCODE_IMPORT_FROM_PDF_FILE) {
-            return retrieveBarcodeFromPdf(context, intent.getData());
+            return retrieveBarcodesFromPdf(context, intent.getData());
         }
 
         if (requestCode == Utils.BARCODE_SCAN || requestCode == Utils.SELECT_BARCODE_REQUEST) {
@@ -251,7 +248,7 @@ public class Utils {
             Log.i(TAG, "Read barcode id: " + contents);
             Log.i(TAG, "Read format: " + format);
 
-            return new BarcodeValues(format, contents);
+            return Collections.singletonList(new BarcodeValues(format, contents));
         }
 
         throw new UnsupportedOperationException("Unknown request code for parseSetBarcodeActivityResult");
@@ -271,22 +268,22 @@ public class Utils {
         return MediaStore.Images.Media.getBitmap(context.getContentResolver(), data);
     }
 
-    static public BarcodeValues getBarcodeFromBitmap(Bitmap bitmap) {
+    static public List<BarcodeValues> getBarcodesFromBitmap(Bitmap bitmap) {
         // This function is vulnerable to OOM, so we try again with a smaller bitmap is we get OOM
         for (int i = 0; i < 10; i++) {
             try {
-                return Utils.getBarcodeFromBitmapReal(bitmap);
+                return Utils.getBarcodesFromBitmapReal(bitmap);
             } catch (OutOfMemoryError e) {
-                Log.w(TAG, "Ran OOM in getBarcodeFromBitmap! Trying again with smaller picture! Retry " + i + " of 10.");
+                Log.w(TAG, "Ran OOM in getBarcodesFromBitmap! Trying again with smaller picture! Retry " + i + " of 10.");
                 bitmap = Bitmap.createScaledBitmap(bitmap, (int) Math.round(0.75 * bitmap.getWidth()), (int) Math.round(0.75 * bitmap.getHeight()), false);
             }
         }
 
         // Give up
-        return new BarcodeValues(null, null);
+        return new ArrayList<>();
     }
 
-    static private BarcodeValues getBarcodeFromBitmapReal(Bitmap bitmap) {
+    static private List<BarcodeValues> getBarcodesFromBitmapReal(Bitmap bitmap) {
         // In order to decode it, the Bitmap must first be converted into a pixel array...
         int[] intArray = new int[bitmap.getWidth() * bitmap.getHeight()];
         bitmap.getPixels(intArray, 0, bitmap.getWidth(), 0, 0, bitmap.getWidth(), bitmap.getHeight());
@@ -295,13 +292,49 @@ public class Utils {
         LuminanceSource source = new RGBLuminanceSource(bitmap.getWidth(), bitmap.getHeight(), intArray);
         BinaryBitmap binaryBitmap = new BinaryBitmap(new HybridBinarizer(source));
 
+        List<BarcodeValues> barcodeValuesList = new ArrayList<>();
         try {
-            Result barcodeResult = new MultiFormatReader().decode(binaryBitmap);
+            MultiFormatReader multiFormatReader = new MultiFormatReader();
+            MultipleBarcodeReader multipleBarcodeReader = new GenericMultipleBarcodeReader(multiFormatReader);
 
-            return new BarcodeValues(barcodeResult.getBarcodeFormat().name(), barcodeResult.getText());
+            Result[] barcodeResults = multipleBarcodeReader.decodeMultiple(binaryBitmap);
+
+            for (Result barcodeResult : barcodeResults) {
+                Log.i(TAG, "Read barcode id: " + barcodeResult.getText());
+                Log.i(TAG, "Read format: " + barcodeResult.getBarcodeFormat().name());
+
+                barcodeValuesList.add(new BarcodeValues(barcodeResult.getBarcodeFormat().name(), barcodeResult.getText()));
+            }
+
+            return barcodeValuesList;
         } catch (NotFoundException e) {
-            return new BarcodeValues(null, null);
+            return barcodeValuesList;
         }
+    }
+
+    static public void makeUserChooseBarcodeFromList(Context context, List<BarcodeValues> barcodeValuesList, BarcodeValuesListDisambiguatorCallback callback) {
+        // If there is only one choice, consider it chosen
+        if (barcodeValuesList.size() == 1) {
+            callback.onUserChoseBarcode(barcodeValuesList.get(0));
+            return;
+        }
+
+        // Ask user to choose a barcode
+        // TODO: This should contain an image of the barcode in question to help users understand the choice they're making
+        CharSequence[] barcodeDescriptions = new CharSequence[barcodeValuesList.size()];
+        for (int i = 0; i < barcodeValuesList.size(); i++) {
+            CatimaBarcode catimaBarcode = CatimaBarcode.fromName(barcodeValuesList.get(i).format());
+            barcodeDescriptions[i] = catimaBarcode.prettyName() + ": " + barcodeValuesList.get(i).content();
+        }
+
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context);
+        builder.setTitle(context.getString(R.string.multiple_barcodes_found_choose_one));
+        builder.setItems(
+                barcodeDescriptions,
+                (dialogInterface, i) -> callback.onUserChoseBarcode(barcodeValuesList.get(i))
+        );
+        builder.setOnCancelListener(dialogInterface -> callback.onUserDismissedSelector());
+        builder.show();
     }
 
     static public Boolean isNotYetValid(Date validFromDate) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,5 +344,6 @@
     <string name="addFromPdfFile">Select a PDF file</string>
     <string name="errorReadingFile">Could not read the file</string>
     <string name="failedLaunchingFileManager">Could not find a supported file manager</string>
-    <string name="multiple_barcodes_found_choose_one">Which of the found barcodes do you want to use?</string>
+    <string name="multipleBarcodesFoundPleaseChooseOne">Which of the found barcodes do you want to use?</string>
+    <string name="pageWithNumber">Page <xliff:g>%d</xliff:g></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,4 +344,5 @@
     <string name="addFromPdfFile">Select a PDF file</string>
     <string name="errorReadingFile">Could not read the file</string>
     <string name="failedLaunchingFileManager">Could not find a supported file manager</string>
+    <string name="multiple_barcodes_found_choose_one">Which of the found barcodes do you want to use?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,4 +341,7 @@
     <string name="spend">Spend</string>
     <string name="receive">Receive</string>
     <string name="amountParsingFailed">Invalid amount</string>
+    <string name="addFromPdfFile">Select a PDF file</string>
+    <string name="errorReadingFile">Could not read the file</string>
+    <string name="failedLaunchingFileManager">Could not find a supported file manager</string>
 </resources>


### PR DESCRIPTION
Fixes #496 and fixes #1449

TODO:

- [X] Import from PDF through More Options
- [X] Import from PDF through Android share menu
- [X] Support multiple barcodes
- [ ] Make multi-barcode-picker nice (probably new issue)
- [ ] Migrate to isolated service (new issue?)

Note: Android documentation for [PdfRenderer](https://developer.android.com/reference/android/graphics/pdf/PdfRenderer#PdfRenderer(android.os.ParcelFileDescriptor)) states:

> If the file is from an untrusted source it is recommended to run the renderer in a separate, isolated process with minimal permissions to limit the impact of security exploits. Note: The constructor should be instantiated on the [ERROR(/android.annotation.WorkerThread)](https://developer.android.com/) as it can be long-running while loading the document.

It is unclear what exactly "minimal permissions" means. In Catima's case, the only permission the app will have is camera access, no internet access. It seems like it would be an improvement to further move this all to a Service with `android:isolatedProcess` set (see [Service](https://developer.android.com/guide/topics/manifest/service-element#isolated)), but I'm not quite sure if that is a big enough priority to delay this functionality for especially as that may take a lot of time as I've never worked with Android services before.

With regards to long-running: I understand this is an issue, especially with networked files (see also #513) but from my testing on my (by now aging) Fairphone 3 even throwing multi-MB PDF files at Catima takes a few seconds at most, so this may be okay to delay to get the functionality out to users.

Unrelated to PDF support, the multi barcode picker currently looks like this, it should probably contain preview images or something to make it easier for users to know what to pick, but I feel that can probably wait for another task as not many users supply files with multiple barcodes: 
![image](https://github.com/CatimaLoyalty/Android/assets/1885159/8d5f832b-8ff1-4133-83eb-a0337690f4aa)