### PR TITLE
Make Back button/gesture not instantly collapse the MainActivity's search view

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,6 +28,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        api-level: [ 21, 34 ]
     steps:
     - uses: actions/checkout@v4.1.7
     - name: Fail on bad translations
@@ -44,6 +47,13 @@ jobs:
       run: ./gradlew lintRelease
     - name: Run unit tests
       run: timeout 5m ./gradlew testReleaseUnitTest || { ./gradlew --stop && timeout 5m ./gradlew testReleaseUnitTest; }
+    - name: Run instrumented tests
+      uses: ReactiveCircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        target: google_apis
+        arch: x86_64
+        script: ./gradlew connectedCheck
     - name: SpotBugs
       run: ./gradlew spotbugsRelease
     - name: Archive test results

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,5 +64,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4.3.6
       with:
-        name: test-results
+        name: test-results-api${{ matrix.api-level }}
         path: app/build/reports

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,7 +51,6 @@ jobs:
       uses: ReactiveCircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
-        target: google_apis
         arch: x86_64
         script: ./gradlew connectedCheck
     - name: SpotBugs

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,6 +47,11 @@ jobs:
       run: ./gradlew lintRelease
     - name: Run unit tests
       run: timeout 5m ./gradlew testReleaseUnitTest || { ./gradlew --stop && timeout 5m ./gradlew testReleaseUnitTest; }
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
     - name: Run instrumented tests
       uses: ReactiveCircus/android-emulator-runner@v2
       with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled = true
 
