### PR TITLE
Disable currency grouping and accept thousand separator as decimal separator

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -1,7 +1,6 @@
 package protect.card_locker;
 
 import android.content.ActivityNotFoundException;
-import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.ColorStateList;
@@ -29,7 +28,6 @@ import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.view.WindowManager;
-import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -61,7 +59,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Currency;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Predicate;


### PR DESCRIPTION
Fixes #1775 at the cost of big values no longer being displayed as nicely (1.000.000 is now displayed as 1000000).

| | |
| - | - |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/527604a5-149c-4866-809a-7598d23bab87) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/2ee12525-5f12-45ac-9beb-065d61e4bdcf) |
| ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/35421300-2402-471c-a613-c339937b3181) | ![image](https://github.com/CatimaLoyalty/Android/assets/1885159/c73ebf20-c791-4d72-8a42-3c75b3cb9063) |