### PR TITLE
Draw app bar under status bar

### DIFF
--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -19,7 +19,8 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/manage_groups_activity.xml
+++ b/app/src/main/res/layout/manage_groups_activity.xml
@@ -19,7 +19,8 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -8,7 +8,8 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"


### PR DESCRIPTION
My favorite way of implementing the functionality desired in https://github.com/CatimaLoyalty/Android/issues/1778 is to tell the app bar that it should draw under the status bar using `fitsSystemWindows` (which has [a bit of a weird behavior](https://stackoverflow.com/a/64622793), but luckly, it does exactly what is wanted in this case). It has the benefit of changing the colors of both at exactly the same time with exactly the same transition automatically.

Before | After
---|---
![before](https://github.com/CatimaLoyalty/Android/assets/16943720/157462a0-637c-465c-8f14-f753a4dcb97d) | ![after](https://github.com/CatimaLoyalty/Android/assets/16943720/3da7ba74-4416-42e5-b3e0-ed8899b5efb4)
