### PR TITLE
Allow fallback to front or back image for thumbnail if icon image is not set

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -88,7 +88,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
         inputHolder.mDivider.setVisibility(View.GONE);
 
         LoyaltyCard loyaltyCard = LoyaltyCard.toLoyaltyCard(inputCursor);
-        Bitmap icon = Utils.retrieveCardImage(mContext, loyaltyCard.id, ImageLocationType.icon);
+        Bitmap icon = Utils.getThumbnailWithFallback(mContext, loyaltyCard.id).first;
 
         if (mLoyaltyCardListDisplayOptions.showingNameBelowThumbnail() && icon != null) {
             showDivider = true;

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -19,6 +19,7 @@ import android.text.method.DigitsKeyListener;
 import android.text.style.ForegroundColorSpan;
 import android.text.util.Linkify;
 import android.util.Log;
+import android.util.Pair;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -84,6 +85,9 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
     String cardIdString;
     String barcodeIdString;
     CatimaBarcode format;
+
+    Bitmap iconBitmap;
+    ImageLocationType iconBitmapLocationType;
 
     Bitmap frontImageBitmap;
     Bitmap backImageBitmap;
@@ -302,10 +306,16 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         binding.bottomAppBarUpdateBalanceButton.setOnClickListener(view -> showBalanceUpdateDialog());
 
         binding.iconContainer.setOnClickListener(view -> {
-            if (Utils.retrieveCardImage(this, loyaltyCard.id, ImageLocationType.icon) != null) {
-                openImageInGallery(ImageType.ICON);
-            } else {
+            if (iconBitmapLocationType == null) {
                 Toast.makeText(LoyaltyCardViewActivity.this, R.string.icon_header_click_text, Toast.LENGTH_LONG).show();
+            } else if (iconBitmapLocationType == ImageLocationType.icon) {
+                openImageInGallery(ImageType.ICON);
+            } else if (iconBitmapLocationType == ImageLocationType.front) {
+                openImageInGallery(ImageType.IMAGE_FRONT);
+            } else if (iconBitmapLocationType == ImageLocationType.back) {
+                openImageInGallery(ImageType.IMAGE_BACK);
+            } else {
+                throw new IllegalArgumentException("Unknown image type: " + iconBitmapLocationType);
             }
         });
         binding.iconContainer.setOnLongClickListener(view -> {
@@ -692,8 +702,10 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         editButtonIcon.setTint(Utils.needsDarkForeground(complementaryColor) ? Color.BLACK : Color.WHITE);
         binding.fabEdit.setImageDrawable(editButtonIcon);
 
-        Bitmap icon = Utils.retrieveCardImage(this, loyaltyCard.id, ImageLocationType.icon);
-        Utils.setIconOrTextWithBackground(this, loyaltyCard, icon, binding.iconImage, binding.iconText);
+        Pair<Bitmap, ImageLocationType> bitmapImageLocationTypePair = Utils.getThumbnailWithFallback(this, loyaltyCard.id);
+        iconBitmap = bitmapImageLocationTypePair.first;
+        iconBitmapLocationType = bitmapImageLocationTypePair.second;
+        Utils.setIconOrTextWithBackground(this, loyaltyCard, iconBitmap, binding.iconImage, binding.iconText);
 
         // If the background is very bright, we should use dark icons
         backgroundNeedsDarkIcons = Utils.needsDarkForeground(backgroundHeaderColor);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -684,7 +684,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             dialog.show();
         });
 
-        int backgroundHeaderColor = Utils.getHeaderColor(this, loyaltyCard);
+        Pair<Bitmap, ImageLocationType> bitmapImageLocationTypePair = Utils.getThumbnailWithFallback(this, loyaltyCard.id);
+        iconBitmap = bitmapImageLocationTypePair.first;
+        iconBitmapLocationType = bitmapImageLocationTypePair.second;
+        Utils.setIconOrTextWithBackground(this, loyaltyCard, iconBitmap, binding.iconImage, binding.iconText);
+
+        int backgroundHeaderColor = Utils.getHeaderColorFromImage(iconBitmap, Utils.getHeaderColor(this, loyaltyCard));
 
         // Also apply colours to UI elements
         int darkenedColor = ColorUtils.blendARGB(backgroundHeaderColor, Color.BLACK, 0.1f);
@@ -701,11 +706,6 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         editButtonIcon.mutate();
         editButtonIcon.setTint(Utils.needsDarkForeground(complementaryColor) ? Color.BLACK : Color.WHITE);
         binding.fabEdit.setImageDrawable(editButtonIcon);
-
-        Pair<Bitmap, ImageLocationType> bitmapImageLocationTypePair = Utils.getThumbnailWithFallback(this, loyaltyCard.id);
-        iconBitmap = bitmapImageLocationTypePair.first;
-        iconBitmapLocationType = bitmapImageLocationTypePair.second;
-        Utils.setIconOrTextWithBackground(this, loyaltyCard, iconBitmap, binding.iconImage, binding.iconText);
 
         // If the background is very bright, we should use dark icons
         backgroundNeedsDarkIcons = Utils.needsDarkForeground(backgroundHeaderColor);

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -23,6 +23,7 @@ import android.text.Layout;
 import android.text.Spanned;
 import android.text.style.ClickableSpan;
 import android.util.Log;
+import android.util.Pair;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
@@ -1024,5 +1025,25 @@ public class Utils {
         } catch (CameraAccessException e) {
             return false;
         }
+    }
+
+    /**
+     * Retrieve the card thumbnail, falling back to the front and back card image if no thumbnail is set
+     *
+     * @param context Android context
+     * @param loyaltyCardId Id of Loyalty Card
+     * @return Bitmap thumbnail or None if no set
+     */
+    public static Pair<Bitmap, ImageLocationType> getThumbnailWithFallback(Context context, int loyaltyCardId) {
+        Bitmap icon;
+        for (ImageLocationType imageLocationType : new ImageLocationType[]{ ImageLocationType.icon, ImageLocationType.front, ImageLocationType.back }) {
+            icon = Utils.retrieveCardImage(context, loyaltyCardId, imageLocationType);
+
+            if (icon != null) {
+                return new Pair<>(icon, imageLocationType);
+            }
+        }
+
+        return new Pair<>(null, null);
     }
 }

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -935,7 +935,7 @@ public class Utils {
      * @return background colour
      */
     public static int setIconOrTextWithBackground(Context context, LoyaltyCard loyaltyCard, Bitmap icon, ImageView backgroundOrIcon, TextView textWhenNoImage) {
-        int headerColor = getHeaderColor(context, loyaltyCard);
+        int headerColor = getHeaderColorFromImage(icon, getHeaderColor(context, loyaltyCard));
         backgroundOrIcon.setImageBitmap(icon);
         backgroundOrIcon.setBackgroundColor(headerColor);
 

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -620,6 +620,16 @@ public class Utils {
         return retrieveCardImageAsFile(context, getCardImageFileName(loyaltyCardId, type));
     }
 
+    static public boolean hasCardImage(Context context, String fileName) {
+        try {
+            context.openFileInput(fileName);
+        } catch (FileNotFoundException e) {
+            return false;
+        }
+
+        return true;
+    }
+
     static public Bitmap retrieveCardImage(Context context, String fileName) {
         FileInputStream in;
         try {
@@ -629,6 +639,10 @@ public class Utils {
         }
 
         return BitmapFactory.decodeStream(in);
+    }
+
+    static public boolean hasCardImage(Context context, int loyaltyCardId, ImageLocationType type) {
+        return hasCardImage(context, getCardImageFileName(loyaltyCardId, type));
     }
 
     static public Bitmap retrieveCardImage(Context context, int loyaltyCardId, ImageLocationType type) {
@@ -1028,11 +1042,28 @@ public class Utils {
     }
 
     /**
+     * Check if the card has an image thumbnail and if yes return what type it is
+     *
+     * @param context Android context
+     * @param loyaltyCardId Id of Loyalty Card
+     * @return ImageLocationType The location type of the thumbnail if it exists, or null if no thumbnail
+     */
+    public static ImageLocationType getThumbnailImageLocationType(Context context, int loyaltyCardId) {
+        for (ImageLocationType imageLocationType : new ImageLocationType[]{ImageLocationType.icon, ImageLocationType.front, ImageLocationType.back}) {
+            if (Utils.hasCardImage(context, loyaltyCardId, imageLocationType)) {
+                return imageLocationType;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Retrieve the card thumbnail, falling back to the front and back card image if no thumbnail is set
      *
      * @param context Android context
      * @param loyaltyCardId Id of Loyalty Card
-     * @return Bitmap thumbnail or None if no set
+     * @return Pair<Bitmap, ImageLocationType> thumbnail and imageLocationType or both null if not set
      */
     public static Pair<Bitmap, ImageLocationType> getThumbnailWithFallback(Context context, int loyaltyCardId) {
         Bitmap icon;

--- a/app/src/main/res/layout/loyalty_card_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_layout.xml
@@ -29,7 +29,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/thumbnailDescription"
                 android:scaleType="fitCenter"
-                android:src="@mipmap/ic_launcher"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes #1929

- [X] Write code to try icon first, then fall back to front or back
- [x] Generate header colour correctly (right now it always is based on the icon or random)
- [ ] Fix the notable slowdown when scrolling through the main activity

 To decide: how should this interact with #1889?