### PR TITLE
Allow store name thumbnails to span multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased - 137
+
+- Allow long store names in preview to split over multiple lines
+
 ## v2.30.0 - 136 (2024-06-18)
 
 - Support for creating a card when sharing plain text

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -39,6 +39,7 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.os.LocaleListCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
+import androidx.core.widget.TextViewCompat;
 import androidx.exifinterface.media.ExifInterface;
 import androidx.palette.graphics.Palette;
 
@@ -941,6 +942,22 @@ public class Utils {
         if (icon != null) {
             textWhenNoImage.setVisibility(View.GONE);
         } else {
+            // Manually calculate how many lines will be needed
+            // This is necessary because Android's auto sizing will split over lines way before reaching the minimum font size and store names split over multiple lines are harder to scan with a quick glance so we should try to prevent it
+            // Because we have to write the text before we can actually know the exact laid out size (trying to delay this causes bugs where the autosize fails) we have to take some... weird shortcuts
+
+            // At this point textWhenNoImage.getWidth() still returns 0, so we cheat by calculating the whole width of the screen and then dividing it by the amount of columns
+            int textviewWidth = Resources.getSystem().getDisplayMetrics().widthPixels / context.getResources().getInteger(R.integer.main_view_card_columns);
+
+            // Calculate how wide a character is and calculate how many characters fit in a line
+            int characterWidth = TextViewCompat.getAutoSizeMinTextSize(textWhenNoImage);
+            int maxWidthPerLine = textviewWidth - textWhenNoImage.getPaddingStart() - textWhenNoImage.getPaddingEnd();
+
+            // Set amount of lines based on what could fit at most
+            int maxLines = ((loyaltyCard.store.length() * characterWidth) / maxWidthPerLine) + 1;
+            textWhenNoImage.setMaxLines(maxLines);
+
+            // Actually set the text and colour
             textWhenNoImage.setVisibility(View.VISIBLE);
             textWhenNoImage.setText(loyaltyCard.store);
             textWhenNoImage.setTextColor(Utils.needsDarkForeground(headerColor) ? Color.BLACK : Color.WHITE);

--- a/app/src/main/res/layout/loyalty_card_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_layout.xml
@@ -42,12 +42,8 @@
                 android:layout_height="match_parent"
                 android:textStyle="bold"
                 app:autoSizeTextType="uniform"
-                app:autoSizeMinTextSize="12sp"
-                app:autoSizeMaxTextSize="100sp"
-                app:autoSizeStepGranularity="2sp"
                 android:gravity="center"
-                android:maxLines="1"
-                android:layout_margin="20dp" />
+                android:padding="20dp" />
 
             <ImageView
                 android:importantForAccessibility="no"


### PR DESCRIPTION
Allowing spanning multiple lines helps in case the store name doesn't fit on a single line. However, the store name should fit a single line if possible because it looks better when the store name isn't split among lines. Due to limitations in Android's autoSizeTextType system, this needs a fairly ugly workaround.

Fixes #1961

| Before | Removing `android:maxLines="1"` on `@+id/thumbnail_text` without other changes  (earlier prototype) | After |
| - | - | - |
| ![Screenshot_20240630-172059_Trebuchet](https://github.com/CatimaLoyalty/Android/assets/1885159/859a1474-363e-4041-946c-dd5592d7b6f6) | ![Screenshot_20240630-172120_Trebuchet](https://github.com/CatimaLoyalty/Android/assets/1885159/4db64b2f-5c1f-4ec8-b13e-456bcb085c98) | ![Screenshot_20240630-172020_Trebuchet](https://github.com/CatimaLoyalty/Android/assets/1885159/46be9428-4e30-44cf-81ab-330a72798f15) |

This needs extra testing on a wide variety of Android versions because it touches a very critical code path.