### PR TITLE
Add F-Droid badge and shield

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ Copylefted libre software (GPLv3+) card management app.
 
 [![GitHub Version](https://img.shields.io/github/v/release/TheLastProject/Catima.svg?logo=github&label=GitHub)](https://github.com/TheLastProject/Catima/releases)
 [![IzzyOnDroid Version](https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/me.hackerchick.catima)](https://apt.izzysoft.de/fdroid/index/apk/me.hackerchick.catima)
+[![F-Droid Version](https://img.shields.io/f-droid/v/me.hackerchick.catima.svg?logo=f-droid&label=F-Droid)](https://f-droid.org/en/packages/me.hackerchick.catima/)
 [![Google Play Store Version](https://img.shields.io/endpoint?color=blue&logo=google-play&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dme.hackerchick.catima%26l%3DGoogle%2520Play%26m%3D%24version)](https://play.google.com/store/apps/details?id=me.hackerchick.catima)
 
 ![Android CI](https://github.com/TheLastProject/Catima/workflows/Android%20CI/badge.svg)
@@ -13,6 +14,9 @@ Copylefted libre software (GPLv3+) card management app.
 
 <a href="https://apt.izzysoft.de/fdroid/index/apk/me.hackerchick.catima" target="_blank">
 <img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height="90"/></a>
+
+<a href="https://f-droid.org/en/packages/me.hackerchick.catima/" target="_blank">
+<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
 
 <a href="https://play.google.com/store/apps/details?id=me.hackerchick.catima" target="_blank">
 <img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>


### PR DESCRIPTION
Add F-Droid badge and shield.

If you want a different ordering of badges, let me know, I can amend my commit.

I see you [intentionally removed them](https://github.com/CatimaLoyalty/Android/commit/6516d18cc2d8260b4f3deec6e33604ad0978c831), and I am aware of your parting with F-Droid :/
Still, some people prefer F-Droid over Izzy (e.g. because Izzy does not actually verify RB afaik). So I would prefer the visibility.