### PR TITLE
Fix/import export hacks

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -9,6 +9,7 @@ import android.text.InputType;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.FrameLayout;
@@ -163,6 +164,10 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
         // Check that there is an app that data can be imported from
         Button importApplication = binding.importOptionApplicationButton;
         importApplication.setOnClickListener(v -> chooseImportType(true, null));
+
+        // FIXME: The importer/exporter is currently quite broken
+        // To prevent the screen from turning off during import/export and some devices killing Catima as it's no longer foregrounded, force the screen to stay on here
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
     private void openFileForImport(Uri uri, char[] password) {

--- a/app/src/main/java/protect/card_locker/ImportExportTask.java
+++ b/app/src/main/java/protect/card_locker/ImportExportTask.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
+import android.widget.Toast;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,14 +91,18 @@ public class ImportExportTask implements CompatCallable<ImportExportResult> {
         progress = new ProgressDialog(activity);
         progress.setTitle(doImport ? R.string.importing : R.string.exporting);
 
-        progress.setOnDismissListener(new DialogInterface.OnDismissListener() {
-            @Override
-            public void onDismiss(DialogInterface dialog) {
-                ImportExportTask.this.stop();
-            }
-        });
+        progress.setOnCancelListener(dialog -> cancel(doImport, true));
+        progress.setOnDismissListener(dialog -> cancel(doImport, true));
 
         progress.show();
+    }
+
+    private void cancel(boolean isImport, boolean showToast) {
+        ImportExportTask.this.stop();
+
+        if (showToast) {
+            Toast.makeText(activity, isImport ? R.string.importCancelled : R.string.exportCancelled, Toast.LENGTH_LONG).show();
+        }
     }
 
     protected ImportExportResult doInBackground(Void... nothing) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -347,4 +347,6 @@
     <string name="multipleBarcodesFoundPleaseChooseOne">Which of the found barcodes do you want to use?</string>
     <string name="pageWithNumber">Page <xliff:g>%d</xliff:g></string>
     <string name="noCameraFoundGuideText">Your device does not seem to have a camera. If it does, try rebooting the device. Otherwise, use the "More options" button below to add a barcode another way.</string>
+    <string name="importCancelled">Import cancelled</string>
+    <string name="exportCancelled">Export cancelled</string>
 </resources>


### PR DESCRIPTION
Keeps screen on import/export activity to prevent getting killing in background (fixes #1978)
Also cancels import/export when tapping next to the progress dialog (fixes #1980)

@Korb I don't have a big enough export file to test either of these (the imports/exports finish way too fast for me). Could you please test this? I've attached a debug build (but feel free to build from this commit yourself too if you'd rather do that): [app-debug.zip](https://github.com/user-attachments/files/16119245/app-debug.zip)