-        resourceConfigurations += listOf("ar", "bg", "bn", "bn-rIN", "bs", "cs", "da", "de", "el-rGR", "en", "eo", "es", "es-rAR", "fi", "fr", "he-rIL", "hi", "hr", "hu", "in-rID", "is", "it", "ja", "ko", "lt", "lv", "nb-rNO", "nl", "oc", "pl", "pt-rBR", "pt-rPT", "ro-rRO", "ru", "sk", "sl", "sr", "sv", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
+        resourceConfigurations += listOf("ar", "bg", "bn", "bn-rIN", "bs", "cs", "da", "de", "el-rGR", "en", "eo", "es", "es-rAR", "et", "fi", "fr", "he-rIL", "hi", "hr", "hu", "in-rID", "is", "it", "ja", "ko", "lt", "lv", "nb-rNO", "nl", "oc", "pl", "pt-rBR", "pt-rPT", "ro-rRO", "ru", "sk", "sl", "sr", "sv", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,9 @@ android {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled = true
 
-        resourceConfigurations += listOf("ar", "bg", "bn", "bn-rIN", "bs", "cs", "da", "de", "el-rGR", "en", "eo", "es", "es-rAR", "et", "fi", "fr", "he-rIL", "hi", "hr", "hu", "in-rID", "is", "it", "ja", "ko", "lt", "lv", "nb-rNO", "nl", "oc", "pl", "pt-rBR", "pt-rPT", "ro-rRO", "ru", "sk", "sl", "sr", "sv", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
+        resourceConfigurations += listOf("ar", "bg", "bn", "bn-rIN", "bs", "cs", "da", "de", "el-rGR", "en", "eo", "es", "es-rAR", "fi", "fr", "he-rIL", "hi", "hr", "hu", "in-rID", "is", "it", "ja", "ko", "lt", "lv", "nb-rNO", "nl", "oc", "pl", "pt-rBR", "pt-rPT", "ro-rRO", "ru", "sk", "sl", "sr", "sv", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -110,9 +112,18 @@ dependencies {
     implementation("io.wcm.tooling.spotbugs:io.wcm.tooling.spotbugs.annotations:1.0.0")
 
     // Testing
-    testImplementation("androidx.test:core:1.6.1")
-    testImplementation("junit:junit:4.13.2")
+    val androidXTestVersion = "1.6.1"
+    val junitVersion = "4.13.2"
+    testImplementation("androidx.test:core:$androidXTestVersion")
+    testImplementation("junit:junit:$junitVersion")
     testImplementation("org.robolectric:robolectric:4.13")
+
+    androidTestImplementation("androidx.test:core:$androidXTestVersion")
+    androidTestImplementation("junit:junit:$junitVersion")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:$androidXTestVersion")
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 }
 
 tasks.withType<SpotBugsTask>().configureEach {

--- a/app/src/androidTest/java/protect/card_locker/MainActivitySearchViewTest.java
+++ b/app/src/androidTest/java/protect/card_locker/MainActivitySearchViewTest.java
@@ -1,0 +1,72 @@
+package protect.card_locker;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withChild;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import android.os.Build;
+
+import androidx.appcompat.widget.Toolbar;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class MainActivitySearchViewTest {
+
+    @Test
+    public void onAndroid13WhenSearchViewIsExpandedAndBackIsPressedThenMenuItemShouldNotBeCollapsed() {
+        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU);
+        String query = "random arbitrary text";
+        try (ActivityScenario<MainActivity> mainActivityScenario = ActivityScenario.launch(MainActivity.class)) {
+            mainActivityScenario.onActivity(this::makeSearchMenuItemVisible);
+            onView(withId(R.id.action_search)).perform(click());
+            onView(withId(androidx.appcompat.R.id.search_src_text)).perform(typeText(query));
+
+            pressBack();
+
+            onView(withId(androidx.appcompat.R.id.search_src_text)).check(matches(withText(query)));
+            mainActivityScenario.onActivity(activity -> assertEquals(query, activity.mFilter));
+        }
+    }
+
+    @Test
+    public void onAndroid13WhenSearchViewIsExpandedThenItShouldOnlyBeCollapsedWhenBackIsPressedTwice() {
+        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU);
+        try (ActivityScenario<MainActivity> mainActivityScenario = ActivityScenario.launch(MainActivity.class)) {
+            mainActivityScenario.onActivity(this::makeSearchMenuItemVisible);
+            onView(withId(R.id.action_search)).perform(click());
+
+            pressBack();
+
+            onView(withId(androidx.appcompat.R.id.search_src_text)).check(matches(isDisplayed()));
+
+            pressBack();
+
+            onView(withId(android.R.id.content)).check(matches(is(not(withChild(withId(androidx.appcompat.R.id.search_src_text))))));
+        }
+    }
+
+    private void makeSearchMenuItemVisible(MainActivity activity) {
+        Toolbar toolbar = activity.findViewById(R.id.toolbar);
+        toolbar.getMenu().findItem(R.id.action_search).setVisible(true);
+    }
+
+    private void pressBack() {
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack();
+    }
+
+}

--- a/app/src/androidTest/java/protect/card_locker/MainActivitySearchViewTest.java
+++ b/app/src/androidTest/java/protect/card_locker/MainActivitySearchViewTest.java
@@ -11,9 +11,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
-
-import android.os.Build;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.test.core.app.ActivityScenario;
@@ -28,8 +25,7 @@ import org.junit.runner.RunWith;
 public class MainActivitySearchViewTest {
 
     @Test
-    public void onAndroid13WhenSearchViewIsExpandedAndBackIsPressedThenMenuItemShouldNotBeCollapsed() {
-        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU);
+    public void whenSearchViewIsExpandedAndBackIsPressedThenMenuItemShouldNotBeCollapsed() {
         String query = "random arbitrary text";
         try (ActivityScenario<MainActivity> mainActivityScenario = ActivityScenario.launch(MainActivity.class)) {
             mainActivityScenario.onActivity(this::makeSearchMenuItemVisible);
@@ -44,8 +40,7 @@ public class MainActivitySearchViewTest {
     }
 
     @Test
-    public void onAndroid13WhenSearchViewIsExpandedThenItShouldOnlyBeCollapsedWhenBackIsPressedTwice() {
-        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU);
+    public void whenSearchViewIsExpandedThenItShouldOnlyBeCollapsedWhenBackIsPressedTwice() {
         try (ActivityScenario<MainActivity> mainActivityScenario = ActivityScenario.launch(MainActivity.class)) {
             mainActivityScenario.onActivity(this::makeSearchMenuItemVisible);
             onView(withId(R.id.action_search)).perform(click());


### PR DESCRIPTION
Fixes #1977.

On Android 13 and later with `android:enableOnBackInvokedCallback="true"`, for some reason pressing Back while the `SearchView` is open and the keyboard is shown simultaneously hides the keyboard and collapses the search view at the same time.

My solution is to set a listener to the menu item that hosts the `SearchView` that hides the keyboard if it's shown and prevents the item from being collapsed (it returns `false`). If the keyboard is hidden then the item is collapsed as normal (it returns `true`).

Alternatives I have tried:
- Remove `android:enableOnBackInvokedCallback="true"` (this is obviously a no go)
- On the [Google's website](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#migrate-app), they mention this:
*You can register an OnBackInvokedCallback with PRIORITY_DEFAULT or PRIORITY_OVERLAY, which is not available in the similar AndroidX OnBackPressedCallback. Registering a callback with PRIORITY_OVERLAY is helpful in some instances. A case where this could apply is when you migrate from onKeyPreIme() and your callback needs to receive the back gesture instead of an open IME. IMEs register callbacks with PRIORITY_DEFAULT when opened. Register your callback with PRIORITY_OVERLAY to ensure OnBackInvokedDispatcher dispatches the back gesture to your callback instead of the open IME.*
According to them I can basically "override"(?) the keyboard's back gesture, but when I tried it on a API 35 (android 15) emulator and a API 33 (android 13) phone, the `OnBackInvokedCallback` I registered isn't called at all when the keyboard is open (the keyboard still closes as if nothing happened).

I also added Espresso UI tests for the 2 scenarios:
- Something is typed into the search view and the keyboard is shown, and "back" is pressed - the `SearchView` should be still expanded and the query should remain.
- The `SearchView` is expanded and the keyboard shown and it should take 2 back presses to collapse it instead of 1.

One thing to notice is that I use the [UI Automator](https://developer.android.com/training/testing/other-components/ui-automator?hl=en) library to simulate Back presses. Since as I said earlier, the `OnBackInvokedCallback` and by extension the AndroidX `OnBackPressedCallback` doesn't work when the keyboard is shown, calling `activity.getOnBackPressedDispatcher().onBackPressed()` is incorrect as it only simulates Back presses *when the keyboard is hidden*.