### PR TITLE
Show image type on view screen when not viewing barcode

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -651,10 +651,15 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         cardIdString = loyaltyCard.cardId;
         barcodeIdString = loyaltyCard.barcodeId;
 
-        binding.cardIdView.setText(loyaltyCard.cardId);
+        binding.mainImageDescription.setText(loyaltyCard.cardId);
 
         // Display full text on click in case it doesn't fit in a single line
-        binding.cardIdView.setOnClickListener(v -> {
+        binding.mainImageDescription.setOnClickListener(v -> {
+            if (mainImageIndex != 0) {
+                // Don't show cardId dialog, we're displaying something else
+                return;
+            }
+
             TextView cardIdView = new TextView(LoyaltyCardViewActivity.this);
             cardIdView.setText(loyaltyCard.cardId);
             cardIdView.setTextIsSelectable(true);
@@ -927,7 +932,9 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         if (imageTypes.isEmpty()) {
             barcodeRenderTarget.setVisibility(View.GONE);
             binding.mainCardView.setCardBackgroundColor(Color.TRANSPARENT);
-            binding.cardIdView.setTextColor(MaterialColors.getColor(binding.cardIdView, com.google.android.material.R.attr.colorOnSurfaceVariant));
+            binding.mainImageDescription.setTextColor(MaterialColors.getColor(binding.mainImageDescription, com.google.android.material.R.attr.colorOnSurfaceVariant));
+
+            binding.mainImageDescription.setText(loyaltyCard.cardId);
             return;
         }
 
@@ -936,7 +943,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         if (wantedImageType == ImageType.BARCODE) {
             barcodeRenderTarget.setBackgroundColor(Color.WHITE);
             binding.mainCardView.setCardBackgroundColor(Color.WHITE);
-            binding.cardIdView.setTextColor(getResources().getColor(R.color.md_theme_light_onSurfaceVariant));
+            binding.mainImageDescription.setTextColor(getResources().getColor(R.color.md_theme_light_onSurfaceVariant));
 
             if (waitForResize) {
                 redrawBarcodeAfterResize(!isFullscreen);
@@ -944,19 +951,24 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
                 drawBarcode(!isFullscreen);
             }
 
+            binding.mainImageDescription.setText(loyaltyCard.cardId);
             barcodeRenderTarget.setContentDescription(getString(R.string.barcodeImageDescriptionWithType, format.prettyName()));
         } else if (wantedImageType == ImageType.IMAGE_FRONT) {
             barcodeRenderTarget.setImageBitmap(frontImageBitmap);
             barcodeRenderTarget.setBackgroundColor(Color.TRANSPARENT);
             binding.mainCardView.setCardBackgroundColor(Color.TRANSPARENT);
-            binding.cardIdView.setTextColor(MaterialColors.getColor(binding.cardIdView, com.google.android.material.R.attr.colorOnSurfaceVariant));
+            binding.mainImageDescription.setTextColor(MaterialColors.getColor(binding.mainImageDescription, com.google.android.material.R.attr.colorOnSurfaceVariant));
+
+            binding.mainImageDescription.setText(getString(R.string.frontImageDescription));
             barcodeRenderTarget.setContentDescription(getString(R.string.frontImageDescription));
         } else if (wantedImageType == ImageType.IMAGE_BACK) {
             barcodeRenderTarget.setImageBitmap(backImageBitmap);
             barcodeRenderTarget.setBackgroundColor(Color.TRANSPARENT);
             binding.mainCardView.setCardBackgroundColor(Color.TRANSPARENT);
-            binding.cardIdView.setTextColor(MaterialColors.getColor(binding.cardIdView, com.google.android.material.R.attr.colorOnSurfaceVariant));
-            barcodeRenderTarget.setContentDescription(getString(R.string.backImageDescription));
+            binding.mainImageDescription.setTextColor(MaterialColors.getColor(binding.mainImageDescription, com.google.android.material.R.attr.colorOnSurfaceVariant));
+
+            binding.mainImageDescription.setText(getString(R.string.frontImageDescription));
+            barcodeRenderTarget.setContentDescription(getString(R.string.frontImageDescription));
         } else {
             throw new IllegalArgumentException("Unknown image type: " + wantedImageType);
         }

--- a/app/src/main/res/layout/loyalty_card_view_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_view_layout.xml
@@ -121,7 +121,7 @@
                                 android:layout_weight="1"/>
 
                             <TextView
-                                android:id="@+id/card_id_view"
+                                android:id="@+id/main_image_description"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:textSize="@dimen/text_size_large"

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -308,7 +308,7 @@ public class LoyaltyCardViewActivityTest {
                                 final String barcodeId, final String barcodeType,
                                 final Bitmap frontImage, final Bitmap backImage) {
         if (mode == ViewMode.VIEW_CARD) {
-            checkFieldProperties(activity, R.id.card_id_view, View.VISIBLE, cardId, FieldTypeView.TextView);
+            checkFieldProperties(activity, R.id.main_image_description, View.VISIBLE, cardId, FieldTypeView.TextView);
         } else {
             int editVisibility = View.VISIBLE;
 


### PR DESCRIPTION
Replace the field showing the barcode ID with the text "Front image" or "Back image" when the front or back image are displayed.

As suggested on https://github.com/CatimaLoyalty/Android/issues/1889#issuecomment-2120550099.

| Before | After |
| ---------- | ------- |
| ![Image shown with barcode below it](https://github.com/CatimaLoyalty/Android/assets/1885159/d2b2288d-a657-47dd-9b89-f486ccf37aab) | ![Image shown with text "Front image" below it](https://github.com/CatimaLoyalty/Android/assets/1885159/f5087422-f267-4401-b892-bae143ecb481)