### PR TITLE
Fix chip contrast in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Allow long store names in preview to split over multiple lines
 - Option to use front of back image in thumbnail menu
 - Minor import/export fixes
+- Minor UI fixes
 
 ## v2.30.0 - 136 (2024-06-18)
 

--- a/app/src/main/res/layout/layout_chip_choice.xml
+++ b/app/src/main/res/layout/layout_chip_choice.xml
@@ -6,4 +6,5 @@
     android:paddingRight="8dp"
     style="@style/Widget.MaterialComponents.Chip.Filter"
     app:checkedIconVisible="true"
-    android:textAppearance="?android:attr/textAppearance" />
+    android:textAppearance="?android:attr/textAppearance"
+    app:checkedIconTint="?attr/colorOnBackground"/>


### PR DESCRIPTION
Fixes #1971 

| Light | Dark |
| - | - |
| ![Screenshot_20240722-194251_Trebuchet](https://github.com/user-attachments/assets/b1780cf2-19bb-4bef-b308-7f433c7abaa0) | ![Screenshot_20240722-194305_Trebuchet](https://github.com/user-attachments/assets/16eb6f87-4265-489c-9fe8-8b4d25ebbb18) |