### PR TITLE
Remove unused strings from string.xml

### DIFF
--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -250,37 +250,6 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         mGroup = null;
         updateLoyaltyCardList(true);
 
-        /*
-         * This was added for Huawei, but Huawei is just too much of a fucking pain.
-         * Just leaving this commented out if needed for the future idk
-         * https://twitter.com/SylvieLorxu/status/1379437902741012483
-         *
-
-        // Show privacy policy on first run
-        SharedPreferences privacyPolicyShownPref = getApplicationContext().getSharedPreferences(
-                getString(R.string.sharedpreference_privacy_policy_shown),
-                Context.MODE_PRIVATE);
-
-
-        if (privacyPolicyShownPref.getInt(getString(R.string.sharedpreference_privacy_policy_shown), 0) == 0) {
-            SharedPreferences.Editor privacyPolicyShownPrefEditor = privacyPolicyShownPref.edit();
-            privacyPolicyShownPrefEditor.putInt(getString(R.string.sharedpreference_privacy_policy_shown), 1);
-            privacyPolicyShownPrefEditor.apply();
-
-            new AlertDialog.Builder(this)
-                    .setTitle(R.string.privacy_policy)
-                    .setMessage(R.string.privacy_policy_popup_text)
-                    .setPositiveButton(R.string.accept, null)
-                    .setNegativeButton(R.string.privacy_policy, new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int whichButton) {
-                            openPrivacyPolicy();
-                        }
-                    })
-                    .setIcon(android.R.drawable.ic_dialog_info)
-                    .show();
-        }
-         */
-
         mBarcodeScannerLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
             // Exit early if the user cancelled the scan (pressed back/home)
             if (result.getResultCode() != RESULT_OK) {

--- a/app/src/main/res/drawable/ic_baseline_unfold_less_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_unfold_less_24.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="?attr/colorControlNormal"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M7.41,18.59L8.83,20 12,16.83 15.17,20l1.41,-1.41L12,14l-4.59,4.59zM16.59,5.41L15.17,4 12,7.17 8.83,4 7.41,5.41 12,10l4.59,-4.59z"/>
-</vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -119,7 +119,6 @@
     <string name="settings_blue_theme">أزرق</string>
     <string name="settings_sky_blue_theme">أزرق سماوي</string>
     <string name="settings_green_theme">أخضر</string>
-    <string name="settings_grey_theme">رمادي</string>
     <string name="settings_brown_theme">بني</string>
     <string name="app_contributors">أصبح ممكنًا بواسطة: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="sort">فرز</string>
@@ -253,14 +252,6 @@
     <string name="welcome">مرحبا بك في كاتيما</string>
     <string name="updateBalanceTitle">كم أنفقت أو استلمت؟</string>
     <string name="currentBalanceSentence">الرصيد الحالي: <xliff:g> %s </xliff:g></string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="zero">عرض الأرشيف (<xliff:g>%1$d</xliff:g> بطاقة)</item>
-        <item quantity="one">عرض الأرشيف (<xliff:g>%1$d</xliff:g> بطاقة)</item>
-        <item quantity="two">عرض الأرشيف (<xliff:g>%1$d</xliff:g> بطاقتين)</item>
-        <item quantity="few">عرض الأرشيف (<xliff:g>%1$d</xliff:g> بطاقات)</item>
-        <item quantity="many">عرض الأرشيف (<xliff:g>%1$d</xliff:g> بطاقات)</item>
-        <item quantity="other">عرض الأرشيف (<xliff:g>%1$d</xliff:g> بطاقات)</item>
-    </plurals>
     <string name="importCards">استيراد البطاقات</string>
     <string name="newBalanceSentence">الرصيد الجديد: <xliff:g>%s</xliff:g></string>
     <string name="cameraPermissionDeniedTitle">تعذر الوصول إلى الكاميرا</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -237,9 +237,6 @@
     <string name="importLoyaltyCardKeychainMessage">حدد ملفك <i>LoyaltyCardKeychain.csv</i> التصدير من Loyalty Card Keychain للاستيراد.
 \nقم بإنشائه من قائمة الاستيراد / التصدير في Loyalty Card Keychain بالضغط على تصدير هناك أولاً.</string>
     <string name="importStocard">الاستيراد من Stocard</string>
-    <string name="privacy_policy_popup_text">إشعار سياسة الخصوصية (مطلوب من قبل بعض متاجر التطبيقات):
-\n
-\nلا يتم جمع أي بيانات على الإطلاق ، والتي يمكن لأي شخص تأكيدها لأن تطبيقنا هو برنامج حر.</string>
     <string name="failedGeneratingShareURL">تعذر إنشاء عنوان URL قابل للمشاركة. الرجاء الإبلاغ عن هذا.</string>
     <string name="help_translate_this_app">ساعد في ترجمة هذا التطبيق</string>
     <string name="on_google_play">على Google Play</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -157,7 +157,6 @@
     </plurals>
     <string name="app_contributors">Осъществено от: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Кафяво</string>
-    <string name="settings_grey_theme">Сиво</string>
     <string name="settings_green_theme">Зелено</string>
     <string name="settings_sky_blue_theme">Небесносиньо</string>
     <string name="settings_blue_theme">Синьо</string>
@@ -226,10 +225,6 @@
     <string name="nextCard">Следваща</string>
     <string name="failedToOpenUrl">Първо инсталирайте уеб браузър</string>
     <string name="welcome">Добре дошли при Катима</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Преглед на архива (<xliff:g>%1$d</xliff:g> карта)</item>
-        <item quantity="other">Преглед на архива (<xliff:g>%1$d</xliff:g> карти)</item>
-    </plurals>
     <string name="barcodeLongPressMessage">В приложението галерия могат да бъдат отваряни само изображения</string>
     <string name="failedToRetrieveImageFile">Не е възможно извличане на изображение</string>
     <string name="noCameraPermissionDirectToSystemSetting">За да сканирате щрихкодове с Catima е необходим достъп до камерата. За да промените разрешението докоснете тук.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -51,9 +51,6 @@
     <string name="importFidme">Внасяне от FidMe</string>
     <string name="exportOptionExplanation">Данните ще бъдат запазени на място по ваш избор.</string>
     <string name="accept">Приемане</string>
-    <string name="privacy_policy_popup_text">Политика за личните данни (необходима от някои магазини за приложения):
-\n
-\nНЕ СЕ СЪБИРАТ ИЗОБЩО НИКАКВИ ДАННИ, което може да бъде потвърдено, защото приложението е със свободен код.</string>
     <string name="privacy_policy">Политика за личните данни</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="turn_flashlight_off">Изключва светкавицата</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -195,10 +195,6 @@
         <item quantity="other"><xliff:g>%1$d</xliff:g> cards (<xliff:g id="archivedCount">%2$d</xliff:g> archived)</item>
     </plurals>
     <string name="nextCard">পরবর্তী</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">সংরক্ষণাগার দেখুন (<xliff:g>%1$d</xliff:g> কার্ড)</item>
-        <item quantity="other">সংরক্ষণাগার দেখুন (<xliff:g>%1$d</xliff:g> কার্ডগুলি)</item>
-    </plurals>
     <string name="failedToOpenUrl">প্রথমে একটি ওয়েব ব্রাউজার ইন্সটল করুন</string>
     <string name="newBalanceSentence">নতুন ব্যালেন্স: <xliff:g>%s</xliff:g></string>
     <string name="chooseValidFromDate">তারিখ থেকে বৈধ নির্বাচন করুন</string>
@@ -219,7 +215,6 @@
 \nপ্রথমে ভাউচার ভল্টে এক্সপোর্ট টিপে এটি তৈরি করুন।</string>
     <string name="settings_oled_dark">অন্ধকার থিমের জন্য খাঁটি কালো পটভূমি</string>
     <string name="setIcon">আইকন সেট করুন</string>
-    <string name="settings_grey_theme">ধূসর</string>
     <string name="updateBalance">ব্যালেন্স আপডেট করুন</string>
     <string name="barcodeLongPressMessage">গ্যালারি অ্যাপে শুধুমাত্র ছবি খোলা যাবে</string>
     <string name="translate_platform">Weblate-এ</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -173,9 +173,6 @@
     <string name="chooseExpiryDate">মেয়াদ শেষ হওয়ার তারিখ মনোনীত করুন</string>
     <string name="moveBarcodeToTopOfScreen">বারকোডটি স্ক্রিনের উপরে উঠিয়ে দিন</string>
     <string name="errorReadingImage">ছবিটি স্ক্যান করা যাচ্ছে না</string>
-    <string name="privacy_policy_popup_text">ব্যক্তিগত তথ্যের গোপনীয়তা নীতি নোটিশ (কিছু অ্যাপ স্টোরের এটি লাগে):
-\n
-\nকোন তথ্য একেবারেই সংগ্রহ করা হয় না, যা যে কেউ নিশ্চিত করতে পারবেন কারন আমাদের অ্যাপ মুক্ত সফটওয়্যার।</string>
     <string name="balance">ব্যালান্স</string>
     <string name="points">পয়েন্ট</string>
     <string name="chooseImportType">এখান থেকে তথ্য আমদানি করুন</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -12,7 +12,6 @@
     <string name="about">সম্পর্কিত</string>
     <string name="card">কার্ড</string>
     <string name="yes">হ্যাঁ</string>
-    <string name="settings_grey_theme">ধূসর</string>
     <string name="ok">ঠিক আছে</string>
     <string name="sendLabel">পাঠান…</string>
     <string name="sort_by_name">নাম</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -87,7 +87,6 @@
     <string name="moveDown">Přesunout dolů</string>
     <string name="moveUp">Přesunout nahoru</string>
     <string name="settings_brown_theme">Hnědá</string>
-    <string name="settings_grey_theme">Šedá</string>
     <string name="settings_green_theme">Zelená</string>
     <string name="settings_sky_blue_theme">Azurová</string>
     <string name="settings_blue_theme">Modrá</string>
@@ -231,11 +230,6 @@
     <string name="nextCard">Následující</string>
     <string name="failedToOpenUrl">Nejprve nainstalujte webový prohlížeč</string>
     <string name="welcome">Vítejte v Catima</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Zobrazit archiv (<xliff:g>%1$d</xliff:g> karta)</item>
-        <item quantity="few">Zobrazit archiv (<xliff:g>%1$d</xliff:g> karty)</item>
-        <item quantity="other">Zobrazit archiv (<xliff:g>%1$d</xliff:g> karet)</item>
-    </plurals>
     <string name="barcodeLongPressMessage">V aplikaci pro galerii mohou být otevírány pouze obrázky</string>
     <string name="failedToRetrieveImageFile">Nepodařilo se získat soubor obrázku</string>
     <string name="cameraPermissionDeniedTitle">Nelze získat přístup k fotoaparátu</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -134,9 +134,6 @@
 \nVytvoříte jej z nabídky Import/Export jiné aplikace Catima tak, že v ní nejprve stisknete tlačítko Exportovat.</string>
     <string name="importCatima">Import z Catima</string>
     <string name="accept">Přijmout</string>
-    <string name="privacy_policy_popup_text">Oznámení o zásadách ochrany osobních údajů (vyžadováno některými obchody s aplikacemi):
-\n
-\nNejsou shromažďovány žádné údaje, což může potvrdit každý, protože naše aplikace je svobodný software.</string>
     <string name="privacy_policy">Zásady soukromí</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="chooseImportType">Importovat data z</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -158,7 +158,6 @@
     <string name="settings_system_locale">System</string>
     <string name="settings_locale">Sprache</string>
     <string name="settings_brown_theme">Braun</string>
-    <string name="settings_grey_theme">Grau</string>
     <string name="settings_green_theme">Grün</string>
     <string name="settings_sky_blue_theme">Himmelblau</string>
     <string name="settings_blue_theme">Blau</string>
@@ -224,10 +223,6 @@
     <string name="previousCard">Vorherige</string>
     <string name="nextCard">Nächste</string>
     <string name="failedToOpenUrl">Bitte installiere einen Webbrowser</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Archiv ansehen (<xliff:g>%1$d</xliff:g> Karte)</item>
-        <item quantity="other">Archiv ansehen (<xliff:g>%1$d</xliff:g> Karten)</item>
-    </plurals>
     <string name="welcome">Willkommen bei Catima</string>
     <string name="barcodeLongPressMessage">In der Galerie können nur Bilder geöffnet werden</string>
     <string name="failedToRetrieveImageFile">Bilddatei konnte nicht abgerufen werden</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -95,9 +95,6 @@
     <string name="expiryStateSentence">Läuft ab: <xliff:g>%s</xliff:g></string>
     <string name="settings_disable_lockscreen_while_viewing_card">Sperrbildschirm verhindern</string>
     <string name="settings_keep_screen_on">Bildschirm aktiv lassen</string>
-    <string name="privacy_policy_popup_text">Hinweis zum Datenschutz (von einigen App-Stores verlangt):
-\n
-\nKEINE DATEN WERDEN GESAMMELT, was jeder bestätigen kann, da unsere Anwendung eine freie Software ist.</string>
     <string name="accept">Annehmen</string>
     <string name="privacy_policy">Datenschutzrichtlinie</string>
     <string name="importVoucherVaultMessage">Wähle deinen <i>vouchervault.json</i>-Export aus Voucher Vault zum Importieren aus.

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -151,7 +151,6 @@
     <string name="setIcon">Ορισμός εικονιδίου</string>
     <string name="settings_sky_blue_theme">Γαλάζιο</string>
     <string name="settings_green_theme">Πράσινο</string>
-    <string name="settings_grey_theme">Γκρι</string>
     <string name="settings_brown_theme">Καφέ</string>
     <string name="sort_by_expiry">Λήξη</string>
     <plurals name="groupCardCount">
@@ -230,10 +229,6 @@
     <string name="updateBalance">Ενημέρωση υπολοίπου</string>
     <string name="barcodeLongPressMessage">Μόνο εικόνες μπορούν να ανοιχτούν στην εφαρμογή φωτογραφιών</string>
     <string name="noCameraPermissionDirectToSystemSetting">Για να σκανάρετε γραμμωτούς κώδικες, θα χρειαστεί πρόσβαση στην κάμερα από το Catima. Πατήστε εδώ για να δώσετε πρόσβαση.</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Προβολή αρχείου (<xliff:g>%1$d</xliff:g> κάρτας)</item>
-        <item quantity="other">Προβολή αρχείου (<xliff:g>%1$d</xliff:g> καρτών)</item>
-    </plurals>
     <string name="importCards">Εισαγωγή καρτών</string>
     <string name="updateBalanceHint">Εισάγετε ποσό</string>
     <string name="currentBalanceSentence">Τωρινό υπόλοιπο <xliff:g>%s</xliff:g></string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -115,9 +115,6 @@
     <string name="privacy_policy">Πολιτική απορρήτου</string>
     <string name="chooseImportType">Εισαγωγή δεδομένων από</string>
     <string name="app_loyalty_card_keychain">Lοyalty Card Keychain</string>
-    <string name="privacy_policy_popup_text">Σημείωμα πολιτικής απορρήτου ( υποχρεωτικό σε κάποια \"μαγαζιά\" εφαρμογών)
-\n
-\nΜΗΔΕΝΙΚΆ ΔΕΔΟΜΈΝΑ ΣΥΛΛΈΓΟΝΤΑΙ, ο οποιοσδήποτε μπορεί να το επιβεβαιώσει μιας και η εφαρμογή είναι ελεύθερο λογισμικό.</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> κάρτα ( <xliff:g id="archivedCount">%2$d</xliff:g> αρχειοθετήθηκε)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> κάρτες ( <xliff:g id="archivedCount">%2$d</xliff:g> αρχειοθετήθηκαν)</item>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -168,9 +168,6 @@
     <string name="expiryStateSentenceExpired">Eksvalidiĝis: <xliff:g>%s</xliff:g></string>
     <string name="balanceParsingFailed">Nevalida saldo</string>
     <string name="chooseImportType">Importi datumojn de</string>
-    <string name="privacy_policy_popup_text">Regularo pri privateco (postulata de iuj aplikaĵejoj):
-\n
-\nNENIUJ DATUMOJ ESTAS KOLEKTATAJ. Iu ajn povas konfirmi tion ĉar nia apo estas libera programaro.</string>
     <string name="importCatima">Importi el Catima</string>
     <string name="settings_green_theme">Verda</string>
     <string name="updateBalance">Ĝisdatigi saldon</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -173,7 +173,6 @@
 \nNENIUJ DATUMOJ ESTAS KOLEKTATAJ. Iu ajn povas konfirmi tion ĉar nia apo estas libera programaro.</string>
     <string name="importCatima">Importi el Catima</string>
     <string name="settings_green_theme">Verda</string>
-    <string name="settings_grey_theme">Griza</string>
     <string name="updateBalance">Ĝisdatigi saldon</string>
     <string name="barcodeLongPressMessage">Nur bildoj povas esti malfermitaj en la galeria apo</string>
     <string name="sort_by_name">Nomo</string>
@@ -188,10 +187,6 @@
     <string name="report_error">Raporti eraron</string>
     <string name="starred">Markitaj</string>
     <string name="newBalanceSentence">Nova saldo: <xliff:g>%s</xliff:g></string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Montri arkivitan (<xliff:g>%1$d</xliff:g> karton)</item>
-        <item quantity="other">Montri arkivitajn (<xliff:g>%1$d</xliff:g> kartojn)</item>
-    </plurals>
     <string name="anyDate">Iam ajn</string>
     <string name="switchToFrontImage">Ŝanĝi al antaŭa bildo</string>
     <string name="openFrontImageInGalleryApp">Malfermi la antaŭan bildon en galeria apo</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -103,9 +103,6 @@
     <string name="settings_keep_screen_on">Mantener la pantalla encendida</string>
     <string name="setBarcodeId">Establecer valor del código de barras</string>
     <string name="importCatima">Importar desde Catima</string>
-    <string name="privacy_policy_popup_text">Notificación de la política de privacidad (requerida por algunas tiendas de aplicaciones):
-\n
-\nNINGÚN DATO ES RECOPILADO, puede ser comprobado por cualquiera ya que nuestra aplicación es software libre.</string>
     <string name="settings_follow_system_orientation">Seguir el sistema</string>
     <string name="intent_import_card_from_url_share_text">Quiero compartirte una tarjeta</string>
     <string name="addFromImage">Seleccione una imágen desde la galería</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -192,7 +192,6 @@
     <string name="exportPassword">Agregar una contraseña para protejer tu exportación (opcional)</string>
     <string name="settings_sky_blue_theme">Celeste</string>
     <string name="settings_green_theme">Verde</string>
-    <string name="settings_grey_theme">Gris</string>
     <string name="exportPasswordHint">Ingresar contraseña</string>
     <string name="setIcon">Establecer miniatura</string>
     <string name="showMoreInfo">Mostrar información</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -161,7 +161,6 @@
     </plurals>
     <string name="app_contributors">Hecho posible por: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Marrón</string>
-    <string name="settings_grey_theme">Gris</string>
     <string name="settings_green_theme">Verde</string>
     <string name="settings_sky_blue_theme">Azul cielo</string>
     <string name="settings_blue_theme">Azul</string>
@@ -210,11 +209,6 @@
     <string name="rate_this_app">Califica esta aplicación</string>
     <string name="options">Opciones</string>
     <string name="failedToOpenUrl">Instale primero un navegador web</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Ver archivo (<xliff:g>%1$d</xliff:g> tarjeta)</item>
-        <item quantity="many">Ver archivo (<xliff:g>%1$d</xliff:g> tarjetas)</item>
-        <item quantity="other">Ver archivo (<xliff:g>%1$d</xliff:g> tarjetas)</item>
-    </plurals>
     <string name="welcome">Bienvenido/a a Catima</string>
     <string name="group_name_already_in_use">Nombre del grupo ya está en uso</string>
     <string name="group_name_is_empty">El nombre del grupo no debe estar vacío</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -128,9 +128,6 @@
     <string name="importFidme">Importar desde FidMe</string>
     <string name="importCatima">Importar desde Catima</string>
     <string name="accept">Aceptar</string>
-    <string name="privacy_policy_popup_text">Aviso de política de privacidad (requerido por algunas tiendas de apps):
-\n
-\nNINGÚN DATO SE RECOPILA, cualquiera puede confirmar ya que nuestra aplicación es software libre.</string>
     <string name="privacy_policy">Política de privacidad</string>
     <string name="app_loyalty_card_keychain">Llavero con tarjeta de fidelización</string>
     <string name="chooseImportType">Importar datos de</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -157,7 +157,6 @@
     <string name="turn_flashlight_off">Sammuta salamavalo</string>
     <string name="app_contributors">Mahdollistanut: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Ruskea</string>
-    <string name="settings_grey_theme">Harmaa</string>
     <string name="settings_green_theme">Vihreä</string>
     <string name="settings_sky_blue_theme">Taivaansininen</string>
     <string name="settings_blue_theme">Siniset</string>
@@ -224,10 +223,6 @@
     <string name="nextCard">Seuraava</string>
     <string name="failedToOpenUrl">Asenna ensin verkkoselain</string>
     <string name="welcome">Tervetuloa Catimaan</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Näytä arkisto (<xliff:g>%1$d</xliff:g> kortti)</item>
-        <item quantity="other">Näytä arkisto (<xliff:g>%1$d</xliff:g> korttia)</item>
-    </plurals>
     <string name="updateBalanceTitle">Kuinka paljon kulutit tai tienasit?</string>
     <string name="updateBalanceHint">Syötä summa</string>
     <string name="barcodeLongPressMessage">Vain kuvia on mahdollista avata galleriasovelluksessa</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -23,9 +23,6 @@
 \nLuo se Catima-sovelluksen Tuo/vie-valikosta painamalla siellä ensin Vie.</string>
     <string name="importCatima">Tuo Catima varmuuskopiotiedostosta</string>
     <string name="accept">Hyväksy</string>
-    <string name="privacy_policy_popup_text">Tietosuojaseloste (joidenkin sovelluskauppojen vaatimus):
-\n
-\nMITÄÄN TIETOJA EI KERÄTÄ LAINKAAN, minkä kuka tahansa voi vahvistaa, koska sovelluksemma on vapaa ohjelmisto.</string>
     <string name="privacy_policy">Tietosuojakäytäntö</string>
     <string name="app_loyalty_card_keychain">Kanta-asiakaskortin avainnippu</string>
     <string name="chooseImportType">Tuo tietoja kohteesta</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -161,7 +161,6 @@
     <string name="settings_system_locale">Système</string>
     <string name="settings_locale">Langue</string>
     <string name="settings_brown_theme">Marron</string>
-    <string name="settings_grey_theme">Gris</string>
     <string name="settings_green_theme">Vert</string>
     <string name="settings_sky_blue_theme">Bleu ciel</string>
     <string name="settings_blue_theme">Bleu</string>
@@ -230,11 +229,6 @@
     <string name="nextCard">Suivant</string>
     <string name="previousCard">Précédent</string>
     <string name="failedToOpenUrl">Installez d\'abord un navigateur web</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Voir les archives (<xliff:g>%1$d</xliff:g> carte)</item>
-        <item quantity="many">Voir les archives (<xliff:g>%1$d</xliff:g> cartes)</item>
-        <item quantity="other">Voir les archives (<xliff:g>%1$d</xliff:g> cartes)</item>
-    </plurals>
     <string name="welcome">Bienvenue dans Catima</string>
     <string name="barcodeLongPressMessage">Seules les images peuvent être ouvertes dans l’application galerie</string>
     <string name="failedToRetrieveImageFile">Impossible de récupérer le fichier image</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -80,9 +80,6 @@
     </plurals>
     <string name="groupsList">Groupes : <xliff:g>%s</xliff:g></string>
     <string name="accept">Accepter</string>
-    <string name="privacy_policy_popup_text">Avis sur la politique de confidentialité (exigé par certains magasins d’applications) :
-\n
-\nAUCUNE DONNÉE N’EST COLLECTÉE, ce que tout le monde peut confirmer puisque notre application est un logiciel libre.</string>
     <string name="privacy_policy">Politique de confidentialité</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="chooseImportType">Importer les données depuis</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -110,9 +110,6 @@
         <item quantity="one"><xliff:g>%s</xliff:g> बिंदु</item>
         <item quantity="other"><xliff:g>%s</xliff:g> अंक</item>
     </plurals>
-    <string name="privacy_policy_popup_text">निजता नीति नोटिस (कुछ ऐप स्टोर के लिए आवश्यक):
-\n
-\nकोई भी डेटा एकत्र नहीं किया जाता है, जिसकी पुष्टि कोई भी कर सकता है क्योंकि हमारा ऐप मुफ्त सॉफ्टवेयर है।</string>
     <string name="importCatimaMessage">आयात करने के लिए, <i>catima.zip</i> फाइल को चुने जो की Catima से निर्यात किया गया था.
 \nदूसरे Catima ऍप के आयात/निर्यात मेनू से निर्यात बटन दबाकर, पहले catima.zip फाइल को बनाये.</string>
     <plurals name="selectedCardCount">

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -200,7 +200,6 @@
     <string name="options">विकल्प</string>
     <string name="settings_magenta_theme">मैजेंटा</string>
     <string name="failedGeneratingShareURL">साझा करने योग्य यूआरएल जैनरेट नहीं किया जा सकता. कृपया इसकी रिपोर्ट करें।</string>
-    <string name="settings_grey_theme">स्लेटी</string>
     <string name="sort_by_most_recently_used">सबसे हाल ही में उपयोग किया गया</string>
     <string name="settings_theme_color">थीम रंग</string>
     <string name="settings_sky_blue_theme">आसमानी नीला</string>
@@ -250,10 +249,6 @@
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> कार्ड (<xliff:g id="archivedCount">%2$d</xliff:g> संग्रहीत)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> कार्ड (<xliff:g id="archivedCount">%2$d</xliff:g> संग्रहीत)</item>
-    </plurals>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">संग्रह देखें (<xliff:g>%1$d</xliff:g> कार्ड)</item>
-        <item quantity="other">संग्रह देखें (<xliff:g>%1$d</xliff:g> कार्ड)</item>
     </plurals>
     <string name="updateBalanceTitle">आपने कितना खर्च या प्राप्त किया?</string>
     <string name="chooseValidFromDate">दिनांक से वैध चुनें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -97,7 +97,6 @@
     <string name="setIcon">Postavi sličicu</string>
     <string name="settings_catima_theme">Catima</string>
     <string name="settings_green_theme">Zelena</string>
-    <string name="settings_grey_theme">Siva</string>
     <string name="sort_by_expiry">Istek</string>
     <string name="barcodeImageDescriptionWithType">Slika vrste crtičnog koda <xliff:g>%s</xliff:g></string>
     <string name="importLoyaltyCardKeychain">Uvezi iz Loyalty Card Keychain</string>
@@ -256,11 +255,6 @@
     <string name="updateBalanceHint">Upiši iznos</string>
     <string name="about_title_fmt">Informacije o <xliff:g id="app_name">%s</xliff:g></string>
     <string name="failedToOpenUrl">Najprije instaliraj web preglednik</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Pogledaj arhivu (<xliff:g>%1$d</xliff:g> kartica)</item>
-        <item quantity="few">Pogledaj arhivu (<xliff:g>%1$d</xliff:g> kartice)</item>
-        <item quantity="other">Pogledaj arhivu (<xliff:g>%1$d</xliff:g> kartica)</item>
-    </plurals>
     <string name="icon_header_click_text">Dugim pritiskom uredi sličicu</string>
     <string name="show_name_below_image_thumbnail">Prikaži ime ispod sličice</string>
     <string name="show_note">Prikaži bilješku</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -137,10 +137,7 @@
     <string name="balance">Saldo</string>
     <string name="chooseImportType">Uvezi podatke iz</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
-    <string name="privacy_policy_popup_text">Obavijest o politici privatnosti (obavezna za neke trgovine aplikacija):
-\n
-\nPODACI SE UOPĆE NE PRIKUPLJAJU, što svatko može potvrditi budući da je naša aplikacija slobodan softver.</string>
-    <string name="importCatimaMessage">Odaberi tvoju iz Catima izvezenu <i>catima.zip</i> datoteku koju želiš uvesti. 
+    <string name="importCatimaMessage">Odaberi tvoju iz Catima izvezenu <i>catima.zip</i> datoteku koju želiš uvesti.
 \nStvori je putem izbornika „Uvoz/Izvoz” jedne druge Catima aplikacije pritiskom na „Izvoz”.</string>
     <string name="height">Visina:</string>
     <string name="switchToFrontImage">Prebaci na prednju sliku</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -62,7 +62,6 @@
     <string name="exportPasswordHint">Kód beírása</string>
     <string name="failedGeneratingShareURL">Nem lehetett megosztható webcímet előállítani. Kérjük, ezt jelentse.</string>
     <string name="settings_theme_color">Téma színe</string>
-    <string name="settings_grey_theme">Szürke</string>
     <string name="sort">Rendezés</string>
     <string name="on_google_play">a Google Playen</string>
     <string name="and_data_usage">és adathasználat</string>
@@ -233,10 +232,6 @@
     <string name="barcodeLongPressMessage">Csak képek nyithatók meg a galéria alkalmazásban</string>
     <string name="unarchived">Kártya archiválása megszüntetve</string>
     <string name="welcome">Üdvözöljük a Catimában</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Archívum megtekintése (<xliff:g>%1$d</xliff:g> kártya)</item>
-        <item quantity="other">Archívum megtekintése (<xliff:g>%1$d</xliff:g> kártya)</item>
-    </plurals>
     <string name="updateBalance">Egyenleg frissítése</string>
     <string name="noCameraPermissionDirectToSystemSetting">A vonalkódok leolvasásához a Catimának hozzá kell férnie a kamerához. Koppintson ide az engedélybeállítások módosításához.</string>
     <string name="validFromDate">Érvényesség kezdete</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -198,9 +198,6 @@
     <string name="groupsList">Csoportok: <xliff:g>%s</xliff:g></string>
     <string name="importCatimaMessage">Válassza ki az exportált <i>catima.zip</i> fájlt az importáláshoz.
 \nLétrehozhatja az Importálás/exportálás menüből az Exportálást megnyomva egy másik Catima alkalmazásban.</string>
-    <string name="privacy_policy_popup_text">Adatvédelmi irányelvek nyilatkozata (némely alkalmazásbolt kéri):
-\n
-\nSEMMILYEN ADAT NEM KERÜL GYŰJTÉSRE, amit bárki ellenőrizhet, hiszen az alkalmazás szabad szoftver.</string>
     <string name="importFidmeMessage">Válassza ki a FidMeből exportált <i>fidme-export-request-xxxxxx.zip</i> fájl majd importálja be, és utána válassza a kézi vonalkódbeírást.
 \nEzt hozza létre a FidMe-profiljában az Adatvédelem rész választásával, majd a Saját adatok kinyerése megnyomásával.</string>
     <string name="settings_card_orientation">Vonalkód tájolása</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -135,9 +135,6 @@
     <string name="points">Poin</string>
     <string name="app_loyalty_card_keychain">Gantungan kunci kartu kesetiaan</string>
     <string name="privacy_policy">Kebijakan Privasi</string>
-    <string name="privacy_policy_popup_text">Pemberitahuan kebijakan privasi (diperlukan oleh beberapa toko aplikasi): 
-\n
-\nTIDAK ADA DATA YANG DIKUMPULKAN SAMA SEKALI, yang dapat dikonfirmasi oleh siapa pun karena aplikasi kami adalah libre software.</string>
     <string name="importCatimaMessage">Pilih ekspor <i>catima.zip</i> Anda dari Catima untuk diimpor.
 \nBuat dari menu Impor/Ekspor aplikasi Catima lain dengan menekan Ekspor di sana terlebih dahulu.</string>
     <string name="importFidmeMessage">Pilih ekspor <i>fidme-export-request-xxxxxx.zip</i> Anda dari FidMe untuk diimpor, dan pilih jenis barcode secara manual setelahnya.

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -55,7 +55,6 @@
     <string name="settings_blue_theme">Biru</string>
     <string name="settings_green_theme">Hijau</string>
     <string name="settings_sky_blue_theme">Biru Langit</string>
-    <string name="settings_grey_theme">Abu-abu</string>
     <string name="settings_brown_theme">Cokelat</string>
     <string name="settings_violet_theme">Ungu</string>
     <string name="settings_magenta_theme">Magenta</string>
@@ -199,9 +198,6 @@
     <string name="translate_platform">di Weblate</string>
     <string name="welcome">Selamat datang di Catima</string>
     <string name="failedToOpenUrl">Install browser web terlebih dahulu</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="other">Lihat arsip (<xliff:g>%1$d</xliff:g> kartu)</item>
-    </plurals>
     <string name="failedLaunchingPhotoPicker">Tidak dapat menemukan aplikasi galeri yang didukung</string>
     <string name="previousCard">Sebelumnya</string>
     <string name="nextCard">Berikutnya</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -81,7 +81,6 @@
     <string name="noGiftCardsGroup">Búðu til nokkur kort og settu þau síðan í hópinn hér.</string>
     <string name="settings_brown_theme">Brún</string>
     <string name="settings_green_theme">Grænn</string>
-    <string name="settings_grey_theme">Grár</string>
     <string name="sort">flokka</string>
     <string name="sort_by">flokka Eftir</string>
     <string name="nextCard">Næsta</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -161,7 +161,6 @@
     <string name="settings_system_locale">Sistema</string>
     <string name="settings_locale">Lingua</string>
     <string name="settings_brown_theme">Marrone</string>
-    <string name="settings_grey_theme">Grigio</string>
     <string name="settings_green_theme">Verde</string>
     <string name="settings_sky_blue_theme">Azzurro</string>
     <string name="settings_blue_theme">Blu</string>
@@ -231,11 +230,6 @@
     <string name="nextCard">Successivo</string>
     <string name="welcome">Benvenuti su Catima</string>
     <string name="failedToOpenUrl">Installa prima un browser web</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Visualizza archivio (<xliff:g>%1$d</xliff:g> scheda)</item>
-        <item quantity="many">Visualizza archivio (<xliff:g>%1$d</xliff:g> carta)</item>
-        <item quantity="other">Visualizza archivio (<xliff:g>%1$d</xliff:g> carte)</item>
-    </plurals>
     <string name="failedToRetrieveImageFile">Impossibile ottenere il file dell\'immagine</string>
     <string name="barcodeLongPressMessage">Si possono aprire solo immagini dell\'app della galleria</string>
     <string name="cameraPermissionDeniedTitle">È impossibile accedere alla fotocamera</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -96,9 +96,6 @@
     <string name="chooseImportType">Importa i dati da</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Impedisci il blocco dello schermo</string>
     <string name="accept">Accetta</string>
-    <string name="privacy_policy_popup_text">Informativa sulla riservatezza (richiesta da alcuni app store):
-\n
-\nNESSUN DATO VIENE RACCOLTO, cosa che chiunque può confermare dato che la nostra applicazione è un software libero.</string>
     <string name="privacy_policy">Informativa sulla riservatezza</string>
     <string name="importVoucherVaultMessage">Seleziona il tuo file di esportazione <i>vouchervault.json</i> da Voucher Vault per importarlo.
 \nCrealo premendo prima Esporta in Voucher Vault.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -13,9 +13,6 @@
 \nファイルがない場合、他のCatimaアプリでファイルをエクスポートしてください。</string>
     <string name="importCatima">Catimaからインポート</string>
     <string name="accept">承認</string>
-    <string name="privacy_policy_popup_text">プライバシーポリシーの案内:
-\n
-\nこのアプリはユーザーのデータを一切収集しません。</string>
     <string name="privacy_policy">プライバシーポリシー</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="chooseImportType">インポート元を選択</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -151,7 +151,6 @@
     <string name="barcodeImageDescriptionWithType">バーコード形式の画像 <xliff:g>%s</xliff:g></string>
     <string name="app_contributors">Made possible by: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">ブラウン/茶色</string>
-    <string name="settings_grey_theme">グレー/灰色</string>
     <string name="settings_green_theme">グリーン/緑色</string>
     <string name="settings_sky_blue_theme">スカイブルー/水色</string>
     <string name="settings_blue_theme">ブルー/青色</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -223,9 +223,6 @@
     <string name="noGroupCards">이 그룹은 비어 있습니다</string>
     <string name="app_loyalty_card_keychain">로열티 카드 키체인</string>
     <string name="privacy_policy">개인 정보 정책</string>
-    <string name="privacy_policy_popup_text">개인 정보 보호 정책 공지(일부 앱 스토어에서 필요):
-\n
-\n아무런 데이터도 수집하지 않습니다. 우리 앱은 자유 소프트웨어이기 때문에 누구나 이를 확인할 수 있습니다.</string>
     <string name="importCatima">Catima에서 가져오기</string>
     <string name="importCatimaMessage">가져올 Catima에서 <i>catima.zip</i> 내보내기를 선택합니다.
 \n먼저 내보내기를 눌러 다른 Catima 앱의 가져오기/내보내기 메뉴에서 생성합니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -242,13 +242,9 @@
     <string name="importVoucherVaultMessage">가져올 Voucher Vault에서 <i>vouchervault.json</i> 내보내기를 선택합니다.
 \n먼저 바우처 금고에서 내보내기를 눌러 생성하세요.</string>
     <string name="sameAsCardId">아이디와 동일</string>
-    <string name="settings_grey_theme">회색</string>
     <string name="settings_sky_blue_theme">하늘색</string>
     <string name="settings_green_theme">초록색</string>
     <string name="settings_brown_theme">갈색</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="other">보관소 보기 (<xliff:g>%1$d</xliff:g> 카)</item>
-    </plurals>
     <string name="previousCard">이전의</string>
     <string name="nextCard">다음</string>
     <string name="failedToOpenUrl">먼저 웹 브라우저를 설치하십시오</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -75,9 +75,6 @@
 \nSukurkite ją iš kitos Catima programos importavimo / eksportavimo meniu, pirmiausia ten paspausdami Eksportuoti.</string>
     <string name="importCatima">Importuoti iš Catima</string>
     <string name="accept">Priimti</string>
-    <string name="privacy_policy_popup_text">Privatumo politikos pranešimas (kurio reikalaujama kai kuriose programėlių parduotuvėse):
-\n
-\nJOKIE DUOMENYS NĖRA RENKAMI, o tai gali patvirtinti bet kas, nes mūsų programėlė yra laisvoji programinė įranga.</string>
     <string name="privacy_policy">Privatumo politika</string>
     <string name="chooseImportType">Importuoti duomenis iš</string>
     <string name="points">Taškai</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -162,7 +162,6 @@
     <string name="settings_system_locale">Sistemos</string>
     <string name="settings_locale">Kalba</string>
     <string name="settings_brown_theme">Ruda</string>
-    <string name="settings_grey_theme">Pilka</string>
     <string name="settings_green_theme">Žalia</string>
     <string name="settings_sky_blue_theme">Dangaus mėlynumo</string>
     <string name="settings_blue_theme">Mėlyna</string>
@@ -204,11 +203,6 @@
     <string name="failedLaunchingPhotoPicker">Nepavyko rasti palaikomos galerijos programėlės</string>
     <string name="previousCard">Ankstesnė</string>
     <string name="nextCard">Kita</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Peržiūrėti archyvą (<xliff:g>%1$d</xliff:g> kortelė)</item>
-        <item quantity="few">Peržiūrėti archyvą (<xliff:g>%1$d</xliff:g> kortelės)</item>
-        <item quantity="other">Peržiūrėti archyvą (<xliff:g>%1$d</xliff:g> kortelių)</item>
-    </plurals>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> kortelė ( archyvuota)<xliff:g id="archivedCount">%2$d</xliff:g></item>
         <item quantity="few"><xliff:g>%1$d</xliff:g> kortelės ( archyvuotos)<xliff:g id="archivedCount">%2$d</xliff:g></item>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -115,9 +115,6 @@
         <item quantity="other"><xliff:g>%s</xliff:g> punkti</item>
     </plurals>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
-    <string name="privacy_policy_popup_text">Paziņojums par privātuma politiku (nepieciešams dažiem lietotņu veikaliem):
-\n
-\nNEKĀDI DATI NETIEK VĀKTI, par ko var pārliecināties ikkatrs, jo mūsu lietotne ir brīva, atvērta koda programmatūra.</string>
     <string name="importCatimaMessage">Izvēlieties jūstu <i>catima.zip</i> failu importam.
 \nFailu var izveidot eksportējot datus no Catima lietotnes citā ierīce, sadaļā \"Imports/Eksports\".</string>
     <string name="importLoyaltyCardKeychainMessage">Importam izvēlieties Jūsu <i>LoyaltyCardKeychain.csv</i> eksporta failu no Loyalty Card Keychain.

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -212,7 +212,6 @@
     <string name="settings_theme_color">Tēmas krāsa</string>
     <string name="settings_violet_theme">Violeta</string>
     <string name="settings_blue_theme">Zila</string>
-    <string name="settings_grey_theme">Pelēka</string>
     <string name="sort">Kārtot</string>
     <string name="showMoreInfo">Rādīt informāciju</string>
     <string name="sort_by_most_recently_used">Nesen lietotās</string>
@@ -222,11 +221,6 @@
     <string name="failedLaunchingPhotoPicker">Nevarēja atrast atbalstītu galerijas lietotni</string>
     <string name="previousCard">Iepriekšējā</string>
     <string name="nextCard">Nākamā</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="zero">Skatīt arhivētu (<xliff:g>%1$d</xliff:g> karti)</item>
-        <item quantity="one">Skatīt arhivētu (<xliff:g>%1$d</xliff:g> karti)</item>
-        <item quantity="other">Skatīt arhivētas (<xliff:g>%1$d</xliff:g> kartes)</item>
-    </plurals>
     <plurals name="groupCardCountWithArchived">
         <item quantity="zero"><xliff:g>%1$d</xliff:g> card (<xliff:g id="archivedCount">%2$d</xliff:g> arhivēta)</item>
         <item quantity="one"><xliff:g>%1$d</xliff:g> card (<xliff:g id="archivedCount">%2$d</xliff:g> arhivēta)</item>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -159,7 +159,6 @@
     <string name="settings_magenta_theme">Magentarød</string>
     <string name="app_contributors">Muliggjort av: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Brun</string>
-    <string name="settings_grey_theme">Grå</string>
     <string name="settings_green_theme">Grønn</string>
     <string name="settings_sky_blue_theme">Himmelblå</string>
     <string name="settings_blue_theme">Blå</string>
@@ -226,10 +225,6 @@
     </plurals>
     <string name="failedToOpenUrl">Installer en nettleser først</string>
     <string name="welcome">Velkommen til Catima</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Vis arkiv (<xliff:g>%1$d</xliff:g> kort)</item>
-        <item quantity="other">Vis arkiv (<xliff:g>%1$d</xliff:g> kort)</item>
-    </plurals>
     <string name="failedToRetrieveImageFile">Kunne ikke hente bildefil</string>
     <string name="barcodeLongPressMessage">Kun bilder kan åpnes i galleriprogrammet</string>
     <string name="cameraPermissionDeniedTitle">Fikk ikke tilgang til kameraet</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -94,9 +94,6 @@
     <string name="app_loyalty_card_keychain">Kundekortknippe</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Forhindre skjermlås</string>
     <string name="settings_keep_screen_on">Behold skjerm påslått</string>
-    <string name="privacy_policy_popup_text">Personvernspraksis-notis (påkrevd av noen programbutikker):
-\n
-\nINGEN DATA SAMLES INN I DET HELE TATT, noe alle kan bekreftes siden programmet vårt er fri programvare.</string>
     <string name="accept">Godta</string>
     <string name="privacy_policy">Personvernspraksis</string>
     <string name="importFidme">Importer fra FidMe</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -94,9 +94,6 @@
     <string name="app_loyalty_card_keychain">Klantenkaartkluis</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Schermvergrendeling uitschakelen</string>
     <string name="settings_keep_screen_on">Scherm niet uitschakelen</string>
-    <string name="privacy_policy_popup_text">Privacybeleid (vereist door sommige appwinkels):
-\n
-\nER WORDEN GEEN GEGEVENS VERZAMELD. Bovendien is onze app open source, zodat een ieder met eigen ogen kan zien wat de app wel of niet doet.</string>
     <string name="privacy_policy">Privacybeleid</string>
     <string name="accept">Accepteren</string>
     <string name="importVoucherVaultMessage">Kies het te importeren <i>vouchervault.json</i>-exportbestand.

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -158,7 +158,6 @@
     <string name="settings_system_locale">Systeemtaal</string>
     <string name="settings_locale">Taal</string>
     <string name="settings_brown_theme">Bruin</string>
-    <string name="settings_grey_theme">Grijs</string>
     <string name="settings_green_theme">Groen</string>
     <string name="settings_sky_blue_theme">Hemelsblauw</string>
     <string name="settings_blue_theme">Blauw</string>
@@ -226,10 +225,6 @@
     <string name="nextCard">Volgende</string>
     <string name="welcome">Welkom bij Catima</string>
     <string name="failedToOpenUrl">Installeer een webbrowser</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Archief bekijken (<xliff:g>%1$d</xliff:g> kaart)</item>
-        <item quantity="other">Archief bekijken (<xliff:g>%1$d</xliff:g> kaarten)</item>
-    </plurals>
     <string name="failedToRetrieveImageFile">De afbeelding kan niet worden opgehaald</string>
     <string name="barcodeLongPressMessage">Alleen afbeeldingen kunnen worden geopend in de galerij-app</string>
     <string name="cameraPermissionDeniedTitle">Geen cameratoegang</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -71,7 +71,6 @@
     <string name="deleteConfirmation">Usunąć tę kartę na stałe\?</string>
     <string name="app_contributors">Możliwe dzięki: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Brązowy</string>
-    <string name="settings_grey_theme">Szary</string>
     <string name="settings_green_theme">Zielony</string>
     <string name="settings_sky_blue_theme">Błękitny</string>
     <string name="settings_blue_theme">Niebieski</string>
@@ -240,12 +239,6 @@
     <string name="barcodeLongPressMessage">W galerii możesz otworzyć tylko obrazy</string>
     <string name="failedToOpenUrl">Najpierw zainstaluj przeglądarkę</string>
     <string name="welcome">Witaj w Catima</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Wyświetl zarchiwizowaną (<xliff:g>%1$d</xliff:g> kartę)</item>
-        <item quantity="few">Wyświetl zarchiwizowane (<xliff:g>%1$d</xliff:g> karty)</item>
-        <item quantity="many">Wyświetl zarchiwizowane (<xliff:g>%1$d</xliff:g> karty)</item>
-        <item quantity="other">Wyświetl zarchiwizowane (<xliff:g>%1$d</xliff:g> karty)</item>
-    </plurals>
     <string name="currentBalanceSentence">Bieżące saldo: <xliff:g>%s</xliff:g></string>
     <string name="noCameraPermissionDirectToSystemSetting">By zeskanować kody kreskowe, Catima musi mieć dostęp do twojej kamery. Dotknij tutaj by zmienić swoje ustawienia dostępu.</string>
     <string name="updateBalanceTitle">Ile wydałeś lub otrzymałeś?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -118,9 +118,6 @@
 \nUtwórz go z menu Importuj/Eksportuj innej aplikacji Catima, wpierw klikając tam Eksportuj.</string>
     <string name="importCatima">Importuj z Catima</string>
     <string name="accept">Zaakceptuj</string>
-    <string name="privacy_policy_popup_text">Informacja o polityce prywatności (wymagana przez niektóre sklepy z aplikacjami):
-\n
-\nŻADNE DANE NIE SĄ ZBIERANE, co może potwierdzić każdy, gdyż nasza aplikacja jest wolnym oprogramowaniem.</string>
     <string name="privacy_policy">Polityka prywatności</string>
     <string name="app_loyalty_card_keychain">Brelok dla twoich kart lojalnościowych</string>
     <string name="chooseImportType">Importuj dane z</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -277,9 +277,6 @@
     <string name="privacy_policy">Política de Privacidade</string>
     <string name="currency">Moeda</string>
     <string name="chooseImportType">Importar dados de</string>
-    <string name="privacy_policy_popup_text">Declaração de Política de Privacidade
-\n
-\nNENHUM DADO É COLETADO, o que pode ser confimado por qualquer pessoa já que o nosso aplicativo é software livre.</string>
     <string name="importCatima">Importar do Catima</string>
     <string name="balanceParsingFailed">Saldo inválido</string>
     <string name="accept">Aceitar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -137,7 +137,6 @@
     <string name="settings_blue_theme">Azul</string>
     <string name="settings_sky_blue_theme">Azul celeste</string>
     <string name="settings_green_theme">Verde</string>
-    <string name="settings_grey_theme">Cinza</string>
     <string name="settings_brown_theme">Marrom</string>
     <string name="app_contributors">Só foi possível graças a: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="sort">Ordenar</string>
@@ -163,11 +162,6 @@
     <string name="failedToOpenUrl">Instale um navegador primeiro</string>
     <string name="welcome">Bem-vindo(a) ao Catima</string>
     <string name="importCards">Importar cartões</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Ver arquivamento (<xliff:g>%1$d</xliff:g> cartão)</item>
-        <item quantity="many">Ver arquivamento (<xliff:g>%1$d</xliff:g> cartões)</item>
-        <item quantity="other">Ver arquivamento (<xliff:g>%1$d</xliff:g> cartões)</item>
-    </plurals>
     <string name="height">Altura:</string>
     <string name="switchToBarcode">Mudar para código de barras</string>
     <string name="switchToFrontImage">Mudar para imagem frontal</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -100,7 +100,6 @@
     <string name="photos">Fotografias</string>
     <string name="passwordRequired">Introduza a palavra-passe</string>
     <string name="settings_green_theme">Verde</string>
-    <string name="settings_grey_theme">Cinzento</string>
     <string name="settings_brown_theme">Castanho</string>
     <string name="updateBarcodeQuestionTitle">Atualizar o valor do código de barras\?</string>
     <string name="updateBarcodeQuestionText">Alterou o identificador. Também quer atualizar o código de barras para usar o mesmo valor\?</string>
@@ -231,11 +230,6 @@
     <string name="nextCard">Próximo</string>
     <string name="previousCard">Anterior</string>
     <string name="failedToOpenUrl">Instale primeiro um navegador de Internet</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Ver arquivo (<xliff:g>%1$d</xliff:g> cartão)</item>
-        <item quantity="many">Ver arquivo (<xliff:g>%1$d</xliff:g> cartões)</item>
-        <item quantity="other">Ver arquivo (<xliff:g>%1$d</xliff:g> cartões)</item>
-    </plurals>
     <string name="welcome">Bem-vindo ao Catima</string>
     <string name="failedToRetrieveImageFile">Falha ao recuperar o ficheiro de imagem</string>
     <string name="barcodeLongPressMessage">Só podem ser abertas imagens na aplicação da galeria</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -133,9 +133,6 @@
     <string name="points">Pontos</string>
     <string name="app_loyalty_card_keychain">Chaveiro de cartão de fidelidade</string>
     <string name="privacy_policy">Política de privacidade</string>
-    <string name="privacy_policy_popup_text">Aviso de política de privacidade (exigido por algumas lojas de aplicações):
-\n
-\nNENHUM DADO É RECOLHIDO DE FORMA ALGUMA, o que qualquer pessoa pode confirmar, já que a nossa aplicação é um software livre de código-fonte aberto.</string>
     <string name="accept">Aceitar</string>
     <string name="importCatima">Importar do Catima</string>
     <string name="importCatimaMessage">Selecione a exportação <i>catima.zip</i> do Catima a importar.

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -97,11 +97,6 @@
     <string name="intent_import_card_from_url_share_multiple_text">Aș dori să partajez niște carduri cu tine</string>
     <string name="app_copyright_fmt" tools:ignore="PluralsCandidate">Drepturi de autor © 2019–<xliff:g>%d</xliff:g> Sylvia van Os și contribuitorii</string>
     <string name="translate_platform">pe Weblate</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Vizualizați arhiva (<xliff:g>%1$d</xliff:g> card)</item>
-        <item quantity="few">Vizualizați arhiva (<xliff:g>%1$d</xliff:g> carduri)</item>
-        <item quantity="other">Vizualizați arhiva (<xliff:g>%1$d</xliff:g> de carduri)</item>
-    </plurals>
     <string name="card_id_must_not_be_empty">Identificatorul cardului nu poate fi liber</string>
     <string name="duplicateCard">Duplicare</string>
     <string name="balanceParsingFailed">Sold invalid</string>
@@ -215,7 +210,6 @@
     <string name="setBarcodeHeight">Setați înălțimea codului de bare</string>
     <string name="settings_landscape_orientation">Orizontal</string>
     <string name="privacy_policy">Politica de Confidențialitate</string>
-    <string name="settings_grey_theme">Gri</string>
     <string name="importStocardMessage">Selectați exportul dvs. <i>***.zip</i> din Stocard pentru a-l importa.
 \nLuați-l prin e-mail către support@stocardapp.com cerând un export al datelor dumneavoastră.</string>
     <string name="openBackImageInGalleryApp">Deschideți imaginea spate în aplicația galerie</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -177,9 +177,6 @@
     <string name="turn_flashlight_off">Opriți lanterna</string>
     <string name="show_note">Afișați notița</string>
     <string name="report_error">Raportați o eroare</string>
-    <string name="privacy_policy_popup_text">Înștiințare despre politica de confidențialitate (necesar de către unele magazine de aplicații):
-\n
-\nDATELE NU SUNT COLECTATE, și oricine poate confirma deoarece aplicația noastră este software deschis.</string>
     <string name="switchToBackImage">Schimbați la imaginea spate</string>
     <string name="settings_follow_system_orientation">Urmare sistem</string>
     <string name="reverse">...în ordine inversă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -75,9 +75,6 @@
     <string name="expiryStateSentence">Срок действия истекает: <xliff:g>%s</xliff:g></string>
     <string name="points">Баллы</string>
     <string name="addManually">Ручной ввод номера</string>
-    <string name="privacy_policy_popup_text">Уведомление о политике конфиденциальности (требуется некоторыми магазинами приложений):
-\n
-\nНИКАКИЕ ДАННЫЕ НЕ СОБИРАЮТСЯ ВООБЩЕ, что может подтвердить любой, так как наше приложение является свободным программным обеспечением.</string>
     <string name="privacy_policy">Политика конфиденциальности</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="chooseImportType">Откуда импортировать данные</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -168,7 +168,6 @@
     <string name="settings_sky_blue_theme">Голубой</string>
     <string name="settings_catima_theme">Catima</string>
     <string name="settings_brown_theme">Коричневый</string>
-    <string name="settings_grey_theme">Серый</string>
     <string name="settings_green_theme">Зелёный</string>
     <string name="settings_blue_theme">Синий</string>
     <string name="settings_violet_theme">Фиолетовый</string>
@@ -238,12 +237,6 @@
     <string name="previousCard">Предыдущая</string>
     <string name="welcome">Добро пожаловать в Catima</string>
     <string name="failedToOpenUrl">Сначала необходимо установить браузер</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Просмотр архива (<xliff:g>%1$d</xliff:g> карта)</item>
-        <item quantity="few">Просмотр архива (<xliff:g>%1$d</xliff:g> карты)</item>
-        <item quantity="many">Просмотр архива (<xliff:g>%1$d</xliff:g> карт)</item>
-        <item quantity="other">Просмотр архива (<xliff:g>%1$d</xliff:g> карт)</item>
-    </plurals>
     <string name="failedToRetrieveImageFile">Невозможно получить файл изображения</string>
     <string name="barcodeLongPressMessage">В приложении галереи можно открывать только изображения</string>
     <string name="noCameraPermissionDirectToSystemSetting">Для сканирования штрих-кодов Catima требуется доступ к камере устройства. Нажмите здесь, чтобы изменить настройки разрешений.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -217,9 +217,6 @@
     <string name="chooseValidFromDate">Zvoliť dátum platné od</string>
     <string name="validFromSentence">Platnosť od: <xliff:g>%s</xliff:g></string>
     <string name="cameraPermissionRequired">Pre túto akciu je potrebné oprávnenie na prístup k fotoaparátu…</string>
-    <string name="privacy_policy_popup_text">Oznámenie o zásadách ochrany osobných údajov (vyžaduje sa v niektorých obchodoch s aplikáciami):
-\n
-\nNEZHROMAŽĎUJÚ SA VÔBEC ŽIADNE ÚDAJE, čo môže ktokoľvek potvrdiť, keďže naša aplikácia je slobodný softvér.</string>
     <string name="importLoyaltyCardKeychainMessage">Vyberte svoj export <i>LoyaltyCardKeychain.csv</i> z Kľúčenky vernostných kariet, ktorý chcete importovať.
 \nVytvorte ho z ponuky Import/Export v aplikácii Loyalty Card Keychain tak, že tam najprv stlačíte tlačidlo Exportovať.</string>
     <string name="importVoucherVaultMessage">Vyberte svoj <i>vouchervault.json</i> export z Trezoru poukážok pre import.

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -149,7 +149,6 @@
     <string name="settings_blue_theme">Modrá</string>
     <string name="settings_sky_blue_theme">Azurová</string>
     <string name="settings_green_theme">Zelená</string>
-    <string name="settings_grey_theme">Šedá</string>
     <string name="settings_brown_theme">Hnedá</string>
     <string name="sort">Zoradiť</string>
     <string name="help_translate_this_app">Pomôžte preložiť túto aplikáciu</string>
@@ -231,11 +230,6 @@
         <item quantity="one"><xliff:g>%1$d</xliff:g> karta (<xliff:g id="archivedCount">%2$d</xliff:g> archivovaná)</item>
         <item quantity="few"><xliff:g>%1$d</xliff:g> karty (<xliff:g id="archivedCount">%2$d</xliff:g> archivované)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> kariet (<xliff:g id="archivedCount">%2$d</xliff:g> archivovaných)</item>
-    </plurals>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Zobraziť archív (<xliff:g>%1$d</xliff:g> karta)</item>
-        <item quantity="few">Zobraziť archív (<xliff:g>%1$d</xliff:g> karty)</item>
-        <item quantity="other">Zobraziť archív (<xliff:g>%1$d</xliff:g> kariet)</item>
     </plurals>
     <string name="barcodeLongPressMessage">V aplikácii galéria je možné otvoriť iba obrázky</string>
     <string name="cameraPermissionDeniedTitle">Nepodarilo sa získať prístup k fotoaparátu</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -85,7 +85,6 @@
     <string name="help_translate_this_app">Pomagajte pri prevajanju aplikacije</string>
     <string name="version_history">Zgodovina različic</string>
     <string name="settings_brown_theme">Rjava</string>
-    <string name="settings_grey_theme">Siva</string>
     <string name="settings_green_theme">Zelena</string>
     <string name="settings_sky_blue_theme">Sinje modra</string>
     <string name="settings_blue_theme">Modra</string>
@@ -246,12 +245,6 @@
         <item quantity="two"><xliff:g>%1$d</xliff:g> kartici (<xliff:g id="archivedCount">%2$d</xliff:g> arhivirani)</item>
         <item quantity="few"><xliff:g>%1$d</xliff:g> kartice (<xliff:g id="archivedCount">%2$d</xliff:g> arhivirane)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> kartic (<xliff:g id="archivedCount">%2$d</xliff:g> arhiviranih)</item>
-    </plurals>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Poglej arhiv (<xliff:g>%1$d</xliff:g> kartice)</item>
-        <item quantity="two">Poglej arhiv (<xliff:g>%1$d</xliff:g> kartic)</item>
-        <item quantity="few">Poglej arhiv (<xliff:g>%1$d</xliff:g> kartic)</item>
-        <item quantity="other">Poglej arhiv (<xliff:g>%1$d</xliff:g> kartic)</item>
     </plurals>
     <string name="cameraPermissionRequired">Za to dejanje je potrebno dovoljenje za dostop do kamere…</string>
     <string name="storageReadPermissionRequired">Za to dejanje je potrebno dovoljenje za branje iz pomnilnika…</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -206,9 +206,6 @@
     <string name="failedToOpenUrl">Prvo namestite spletni brskalnik</string>
     <string name="welcome">Pozdravljeni v Catimi</string>
     <string name="noGiftCardsGroup">Kreiraj kartice in jim dodeli skupino tukaj.</string>
-    <string name="privacy_policy_popup_text">Obvestilo o politiki zasebnosti (nekatere trgovine aplikacij to zahtevajo):
-\n
-\nPODATKI SE NE ZBIRAJO, kar se lahko preveri v programski kodi, saj je aplikacija prosta programska oprema.</string>
     <plurals name="deleteCardsTitle">
         <item quantity="one">Izbriši <xliff:g>%d</xliff:g> kartico zvestobe</item>
         <item quantity="two">Izbriši <xliff:g>%d</xliff:g> kartici zvestobe</item>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -104,9 +104,6 @@
     <string name="chooseImportType">Uvoz podataka iz</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="privacy_policy">Politika privatnosti</string>
-    <string name="privacy_policy_popup_text">Obaveštenje o politici privatnosti (zahtevano od nekih prodavnica aplikacija): 
-\n
-\nPODACI SE UOPŠTE NE PRIKUPLJAJU, što svako može proveriti jer je naša aplikacija slobodni softver.</string>
     <string name="accept">Prihvati</string>
     <string name="importCatima">Uvezi iz Catime</string>
     <string name="importFidme">Uvoz iz FidMe</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -178,11 +178,6 @@
     <string name="previousCard">Prethodna</string>
     <string name="nextCard">Sledeća</string>
     <string name="failedToOpenUrl">Prvo instalirajte internet pregledač</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Pregledaj arhivu (<xliff:g>%1$d</xliff:g> kartica)</item>
-        <item quantity="few">Pregledaj arhivu (<xliff:g>%1$d</xliff:g> kartice)</item>
-        <item quantity="other">Pregledaj arhivu (<xliff:g>%1$d</xliff:g> kartica)</item>
-    </plurals>
     <string name="welcome">Dobrodošli u Catima aplikaciju</string>
     <string name="importCards">Uvezi kartice</string>
     <string name="updateBalanceTitle">Koliko si potrošio ili primio?</string>
@@ -273,7 +268,6 @@
     <string name="settings_green_theme">Zelena</string>
     <string name="barcodeLongPressMessage">Samo fotografije mogu da se otvore u galerija aplikaciji</string>
     <string name="settings_blue_theme">Plava</string>
-    <string name="settings_grey_theme">Siva</string>
     <string name="translate_platform">na Weblate-u</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> kartica (<xliff:g id="archivedCount">%2$d</xliff:g> arhivirana)</item>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -158,7 +158,6 @@
     <string name="settings_locale">Språk</string>
     <string name="app_contributors">Möjliggjordes av: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Brunt</string>
-    <string name="settings_grey_theme">Grått</string>
     <string name="settings_green_theme">Grönt</string>
     <string name="settings_sky_blue_theme">Himmelblått</string>
     <string name="settings_blue_theme">Blått</string>
@@ -224,10 +223,6 @@
         <item quantity="other"><xliff:g>%1$d</xliff:g> kort (<xliff:g id="archivedCount">%2$d</xliff:g> arkiverade)</item>
     </plurals>
     <string name="failedToOpenUrl">Installera en webbläsare först</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Visa arkiv (<xliff:g>%1$d</xliff:g> card)</item>
-        <item quantity="other">Visa arkiv (<xliff:g>%1$d</xliff:g> cards)</item>
-    </plurals>
     <string name="welcome">Välkommen till Catima</string>
     <string name="importCards">Importera kort</string>
     <string name="cameraPermissionDeniedTitle">Kunde inte komma åt kamera</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -133,9 +133,6 @@
     <string name="exportSuccessfulTitle">Exporten lyckades</string>
     <string name="scanCardBarcode">Skanna streckkod</string>
     <string name="settings_system_theme">Systemtemat</string>
-    <string name="privacy_policy_popup_text">Notis rörande integritetspolicy (krävs av vissa appbutiker):
-\n
-\nINGEN DATA ALLS SAMLAS IN, vilket vem som helst kan bekräfta eftersom vår app är fri programvara.</string>
     <string name="privacy_policy">Integritetspolicy</string>
     <string name="expiryStateSentenceExpired">Förföll: <xliff:g>%s</xliff:g></string>
     <string name="chooseExpiryDate">Välj förfallodatum</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2,7 +2,6 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
     <string name="app_contributors">Katkıda bulunanlar: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="settings_brown_theme">Kahverengi</string>
-    <string name="settings_grey_theme">Gri</string>
     <string name="settings_green_theme">Yeşil</string>
     <string name="settings_sky_blue_theme">Gök mavisi</string>
     <string name="settings_blue_theme">Mavi</string>
@@ -225,10 +224,6 @@
     <string name="previousCard">Önceki</string>
     <string name="nextCard">Sonraki</string>
     <string name="failedToOpenUrl">Önce bir web tarayıcısı kurun</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Arşivi görüntüle (<xliff:g>%1$d</xliff:g> kart)</item>
-        <item quantity="other">Arşivi görüntüle (<xliff:g>%1$d</xliff:g> kart)</item>
-    </plurals>
     <string name="welcome">Catima\'ya Hoş Geldiniz</string>
     <string name="failedToRetrieveImageFile">Resim dosyası alınamadı</string>
     <string name="barcodeLongPressMessage">Galeri uygulamasında yalnızca resimler açılabilir</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -49,9 +49,6 @@
 \nBaşka bir Catima uygulamasının İçe/Dışa aktar menüsündeki \"Dışa aktar\" düğmesine basarak bir tane oluşturun.</string>
     <string name="importCatima">Catima\'dan içe aktar</string>
     <string name="accept">Kabul et</string>
-    <string name="privacy_policy_popup_text">Gizlilik politikası bildirimi (bazı uygulama mağazaları için gerekli):
-\n
-\nHİÇBİR VERİ TOPLANMAMAKTADIR ve uygulamamız özgür yazılım olduğu için bunu herkes doğrulayabilir.</string>
     <string name="privacy_policy">Gizlilik Politikası</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="chooseImportType">Verileri şuradan içe aktar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
-    <string name="privacy_policy_popup_text">Політика конфіденційності (вимагається деякими магазинами):
-\n
-\nЖОДНОЇ ІНФОРМАЦІЇ НЕ ЗБИРАЄТЬСЯ, що може підтвердити будь-хто, адже наш застосунок це вільне програмне забезпечення.</string>
     <string name="noGiftCards">Натисніть кнопку +, щоб додати картку, або ⋮ для імпорту з меню.</string>
     <string name="settings_display_barcode_max_brightness">Яскравіший штрих-код</string>
     <string name="selectBarcodeTitle">Оберіть штрих-код</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -172,7 +172,6 @@
     <string name="settings_system_locale">Системна</string>
     <string name="settings_locale">Мова</string>
     <string name="settings_brown_theme">Коричневий</string>
-    <string name="settings_grey_theme">Сірий</string>
     <string name="settings_green_theme">Зелений</string>
     <string name="settings_sky_blue_theme">Небесно-синій</string>
     <string name="app_contributors">Стало можливим завдяки: <xliff:g id="app_contributors">%s</xliff:g></string>
@@ -236,12 +235,6 @@
     <string name="failedLaunchingPhotoPicker">Підтримуваний застосунок галереї не знайдено</string>
     <string name="previousCard">Попередня</string>
     <string name="nextCard">Наступна</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">Переглянути архів (<xliff:g>%1$d</xliff:g> картка)</item>
-        <item quantity="few">Переглянути архів (<xliff:g>%1$d</xliff:g> картки)</item>
-        <item quantity="many">Переглянути архів (<xliff:g>%1$d</xliff:g> карток)</item>
-        <item quantity="other">Переглянути архів (<xliff:g>%1$d</xliff:g> карток)</item>
-    </plurals>
     <string name="failedToOpenUrl">Спочатку встановіть браузер</string>
     <string name="welcome">Ласкаво просимо до Catima</string>
     <string name="failedToRetrieveImageFile">Збій доступу до файлу зображення</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -112,9 +112,6 @@
     <string name="turn_flashlight_off">Tắt đèn pin</string>
     <string name="show_note">Hiện ghi chú</string>
     <string name="report_error">Báo Lỗi</string>
-    <string name="privacy_policy_popup_text">Thông báo về chính sách quyền riêng tư (yêu cầu bởi vài cửa hàng ứng dụng)
-\n
-\nKHÔNG BẤT KỲ DỮ LIỆU NÀO BỊ THU THẬP, bất cứ ai cũng có thể xác nhận điều này vì ứng dụng của chúng tôi là phần mền mã nguồn mở.</string>
     <string name="passwordRequired">Xin mời nhập mật khẩu</string>
     <string name="settings_follow_system_orientation">Hệ thống theo dõi</string>
     <string name="intent_import_card_from_url_share_text">Tôi muốn chia sẻ thẻ với bạn</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -2,9 +2,6 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
     <string name="translate_platform">trên Weblate</string>
     <string name="failedOpeningFileManager">Cài đặt trình quản lý tập tin trước đã.</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="other">Xem lưu trữ (<xliff:g>%1$d</xliff:g> thẻ)</item>
-    </plurals>
     <string name="intent_import_card_from_url_share_multiple_text">Tôi muốn chia sẻ vài cái thẻ với bạn</string>
     <string name="card_id_must_not_be_empty">ID thẻ không thể bỏ trống</string>
     <string name="duplicateCard">Tạo bản sao</string>
@@ -158,7 +155,6 @@
     <string name="setBarcodeHeight">Đặt chiều cao cho mã vạch</string>
     <string name="settings_landscape_orientation">Ngang</string>
     <string name="privacy_policy">Chính Sách Quyền Riêng Tư</string>
-    <string name="settings_grey_theme">Màu xám</string>
     <string name="enter_group_name">Nhập tên nhóm</string>
     <string name="importStocardMessage">Chọn <i>***.zip</i> được xuất từ Stocard để nhập liệu.
 \nLấy tập tin này bằng cách gửi thư yêu cầu xuất dữ liệu đến support@stocardapp.com.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -169,7 +169,6 @@
     <string name="source_repository">源码库</string>
     <string name="include_if_asking_support">请求帮助时，请填写下列信息：</string>
     <string name="exportPasswordHint">输入密码</string>
-    <string name="settings_grey_theme">灰色</string>
     <string name="sort">排序</string>
     <string name="version_history">历史版本</string>
     <string name="rate_this_app">给这个应用评分</string>
@@ -223,9 +222,6 @@
     <string name="welcome">欢迎使用Catima</string>
     <string name="updateBalanceHint">输入金额</string>
     <string name="importCards">导入卡</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="other">查看存档（<xliff:g>%1$d</xliff:g> 张卡片）</item>
-    </plurals>
     <string name="updateBalance">更新余额</string>
     <string name="updateBalanceTitle">你支出或者收到了多少钱？</string>
     <string name="currentBalanceSentence">当前余额：<xliff:g>%s</xliff:g></string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -32,9 +32,6 @@
 \n先按另一个 Catima 应用程序导入/导出菜单中“导出”创建文件。</string>
     <string name="importCatima">从 Catima 导入</string>
     <string name="accept">接受</string>
-    <string name="privacy_policy_popup_text">隐私政策通知（一些应用程序商店要求）。
-\n
-\n本应用没有收集任何数据，任何人都可以查阅源码来确认，因为本软件是自由软件。</string>
     <string name="privacy_policy">隐私政策</string>
     <string name="app_loyalty_card_keychain">会员卡卡包</string>
     <string name="chooseImportType">数据导入源</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -87,7 +87,6 @@
     <string name="settings_blue_theme">藍色</string>
     <string name="settings_sky_blue_theme">天空藍</string>
     <string name="settings_green_theme">綠色</string>
-    <string name="settings_grey_theme">灰色</string>
     <string name="settings_brown_theme">棕色</string>
     <string name="sort_by_name">名稱</string>
     <string name="sort_by_most_recently_used">最近使用</string>
@@ -220,9 +219,6 @@
     <string name="previousCard">上一張</string>
     <string name="nextCard">下一張</string>
     <string name="welcome">歡迎使用 Catima</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="other">檢視封存（<xliff:g>%1$d</xliff:g> 張卡片）</item>
-    </plurals>
     <string name="settings_lock_on_opening_orientation">開啟卡片時鎖定的方向</string>
     <string name="importCards">導入卡片</string>
     <string name="noCameraPermissionDirectToSystemSetting">Catima 需要鏡頭使用權才能夠掃描條碼， 點擊這裏更變你的權限設定。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -9,9 +9,6 @@
     <string name="cardId">卡片 ID</string>
     <string name="barcodeType">條碼種類</string>
     <string name="noBarcode">無條碼</string>
-    <string name="privacy_policy_popup_text">隱私權政策（某些應用程式商店需要此條目）: 
-\n
-\n我們並不會收集任何資料！任何人都可以檢視我們的原始碼並驗證這點。</string>
     <string name="star">新增至收藏</string>
     <string name="app_license">公共版權（Copylefted）的自由軟體，許可 GPLv3+</string>
     <string name="unstar">從收藏中移除</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,7 +21,6 @@
     <!-- Padding for layouts-->
     <dimen name="activity_scanner_padding">10dp</dimen>
     <dimen name="alert_dialog_content_padding">@dimen/mtrl_alert_dialog_picker_background_inset</dimen>
-    <dimen name="alert_dialog_title_padding">8dp</dimen>
     <!-- The default letter tile text size -->
     <dimen name="tileLetterFontSize">66sp</dimen>
     <dimen name="tileLetterFontSizeForShortcut">48dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,6 @@
     <string name="settings_key_allow_content_provider_read" translatable="false">pref_allow_content_provider_read</string>
     <string name="settings_key_oled_dark" translatable="false">pref_oled_dark</string>
     <string name="sharedpreference_active_tab" translatable="false">sharedpreference_active_tab</string>
-    <string name="sharedpreference_privacy_policy_shown" translatable="false">sharedpreference_privacy_policy_shown</string>
     <string name="sharedpreference_sort" translatable="false">sharedpreference_sort</string>
     <string name="sharedpreference_sort_order" translatable="false">sharedpreference_sort_order</string>
     <string name="sharedpreference_sort_direction" translatable="false">sharedpreference_sort_direction</string>
@@ -181,7 +180,6 @@
     <string name="chooseImportType">Import data from</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="privacy_policy">Privacy Policy</string>
-    <string name="privacy_policy_popup_text">Privacy policy notice (required by some app stores):\n\nNO DATA IS COLLECTED AT ALL, which anyone can confirm since our app is libre software.</string>
     <string name="accept">Accept</string>
     <string name="importCatima">Import from Catima</string>
     <string name="importCatimaMessage">Select your <i>catima.zip</i> export from Catima to import.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,7 +237,6 @@
     <string name="settings_blue_theme">Blue</string>
     <string name="settings_sky_blue_theme">Sky blue</string>
     <string name="settings_green_theme">Green</string>
-    <string name="settings_grey_theme">Grey</string>
     <string name="settings_brown_theme">Brown</string>
     <string name="settings_key_catima_theme" translatable="false">catima_theme</string>
     <string name="settings_key_pink_theme" translatable="false">pink_theme</string>
@@ -246,7 +245,6 @@
     <string name="settings_key_blue_theme" translatable="false">blue_theme</string>
     <string name="settings_key_sky_blue_theme" translatable="false">sky_blue_theme</string>
     <string name="settings_key_green_theme" translatable="false">green_theme</string>
-    <string name="settings_key_grey_theme" translatable="false">grey_theme</string>
     <string name="settings_key_brown_theme" translatable="false">brown_theme</string>
     <string name="app_contributors">Made possible by: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="sort">Sort</string>
@@ -290,10 +288,6 @@
     <string name="previousCard">Previous</string>
     <string name="nextCard">Next</string>
     <string name="failedToOpenUrl">Install a web browser first</string>
-    <plurals name="viewArchivedCardsWithCount">
-        <item quantity="one">View archive (<xliff:g>%1$d</xliff:g> card)</item>
-        <item quantity="other">View archive (<xliff:g>%1$d</xliff:g> cards)</item>
-    </plurals>
     <string name="welcome">Welcome to Catima</string>
     <string name="importCards">Import cards</string>
     <string name="updateBalanceTitle">How much did you spend or receive?</string>


### PR DESCRIPTION
Remove unused strings that were found by "Unused resources" command. 
![image](https://github.com/user-attachments/assets/0760b2da-10d5-4838-87bd-df366b91a680)
3 strings were left for possible usage in the future. 
![image](https://github.com/user-attachments/assets/c69347c5-639e-44d1-8b8a-af5dcdc69b21)
Here is the commented usage of these strings 
![image](https://github.com/user-attachments/assets/49d6614b-8bfd-465b-9e07-d6d66386877c)
