### PR TITLE
Load thumbnails on main screen asynchronously

### DIFF
--- a/app/src/main/res/layout/loyalty_card_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_layout.xml
@@ -29,7 +29,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/thumbnailDescription"
                 android:scaleType="fitCenter"
-                android:src="@mipmap/ic_launcher"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Decoding a bitmap can be slow. On slow devices, loading all the images as soon as the card should be shown can lead to UI freezes.

By loading the thumbnail asynchronously, scrolling quickly remains smooth even on slow devices.

Note: This works quite well on my Fairphone 3 with just a few images, needs testing with many images and also on fast devices.