### PR TITLE
Refactor to allow updating a loyalty card from a bundle

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
@@ -71,7 +71,7 @@ public class BarcodeSelectorActivity extends CatimaAppCompatActivity implements 
         });
 
         final Bundle b = getIntent().getExtras();
-        final String initialCardId = b != null ? b.getString("initialCardId") : null;
+        final String initialCardId = b != null ? b.getString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID) : null;
 
         if (initialCardId != null) {
             cardId.setText(initialCardId);

--- a/app/src/main/java/protect/card_locker/BarcodeValues.java
+++ b/app/src/main/java/protect/card_locker/BarcodeValues.java
@@ -4,11 +4,11 @@ import androidx.annotation.Nullable;
 
 public class BarcodeValues {
     @Nullable
-    private final String mFormat;
+    private final CatimaBarcode mFormat;
     private final String mContent;
     private String mNote;
 
-    public BarcodeValues(@Nullable String format, String content) {
+    public BarcodeValues(@Nullable CatimaBarcode format, String content) {
         mFormat = format;
         mContent = content;
     }
@@ -17,7 +17,7 @@ public class BarcodeValues {
         mNote = note;
     }
 
-    public @Nullable String format() {
+    public @Nullable CatimaBarcode format() {
         return mFormat;
     }
 

--- a/app/src/main/java/protect/card_locker/BarcodeValues.java
+++ b/app/src/main/java/protect/card_locker/BarcodeValues.java
@@ -1,11 +1,14 @@
 package protect.card_locker;
 
+import androidx.annotation.Nullable;
+
 public class BarcodeValues {
+    @Nullable
     private final String mFormat;
     private final String mContent;
     private String mNote;
 
-    public BarcodeValues(String format, String content) {
+    public BarcodeValues(@Nullable String format, String content) {
         mFormat = format;
         mContent = content;
     }
@@ -14,7 +17,7 @@ public class BarcodeValues {
         mNote = note;
     }
 
-    public String format() {
+    public @Nullable String format() {
         return mFormat;
     }
 

--- a/app/src/main/java/protect/card_locker/CardShortcutConfigure.java
+++ b/app/src/main/java/protect/card_locker/CardShortcutConfigure.java
@@ -61,7 +61,7 @@ public class CardShortcutConfigure extends CatimaAppCompatActivity implements Lo
     private void onClickAction(int position) {
         Cursor selected = DBHelper.getLoyaltyCardCursor(mDatabase, DBHelper.LoyaltyCardArchiveFilter.All);
         selected.moveToPosition(position);
-        LoyaltyCard loyaltyCard = LoyaltyCard.toLoyaltyCard(selected);
+        LoyaltyCard loyaltyCard = LoyaltyCard.fromCursor(selected);
 
         Log.d(TAG, "Creating shortcut for card " + loyaltyCard.store + "," + loyaltyCard.id);
 

--- a/app/src/main/java/protect/card_locker/CardsOnPowerScreenService.java
+++ b/app/src/main/java/protect/card_locker/CardsOnPowerScreenService.java
@@ -42,10 +42,10 @@ public class CardsOnPowerScreenService extends ControlsProviderService {
         Cursor loyaltyCardCursor = DBHelper.getLoyaltyCardCursor(mDatabase, DBHelper.LoyaltyCardArchiveFilter.Unarchived);
         return subscriber -> {
             while (loyaltyCardCursor.moveToNext()) {
-                LoyaltyCard card = LoyaltyCard.toLoyaltyCard(loyaltyCardCursor);
+                LoyaltyCard card = LoyaltyCard.fromCursor(loyaltyCardCursor);
                 Intent openIntent = new Intent(this, LoyaltyCardViewActivity.class)
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        .putExtra("id", card.id);
+                        .putExtra(LoyaltyCardViewActivity.BUNDLE_ID, card.id);
                 PendingIntent pendingIntent = PendingIntent.getActivity(getBaseContext(), card.id, openIntent, PendingIntent.FLAG_IMMUTABLE);
                 subscriber.onNext(
                         new Control.StatelessBuilder(PREFIX + card.id, pendingIntent)
@@ -73,7 +73,7 @@ public class CardsOnPowerScreenService extends ControlsProviderService {
                 if (card != null) {
                     Intent openIntent = new Intent(this, LoyaltyCardViewActivity.class)
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            .putExtra("id", card.id);
+                            .putExtra(LoyaltyCardViewActivity.BUNDLE_ID, card.id);
                     PendingIntent pendingIntent = PendingIntent.getActivity(getBaseContext(), card.id, openIntent, PendingIntent.FLAG_IMMUTABLE);
                     control = new Control.StatefulBuilder(controlId, pendingIntent)
                             .setTitle(card.store)
@@ -129,7 +129,7 @@ public class CardsOnPowerScreenService extends ControlsProviderService {
         consumer.accept(ControlAction.RESPONSE_OK);
         Intent openIntent = new Intent(this, LoyaltyCardViewActivity.class)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                .putExtra("id", controlIdToCardId(controlId));
+                .putExtra(LoyaltyCardViewActivity.BUNDLE_ID, controlIdToCardId(controlId));
         startActivity(openIntent);
 
         closePowerScreenOnAndroid11();

--- a/app/src/main/java/protect/card_locker/CatimaBarcode.java
+++ b/app/src/main/java/protect/card_locker/CatimaBarcode.java
@@ -1,5 +1,7 @@
 package protect.card_locker;
 
+import androidx.annotation.NonNull;
+
 import com.google.zxing.BarcodeFormat;
 
 import java.util.Arrays;
@@ -45,15 +47,15 @@ public class CatimaBarcode {
         mBarcodeFormat = barcodeFormat;
     }
 
-    public static CatimaBarcode fromBarcode(BarcodeFormat barcodeFormat) {
+    public static CatimaBarcode fromBarcode(@NonNull BarcodeFormat barcodeFormat) {
         return new CatimaBarcode(barcodeFormat);
     }
 
-    public static CatimaBarcode fromName(String name) {
+    public static CatimaBarcode fromName(@NonNull String name) {
         return new CatimaBarcode(BarcodeFormat.valueOf(name));
     }
 
-    public static CatimaBarcode fromPrettyName(String prettyName) {
+    public static CatimaBarcode fromPrettyName(@NonNull String prettyName) {
         try {
             return new CatimaBarcode(barcodeFormats.get(barcodePrettyNames.indexOf(prettyName)));
         } catch (IndexOutOfBoundsException e) {

--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -332,7 +332,7 @@ public class DBHelper extends SQLiteOpenHelper {
         Set<String> files = new HashSet<>();
         Cursor cardCursor = getLoyaltyCardCursor(database);
         while (cardCursor.moveToNext()) {
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cardCursor);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cardCursor);
             for (ImageLocationType imageLocationType : ImageLocationType.values()) {
                 String name = Utils.getCardImageFileName(card.id, imageLocationType);
                 if (Utils.retrieveCardImageAsFile(context, name).exists()) {
@@ -542,7 +542,7 @@ public class DBHelper extends SQLiteOpenHelper {
 
         if (data.getCount() == 1) {
             data.moveToFirst();
-            card = LoyaltyCard.toLoyaltyCard(data);
+            card = LoyaltyCard.fromCursor(data);
         }
 
         data.close();

--- a/app/src/main/java/protect/card_locker/LoyaltyCard.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCard.java
@@ -1,6 +1,7 @@
 package protect.card_locker;
 
 import android.database.Cursor;
+import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -10,72 +11,203 @@ import androidx.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Currency;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 public class LoyaltyCard implements Parcelable {
-    public final int id;
-    public final String store;
-    public final String note;
+    public int id;
+    public String store;
+    public String note;
     @Nullable
-    public final Date validFrom;
+    public Date validFrom;
     @Nullable
-    public final Date expiry;
-    public final BigDecimal balance;
+    public Date expiry;
+    public BigDecimal balance;
     @Nullable
-    public final Currency balanceType;
-    public final String cardId;
+    public Currency balanceType;
+    public String cardId;
     @Nullable
-    public final String barcodeId;
+    public String barcodeId;
     @Nullable
-    public final CatimaBarcode barcodeType;
+    public CatimaBarcode barcodeType;
     @Nullable
-    public final Integer headerColor;
-    public final int starStatus;
-    public final int archiveStatus;
-    public final long lastUsed;
+    public Integer headerColor;
+    public int starStatus;
+    public long lastUsed;
     public int zoomLevel;
+    public int archiveStatus;
 
+    public static final String BUNDLE_LOYALTY_CARD_ID = "loyaltyCardId";
+    public static final String BUNDLE_LOYALTY_CARD_STORE = "loyaltyCardStore";
+    public static final String BUNDLE_LOYALTY_CARD_NOTE = "loyaltyCardNote";
+    public static final String BUNDLE_LOYALTY_CARD_VALID_FROM = "loyaltyCardValidFrom";
+    public static final String BUNDLE_LOYALTY_CARD_EXPIRY = "loyaltyCardExpiry";
+    public static final String BUNDLE_LOYALTY_CARD_BALANCE = "loyaltyCardBalance";
+    public static final String BUNDLE_LOYALTY_CARD_BALANCE_TYPE = "loyaltyCardBalanceType";
+    public static final String BUNDLE_LOYALTY_CARD_CARD_ID = "loyaltyCardCardId";
+    public static final String BUNDLE_LOYALTY_CARD_BARCODE_ID = "loyaltyCardBarcodeId";
+    public static final String BUNDLE_LOYALTY_CARD_BARCODE_TYPE = "loyaltyCardBarcodeType";
+    public static final String BUNDLE_LOYALTY_CARD_HEADER_COLOR = "loyaltyCardHeaderColor";
+    public static final String BUNDLE_LOYALTY_CARD_STAR_STATUS = "loyaltyCardStarStatus";
+    public static final String BUNDLE_LOYALTY_CARD_LAST_USED = "loyaltyCardLastUsed";
+    public static final String BUNDLE_LOYALTY_CARD_ZOOM_LEVEL = "loyaltyCardZoomLevel";
+    public static final String BUNDLE_LOYALTY_CARD_ARCHIVE_STATUS = "loyaltyCardArchiveStatus";
+
+    /**
+     * Create a loyalty card object with default values
+     */
+    public LoyaltyCard() {
+        setId(-1);
+        setStore("");
+        setNote("");
+        setValidFrom(null);
+        setExpiry(null);
+        setBalance(new BigDecimal("0"));
+        setBalanceType(null);
+        setCardId("");
+        setBarcodeId(null);
+        setBarcodeType(null);
+        setHeaderColor(null);
+        setStarStatus(0);
+        setLastUsed(0);
+        setZoomLevel(100);
+        setArchiveStatus(0);
+    }
+
+    /**
+     * Create a new loyalty card
+     *
+     * @param id
+     * @param store
+     * @param note
+     * @param validFrom
+     * @param expiry
+     * @param balance
+     * @param balanceType
+     * @param cardId
+     * @param barcodeId
+     * @param barcodeType
+     * @param headerColor
+     * @param starStatus
+     * @param lastUsed
+     * @param zoomLevel
+     * @param archiveStatus
+     */
     public LoyaltyCard(final int id, final String store, final String note, @Nullable final Date validFrom,
                        @Nullable final Date expiry, final BigDecimal balance, @Nullable final Currency balanceType,
                        final String cardId, @Nullable final String barcodeId, @Nullable final CatimaBarcode barcodeType,
                        @Nullable final Integer headerColor, final int starStatus,
                        final long lastUsed, final int zoomLevel, final int archiveStatus) {
+        setId(id);
+        setStore(store);
+        setNote(note);
+        setValidFrom(validFrom);
+        setExpiry(expiry);
+        setBalance(balance);
+        setBalanceType(balanceType);
+        setCardId(cardId);
+        setBarcodeId(barcodeId);
+        setBarcodeType(barcodeType);
+        setHeaderColor(headerColor);
+        setStarStatus(starStatus);
+        setLastUsed(lastUsed);
+        setZoomLevel(zoomLevel);
+        setArchiveStatus(archiveStatus);
+    }
+
+    public void setId(int id) {
         this.id = id;
+    }
+
+    public void setStore(@NonNull String store) {
         this.store = store;
+    }
+
+    public void setNote(@Nullable String note) {
         this.note = note;
+    }
+
+    public void setValidFrom(@Nullable Date validFrom) {
         this.validFrom = validFrom;
+    }
+
+    public void setExpiry(@Nullable Date expiry) {
         this.expiry = expiry;
+    }
+
+    public void setBalance(@Nullable BigDecimal balance) {
         this.balance = balance;
+    }
+
+    public void setBalanceType(@Nullable Currency balanceType) {
         this.balanceType = balanceType;
+    }
+
+    public void setCardId(@NonNull String cardId) {
         this.cardId = cardId;
+    }
+
+    public void setBarcodeId(@Nullable String barcodeId) {
         this.barcodeId = barcodeId;
+    }
+
+    public void setBarcodeType(@Nullable CatimaBarcode barcodeType) {
         this.barcodeType = barcodeType;
+    }
+
+    public void setHeaderColor(@Nullable Integer headerColor) {
         this.headerColor = headerColor;
+    }
+
+    public void setStarStatus(int starStatus) {
+        if (starStatus != 0 && starStatus != 1) {
+            throw new IllegalArgumentException("starStatus must be 0 or 1");
+        }
+
         this.starStatus = starStatus;
+    }
+
+    public void setLastUsed(long lastUsed) {
         this.lastUsed = lastUsed;
+    }
+
+    public void setZoomLevel(int zoomLevel) {
+        if (zoomLevel < 0 || zoomLevel > 100) {
+            throw new IllegalArgumentException("zoomLevel must be in range 0-100");
+        }
+
         this.zoomLevel = zoomLevel;
+    }
+
+    public void setArchiveStatus(int archiveStatus) {
+        if (archiveStatus != 0 && archiveStatus != 1) {
+            throw new IllegalArgumentException("archiveStatus must be 0 or 1");
+        }
+
         this.archiveStatus = archiveStatus;
     }
 
     protected LoyaltyCard(Parcel in) {
-        id = in.readInt();
-        store = in.readString();
-        note = in.readString();
+        setId(in.readInt());
+        setStore(Objects.requireNonNull(in.readString()));
+        setNote(in.readString());
         long tmpValidFrom = in.readLong();
-        validFrom = tmpValidFrom != -1 ? new Date(tmpValidFrom) : null;
+        setValidFrom(tmpValidFrom != -1 ? new Date(tmpValidFrom) : null);
         long tmpExpiry = in.readLong();
-        expiry = tmpExpiry != -1 ? new Date(tmpExpiry) : null;
-        balance = (BigDecimal) in.readValue(BigDecimal.class.getClassLoader());
-        balanceType = (Currency) in.readValue(Currency.class.getClassLoader());
-        cardId = in.readString();
-        barcodeId = in.readString();
+        setExpiry(tmpExpiry != -1 ? new Date(tmpExpiry) : null);
+        setBalance((BigDecimal) in.readValue(BigDecimal.class.getClassLoader()));
+        setBalanceType((Currency) in.readValue(Currency.class.getClassLoader()));
+        setCardId(Objects.requireNonNull(in.readString()));
+        setBarcodeId(in.readString());
         String tmpBarcodeType = in.readString();
-        barcodeType = !tmpBarcodeType.isEmpty() ? CatimaBarcode.fromName(tmpBarcodeType) : null;
+        setBarcodeType((tmpBarcodeType != null && !tmpBarcodeType.isEmpty()) ? CatimaBarcode.fromName(tmpBarcodeType) : null);
         int tmpHeaderColor = in.readInt();
-        headerColor = tmpHeaderColor != -1 ? tmpHeaderColor : null;
-        starStatus = in.readInt();
-        lastUsed = in.readLong();
-        zoomLevel = in.readInt();
-        archiveStatus = in.readInt();
+        setHeaderColor(tmpHeaderColor != -1 ? tmpHeaderColor : null);
+        setStarStatus(in.readInt());
+        setLastUsed(in.readLong());
+        setZoomLevel(in.readInt());
+        setArchiveStatus(in.readInt());
     }
 
     @Override
@@ -97,7 +229,103 @@ public class LoyaltyCard implements Parcelable {
         parcel.writeInt(archiveStatus);
     }
 
-    public static LoyaltyCard toLoyaltyCard(Cursor cursor) {
+    public static LoyaltyCard fromBundle(Bundle bundle) {
+        // Grab default card
+        LoyaltyCard loyaltyCard = new LoyaltyCard();
+
+        // Update from bundle
+        loyaltyCard.updateFromBundle(bundle);
+
+        // Return updated version
+        return loyaltyCard;
+    }
+
+    public void updateFromBundle(Bundle bundle) {
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_ID)) {
+            setId(bundle.getInt(BUNDLE_LOYALTY_CARD_ID));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_STORE)) {
+            setStore(Objects.requireNonNull(bundle.getString(BUNDLE_LOYALTY_CARD_STORE)));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_NOTE)) {
+            setNote(bundle.getString(BUNDLE_LOYALTY_CARD_NOTE));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_VALID_FROM)) {
+            long tmpValidFrom = bundle.getLong(BUNDLE_LOYALTY_CARD_VALID_FROM, -1);
+            setValidFrom(tmpValidFrom != -1 ? new Date(tmpValidFrom) : null);
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_EXPIRY)) {
+            long tmpExpiry = bundle.getLong(BUNDLE_LOYALTY_CARD_EXPIRY, -1);
+            setExpiry(tmpExpiry != -1 ? new Date(tmpExpiry) : null);
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BALANCE)) {
+            setBalance(new BigDecimal(bundle.getString(BUNDLE_LOYALTY_CARD_BALANCE)));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BALANCE_TYPE)) {
+            String tmpBalanceType = bundle.getString(BUNDLE_LOYALTY_CARD_BALANCE_TYPE, null);
+            setBalanceType(tmpBalanceType != null ? Currency.getInstance(tmpBalanceType) : null);
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_CARD_ID)) {
+            setCardId(Objects.requireNonNull(bundle.getString(BUNDLE_LOYALTY_CARD_CARD_ID)));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BARCODE_ID)) {
+            setBarcodeId(bundle.getString(BUNDLE_LOYALTY_CARD_BARCODE_ID));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BARCODE_TYPE)) {
+            String tmpBarcodeType = bundle.getString(BUNDLE_LOYALTY_CARD_BARCODE_TYPE, null);
+            setBarcodeType(tmpBarcodeType != null ? CatimaBarcode.fromName(tmpBarcodeType) : null);
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_HEADER_COLOR)) {
+            int tmpHeaderColor = bundle.getInt(BUNDLE_LOYALTY_CARD_HEADER_COLOR, -1);
+            setHeaderColor(tmpHeaderColor != -1 ? tmpHeaderColor : null);
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_STAR_STATUS)) {
+            setStarStatus(bundle.getInt(BUNDLE_LOYALTY_CARD_STAR_STATUS));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_LAST_USED)) {
+            setLastUsed(bundle.getLong(BUNDLE_LOYALTY_CARD_LAST_USED));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_ZOOM_LEVEL)) {
+            setZoomLevel(bundle.getInt(BUNDLE_LOYALTY_CARD_ZOOM_LEVEL));
+        }
+        if (bundle.containsKey(BUNDLE_LOYALTY_CARD_ARCHIVE_STATUS)) {
+            setArchiveStatus(bundle.getInt(BUNDLE_LOYALTY_CARD_ARCHIVE_STATUS));
+        }
+    }
+
+    public Bundle toBundle() {
+        Bundle bundle = new Bundle();
+
+        bundle.putInt(BUNDLE_LOYALTY_CARD_ID, id);
+        bundle.putString(BUNDLE_LOYALTY_CARD_STORE, store);
+        bundle.putString(BUNDLE_LOYALTY_CARD_NOTE, note);
+        if (validFrom != null) {
+            bundle.putLong(BUNDLE_LOYALTY_CARD_VALID_FROM, validFrom.getTime());
+        }
+        if (expiry != null) {
+            bundle.putLong(BUNDLE_LOYALTY_CARD_EXPIRY, expiry.getTime());
+        }
+        bundle.putString(BUNDLE_LOYALTY_CARD_BALANCE, balance.toString());
+        if (balanceType != null) {
+            bundle.putString(BUNDLE_LOYALTY_CARD_BALANCE_TYPE, balanceType.toString());
+        }
+        bundle.putString(BUNDLE_LOYALTY_CARD_CARD_ID, cardId);
+        bundle.putString(BUNDLE_LOYALTY_CARD_BARCODE_ID, barcodeId);
+        if (barcodeType != null) {
+            bundle.putString(BUNDLE_LOYALTY_CARD_BARCODE_TYPE, barcodeType.name());
+        }
+        if (headerColor != null) {
+            bundle.putInt(BUNDLE_LOYALTY_CARD_HEADER_COLOR, headerColor);
+        }
+        bundle.putInt(BUNDLE_LOYALTY_CARD_STAR_STATUS, starStatus);
+        bundle.putLong(BUNDLE_LOYALTY_CARD_LAST_USED, lastUsed);
+        bundle.putInt(BUNDLE_LOYALTY_CARD_ZOOM_LEVEL, zoomLevel);
+        bundle.putInt(BUNDLE_LOYALTY_CARD_ARCHIVE_STATUS, archiveStatus);
+
+        return bundle;
+    }
+
+    public static LoyaltyCard fromCursor(Cursor cursor) {
         int id = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ID));
         String store = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STORE));
         String note = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.NOTE));
@@ -106,10 +334,10 @@ public class LoyaltyCard implements Parcelable {
         BigDecimal balance = new BigDecimal(cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE)));
         String cardId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.CARD_ID));
         String barcodeId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_ID));
-        int starred = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS));
+        int starStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS));
         long lastUsed = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.LAST_USED));
         int zoomLevel = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ZOOM_LEVEL));
-        int archived = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS));
+        int archiveStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS));
 
         int barcodeTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE);
         int balanceTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE);
@@ -141,7 +369,7 @@ public class LoyaltyCard implements Parcelable {
             headerColor = cursor.getInt(headerColorColumn);
         }
 
-        return new LoyaltyCard(id, store, note, validFrom, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, starred, lastUsed, zoomLevel, archived);
+        return new LoyaltyCard(id, store, note, validFrom, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, starStatus, lastUsed, zoomLevel, archiveStatus);
     }
 
     public static boolean isDuplicate(final LoyaltyCard a, final LoyaltyCard b) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCard.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCard.java
@@ -70,7 +70,7 @@ public class LoyaltyCard implements Parcelable {
         setBarcodeType(null);
         setHeaderColor(null);
         setStarStatus(0);
-        setLastUsed(0);
+        setLastUsed(Utils.getUnixTime());
         setZoomLevel(100);
         setArchiveStatus(0);
     }
@@ -229,67 +229,97 @@ public class LoyaltyCard implements Parcelable {
         parcel.writeInt(archiveStatus);
     }
 
-    public static LoyaltyCard fromBundle(Bundle bundle) {
+    public static LoyaltyCard fromBundle(Bundle bundle, boolean requireFull) {
         // Grab default card
         LoyaltyCard loyaltyCard = new LoyaltyCard();
 
         // Update from bundle
-        loyaltyCard.updateFromBundle(bundle);
+        loyaltyCard.updateFromBundle(bundle, requireFull);
 
         // Return updated version
         return loyaltyCard;
     }
 
-    public void updateFromBundle(Bundle bundle) {
+    public void updateFromBundle(Bundle bundle, boolean requireFull) {
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_ID)) {
             setId(bundle.getInt(BUNDLE_LOYALTY_CARD_ID));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_ID);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_STORE)) {
             setStore(Objects.requireNonNull(bundle.getString(BUNDLE_LOYALTY_CARD_STORE)));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_STORE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_NOTE)) {
             setNote(bundle.getString(BUNDLE_LOYALTY_CARD_NOTE));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_NOTE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_VALID_FROM)) {
             long tmpValidFrom = bundle.getLong(BUNDLE_LOYALTY_CARD_VALID_FROM, -1);
             setValidFrom(tmpValidFrom != -1 ? new Date(tmpValidFrom) : null);
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_VALID_FROM);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_EXPIRY)) {
             long tmpExpiry = bundle.getLong(BUNDLE_LOYALTY_CARD_EXPIRY, -1);
             setExpiry(tmpExpiry != -1 ? new Date(tmpExpiry) : null);
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_EXPIRY);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BALANCE)) {
             setBalance(new BigDecimal(bundle.getString(BUNDLE_LOYALTY_CARD_BALANCE)));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BALANCE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BALANCE_TYPE)) {
             String tmpBalanceType = bundle.getString(BUNDLE_LOYALTY_CARD_BALANCE_TYPE, null);
             setBalanceType(tmpBalanceType != null ? Currency.getInstance(tmpBalanceType) : null);
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BALANCE_TYPE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_CARD_ID)) {
             setCardId(Objects.requireNonNull(bundle.getString(BUNDLE_LOYALTY_CARD_CARD_ID)));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_CARD_ID);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BARCODE_ID)) {
             setBarcodeId(bundle.getString(BUNDLE_LOYALTY_CARD_BARCODE_ID));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BARCODE_ID);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BARCODE_TYPE)) {
             String tmpBarcodeType = bundle.getString(BUNDLE_LOYALTY_CARD_BARCODE_TYPE, null);
             setBarcodeType(tmpBarcodeType != null ? CatimaBarcode.fromName(tmpBarcodeType) : null);
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BARCODE_TYPE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_HEADER_COLOR)) {
             int tmpHeaderColor = bundle.getInt(BUNDLE_LOYALTY_CARD_HEADER_COLOR, -1);
             setHeaderColor(tmpHeaderColor != -1 ? tmpHeaderColor : null);
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_HEADER_COLOR);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_STAR_STATUS)) {
             setStarStatus(bundle.getInt(BUNDLE_LOYALTY_CARD_STAR_STATUS));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_STAR_STATUS);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_LAST_USED)) {
             setLastUsed(bundle.getLong(BUNDLE_LOYALTY_CARD_LAST_USED));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_LAST_USED);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_ZOOM_LEVEL)) {
             setZoomLevel(bundle.getInt(BUNDLE_LOYALTY_CARD_ZOOM_LEVEL));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_ZOOM_LEVEL);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_ARCHIVE_STATUS)) {
             setArchiveStatus(bundle.getInt(BUNDLE_LOYALTY_CARD_ARCHIVE_STATUS));
+        } else if (requireFull) {
+            throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_ARCHIVE_STATUS);
         }
     }
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCard.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCard.java
@@ -124,7 +124,7 @@ public class LoyaltyCard implements Parcelable {
         this.store = store;
     }
 
-    public void setNote(@Nullable String note) {
+    public void setNote(@NonNull String note) {
         this.note = note;
     }
 
@@ -136,7 +136,7 @@ public class LoyaltyCard implements Parcelable {
         this.expiry = expiry;
     }
 
-    public void setBalance(@Nullable BigDecimal balance) {
+    public void setBalance(@NonNull BigDecimal balance) {
         this.balance = balance;
     }
 
@@ -152,7 +152,7 @@ public class LoyaltyCard implements Parcelable {
         this.barcodeId = barcodeId;
     }
 
-    public void setBarcodeType(@Nullable CatimaBarcode barcodeType) {
+        public void setBarcodeType(@Nullable CatimaBarcode barcodeType) {
         this.barcodeType = barcodeType;
     }
 
@@ -191,7 +191,7 @@ public class LoyaltyCard implements Parcelable {
     protected LoyaltyCard(Parcel in) {
         setId(in.readInt());
         setStore(Objects.requireNonNull(in.readString()));
-        setNote(in.readString());
+        setNote(Objects.requireNonNull(in.readString()));
         long tmpValidFrom = in.readLong();
         setValidFrom(tmpValidFrom != -1 ? new Date(tmpValidFrom) : null);
         long tmpExpiry = in.readLong();
@@ -211,7 +211,7 @@ public class LoyaltyCard implements Parcelable {
     }
 
     @Override
-    public void writeToParcel(Parcel parcel, int i) {
+    public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeInt(id);
         parcel.writeString(store);
         parcel.writeString(note);
@@ -252,12 +252,12 @@ public class LoyaltyCard implements Parcelable {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_STORE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_NOTE)) {
-            setNote(bundle.getString(BUNDLE_LOYALTY_CARD_NOTE));
+            setNote(Objects.requireNonNull(bundle.getString(BUNDLE_LOYALTY_CARD_NOTE)));
         } else if (requireFull) {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_NOTE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_VALID_FROM)) {
-            long tmpValidFrom = bundle.getLong(BUNDLE_LOYALTY_CARD_VALID_FROM, -1);
+            long tmpValidFrom = bundle.getLong(BUNDLE_LOYALTY_CARD_VALID_FROM);
             setValidFrom(tmpValidFrom != -1 ? new Date(tmpValidFrom) : null);
         } else if (requireFull) {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_VALID_FROM);
@@ -356,48 +356,56 @@ public class LoyaltyCard implements Parcelable {
     }
 
     public static LoyaltyCard fromCursor(Cursor cursor) {
+        // id
         int id = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ID));
+        // store
         String store = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STORE));
+        // note
         String note = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.NOTE));
-        long validFromLong = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.VALID_FROM));
-        long expiryLong = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.EXPIRY));
-        BigDecimal balance = new BigDecimal(cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE)));
-        String cardId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.CARD_ID));
-        String barcodeId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_ID));
-        int starStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS));
-        long lastUsed = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.LAST_USED));
-        int zoomLevel = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ZOOM_LEVEL));
-        int archiveStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS));
-
-        int barcodeTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE);
-        int balanceTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE);
-        int headerColorColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR);
-
-        CatimaBarcode barcodeType = null;
-        Currency balanceType = null;
+        // validFrom
         Date validFrom = null;
-        Date expiry = null;
-        Integer headerColor = null;
-
-        if (cursor.isNull(barcodeTypeColumn) == false) {
-            barcodeType = CatimaBarcode.fromName(cursor.getString(barcodeTypeColumn));
-        }
-
-        if (cursor.isNull(balanceTypeColumn) == false) {
-            balanceType = Currency.getInstance(cursor.getString(balanceTypeColumn));
-        }
-
+        long validFromLong = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.VALID_FROM));
         if (validFromLong > 0) {
             validFrom = new Date(validFromLong);
         }
-
+        // expiry
+        Date expiry = null;
+        long expiryLong = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.EXPIRY));
         if (expiryLong > 0) {
             expiry = new Date(expiryLong);
         }
-
-        if (cursor.isNull(headerColorColumn) == false) {
+        // balance
+        BigDecimal balance = new BigDecimal(cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE)));
+        // balanceType
+        Currency balanceType = null;
+        int balanceTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE);
+        if (!cursor.isNull(balanceTypeColumn)) {
+            balanceType = Currency.getInstance(cursor.getString(balanceTypeColumn));
+        }
+        // cardId
+        String cardId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.CARD_ID));
+        // barcodeId
+        String barcodeId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_ID));
+        // barcodeType
+        CatimaBarcode barcodeType = null;
+        int barcodeTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE);
+        if (!cursor.isNull(barcodeTypeColumn)) {
+            barcodeType = CatimaBarcode.fromName(cursor.getString(barcodeTypeColumn));
+        }
+        // headerColor
+        Integer headerColor = null;
+        int headerColorColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR);
+        if (!cursor.isNull(headerColorColumn)) {
             headerColor = cursor.getInt(headerColorColumn);
         }
+        // starStatus
+        int starStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS));
+        // lastUsed
+        long lastUsed = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.LAST_USED));
+        // zoomLevel
+        int zoomLevel = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ZOOM_LEVEL));
+        // archiveStatus
+        int archiveStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS));
 
         return new LoyaltyCard(id, store, note, validFrom, expiry, balance, balanceType, cardId, barcodeId, barcodeType, headerColor, starStatus, lastUsed, zoomLevel, archiveStatus);
     }

--- a/app/src/main/java/protect/card_locker/LoyaltyCard.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCard.java
@@ -152,7 +152,7 @@ public class LoyaltyCard implements Parcelable {
         this.barcodeId = barcodeId;
     }
 
-        public void setBarcodeType(@Nullable CatimaBarcode barcodeType) {
+    public void setBarcodeType(@Nullable CatimaBarcode barcodeType) {
         this.barcodeType = barcodeType;
     }
 
@@ -193,9 +193,9 @@ public class LoyaltyCard implements Parcelable {
         setStore(Objects.requireNonNull(in.readString()));
         setNote(Objects.requireNonNull(in.readString()));
         long tmpValidFrom = in.readLong();
-        setValidFrom(tmpValidFrom != -1 ? new Date(tmpValidFrom) : null);
+        setValidFrom(tmpValidFrom > 0 ? new Date(tmpValidFrom) : null);
         long tmpExpiry = in.readLong();
-        setExpiry(tmpExpiry != -1 ? new Date(tmpExpiry) : null);
+        setExpiry(tmpExpiry > 0 ? new Date(tmpExpiry) : null);
         setBalance((BigDecimal) in.readValue(BigDecimal.class.getClassLoader()));
         setBalanceType((Currency) in.readValue(Currency.class.getClassLoader()));
         setCardId(Objects.requireNonNull(in.readString()));
@@ -258,13 +258,13 @@ public class LoyaltyCard implements Parcelable {
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_VALID_FROM)) {
             long tmpValidFrom = bundle.getLong(BUNDLE_LOYALTY_CARD_VALID_FROM);
-            setValidFrom(tmpValidFrom != -1 ? new Date(tmpValidFrom) : null);
+            setValidFrom(tmpValidFrom > 0 ? new Date(tmpValidFrom) : null);
         } else if (requireFull) {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_VALID_FROM);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_EXPIRY)) {
-            long tmpExpiry = bundle.getLong(BUNDLE_LOYALTY_CARD_EXPIRY, -1);
-            setExpiry(tmpExpiry != -1 ? new Date(tmpExpiry) : null);
+            long tmpExpiry = bundle.getLong(BUNDLE_LOYALTY_CARD_EXPIRY);
+            setExpiry(tmpExpiry > 0 ? new Date(tmpExpiry) : null);
         } else if (requireFull) {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_EXPIRY);
         }
@@ -274,7 +274,7 @@ public class LoyaltyCard implements Parcelable {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BALANCE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BALANCE_TYPE)) {
-            String tmpBalanceType = bundle.getString(BUNDLE_LOYALTY_CARD_BALANCE_TYPE, null);
+            String tmpBalanceType = bundle.getString(BUNDLE_LOYALTY_CARD_BALANCE_TYPE);
             setBalanceType(tmpBalanceType != null ? Currency.getInstance(tmpBalanceType) : null);
         } else if (requireFull) {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BALANCE_TYPE);
@@ -290,13 +290,13 @@ public class LoyaltyCard implements Parcelable {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BARCODE_ID);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_BARCODE_TYPE)) {
-            String tmpBarcodeType = bundle.getString(BUNDLE_LOYALTY_CARD_BARCODE_TYPE, null);
+            String tmpBarcodeType = bundle.getString(BUNDLE_LOYALTY_CARD_BARCODE_TYPE);
             setBarcodeType(tmpBarcodeType != null ? CatimaBarcode.fromName(tmpBarcodeType) : null);
         } else if (requireFull) {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_BARCODE_TYPE);
         }
         if (bundle.containsKey(BUNDLE_LOYALTY_CARD_HEADER_COLOR)) {
-            int tmpHeaderColor = bundle.getInt(BUNDLE_LOYALTY_CARD_HEADER_COLOR, -1);
+            int tmpHeaderColor = bundle.getInt(BUNDLE_LOYALTY_CARD_HEADER_COLOR);
             setHeaderColor(tmpHeaderColor != -1 ? tmpHeaderColor : null);
         } else if (requireFull) {
             throw new IllegalArgumentException("Missing key " + BUNDLE_LOYALTY_CARD_HEADER_COLOR);
@@ -363,41 +363,27 @@ public class LoyaltyCard implements Parcelable {
         // note
         String note = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.NOTE));
         // validFrom
-        Date validFrom = null;
         long validFromLong = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.VALID_FROM));
-        if (validFromLong > 0) {
-            validFrom = new Date(validFromLong);
-        }
+        Date validFrom = validFromLong > 0 ? new Date(validFromLong) : null;
         // expiry
-        Date expiry = null;
         long expiryLong = cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.EXPIRY));
-        if (expiryLong > 0) {
-            expiry = new Date(expiryLong);
-        }
+        Date expiry = expiryLong > 0 ? new Date(expiryLong) : null;
         // balance
         BigDecimal balance = new BigDecimal(cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE)));
         // balanceType
-        Currency balanceType = null;
         int balanceTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE);
-        if (!cursor.isNull(balanceTypeColumn)) {
-            balanceType = Currency.getInstance(cursor.getString(balanceTypeColumn));
-        }
+        Currency balanceType = !cursor.isNull(balanceTypeColumn) ? Currency.getInstance(cursor.getString(balanceTypeColumn)) : null;
         // cardId
         String cardId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.CARD_ID));
         // barcodeId
-        String barcodeId = cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_ID));
+        int barcodeIdColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_ID);
+        String barcodeId = !cursor.isNull(barcodeIdColumn) ? cursor.getString(barcodeIdColumn) : null;
         // barcodeType
-        CatimaBarcode barcodeType = null;
         int barcodeTypeColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE);
-        if (!cursor.isNull(barcodeTypeColumn)) {
-            barcodeType = CatimaBarcode.fromName(cursor.getString(barcodeTypeColumn));
-        }
+        CatimaBarcode barcodeType = !cursor.isNull(barcodeTypeColumn) ? CatimaBarcode.fromName(cursor.getString(barcodeTypeColumn)) : null;
         // headerColor
-        Integer headerColor = null;
         int headerColorColumn = cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR);
-        if (!cursor.isNull(headerColorColumn)) {
-            headerColor = cursor.getInt(headerColorColumn);
-        }
+        Integer headerColor = !cursor.isNull(headerColorColumn) ? cursor.getInt(headerColorColumn) : null;
         // starStatus
         int starStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS));
         // lastUsed

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -79,7 +79,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
 
     public LoyaltyCard getCard(int position) {
         mCursor.moveToPosition(position);
-        return LoyaltyCard.toLoyaltyCard(mCursor);
+        return LoyaltyCard.fromCursor(mCursor);
     }
 
     public void onBindViewHolder(LoyaltyCardListItemViewHolder inputHolder, Cursor inputCursor) {
@@ -87,7 +87,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
         boolean showDivider = false;
         inputHolder.mDivider.setVisibility(View.GONE);
 
-        LoyaltyCard loyaltyCard = LoyaltyCard.toLoyaltyCard(inputCursor);
+        LoyaltyCard loyaltyCard = LoyaltyCard.fromCursor(inputCursor);
         Bitmap icon = Utils.retrieveCardImage(mContext, loyaltyCard.id, ImageLocationType.icon);
 
         if (mLoyaltyCardListDisplayOptions.showingNameBelowThumbnail() && icon != null) {
@@ -192,7 +192,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
         int i;
         for (i = 0; i < mSelectedItems.size(); i++) {
             mCursor.moveToPosition(mSelectedItems.keyAt(i));
-            result.add(LoyaltyCard.toLoyaltyCard(mCursor));
+            result.add(LoyaltyCard.fromCursor(mCursor));
         }
 
         return result;

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -307,7 +307,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
 
         // If the intent contains any loyalty card fields, override those fields in our current temp card
         if (b != null) {
-            tempLoyaltyCard.updateFromBundle(b);
+            tempLoyaltyCard.updateFromBundle(b, false);
         }
 
         Log.d(TAG, "Edit activity: id=" + loyaltyCardId
@@ -704,19 +704,9 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                 Utils.makeUserChooseBarcodeFromList(this, barcodeValuesList, new BarcodeValuesListDisambiguatorCallback() {
                     @Override
                     public void onUserChoseBarcode(BarcodeValues barcodeValues) {
-<<<<<<< Updated upstream
-                        Bundle bundle = new Bundle();
-                        bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID, barcodeValues.content());
-                        bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_TYPE, barcodeValues.format());
-                        bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_ID, "");
-                        tempLoyaltyCard.updateFromBundle(bundle);
-=======
-                        CatimaBarcode barcodeType = barcodeValues.format();
-
                         setLoyaltyCardCardId(barcodeValues.content());
-                        setLoyaltyCardBarcodeType(barcodeType);
+                        setLoyaltyCardBarcodeType(barcodeValues.format());
                         setLoyaltyCardBarcodeId("");
->>>>>>> Stashed changes
                     }
 
                     @Override
@@ -957,7 +947,6 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         }
 
         // Fix up some fields
-        // TODO: Double check if necessary and if can't reflow differently
         if (tempLoyaltyCard.barcodeType != null) {
             try {
                 barcodeTypeField.setText(tempLoyaltyCard.barcodeType.prettyName());
@@ -998,9 +987,6 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
 
         generateIcon(storeFieldEdit.getText().toString().trim());
 
-        // It can't be null because we set it in updateTempState but SpotBugs insists it can be
-        // NP_NULL_ON_SOME_PATH: Possible null pointer dereference and
-        // NP_NULL_PARAM_DEREF: Method call passes null for non-null parameter
         Integer headerColor = tempLoyaltyCard.headerColor;
         if (headerColor != null) {
             thumbnail.setOnClickListener(new ChooseCardImage());

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -208,31 +208,43 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         super.attachBaseContext(base);
     }
 
-    protected void setLoyaltyCardStore(String store) {
+    protected void setLoyaltyCardStore(@NonNull String store) {
         tempLoyaltyCard.setStore(store);
 
         hasChanged = true;
     }
 
-    protected void setLoyaltyCardNote(String note) {
+    protected void setLoyaltyCardNote(@NonNull String note) {
         tempLoyaltyCard.setNote(note);
 
         hasChanged = true;
     }
 
-    protected void setLoyaltyCardBalance(BigDecimal balance) {
+    protected void setLoyaltyCardValidFrom(@Nullable Date validFrom) {
+        tempLoyaltyCard.setValidFrom(validFrom);
+
+        hasChanged = true;
+    }
+
+    protected void setLoyaltyCardExpiry(@Nullable Date expiry) {
+        tempLoyaltyCard.setExpiry(expiry);
+
+        hasChanged = true;
+    }
+
+    protected void setLoyaltyCardBalance(@NonNull BigDecimal balance) {
         tempLoyaltyCard.setBalance(balance);
 
         hasChanged = true;
     }
 
-    protected void setLoyaltyCardBalanceType(Currency balanceType) {
+    protected void setLoyaltyCardBalanceType(@Nullable Currency balanceType) {
         tempLoyaltyCard.setBalanceType(balanceType);
 
         hasChanged = true;
     }
 
-    protected void setLoyaltyCardCardId(String cardId) {
+    protected void setLoyaltyCardCardId(@NonNull String cardId) {
         tempLoyaltyCard.setCardId(cardId);
 
         generateBarcode();
@@ -240,7 +252,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         hasChanged = true;
     }
 
-    protected void setLoyaltyCardBarcodeId(String barcodeId) {
+    protected void setLoyaltyCardBarcodeId(@Nullable String barcodeId) {
         tempLoyaltyCard.setBarcodeId(barcodeId);
 
         generateBarcode();
@@ -248,7 +260,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         hasChanged = true;
     }
 
-    protected void setLoyaltyCardBarcodeType(CatimaBarcode barcodeType) {
+    protected void setLoyaltyCardBarcodeType(@Nullable CatimaBarcode barcodeType) {
         tempLoyaltyCard.setBarcodeType(barcodeType);
 
         generateBarcode();
@@ -256,20 +268,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         hasChanged = true;
     }
 
-    protected void setLoyaltyCardHeaderColor(Integer headerColor) {
+    protected void setLoyaltyCardHeaderColor(@Nullable Integer headerColor) {
         tempLoyaltyCard.setHeaderColor(headerColor);
-
-        hasChanged = true;
-    }
-
-    protected void setLoyaltyCardValidFrom(Date validFrom) {
-        tempLoyaltyCard.setValidFrom(validFrom);
-
-        hasChanged = true;
-    }
-
-    protected void setLoyaltyCardExpiry(Date expiry) {
-        tempLoyaltyCard.setExpiry(expiry);
 
         hasChanged = true;
     }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -97,6 +97,10 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
     static final String STATE_IMAGEINDEX = "imageIndex";
     static final String STATE_FULLSCREEN = "isFullscreen";
 
+    static final String BUNDLE_ID = "id";
+    static final String BUNDLE_CARDLIST = "cardList";
+    static final String BUNDLE_TRANSITION_RIGHT = "transition_right";
+
     final private TaskHandler mTasks = new TaskHandler();
     Runnable barcodeImageGenerationFinishedCallback;
 
@@ -181,8 +185,8 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
     private void extractIntentFields(Intent intent) {
         final Bundle b = intent.getExtras();
-        loyaltyCardId = b != null ? b.getInt("id") : 0;
-        cardList = b != null ? b.getIntegerArrayList("cardList") : null;
+        loyaltyCardId = b != null ? b.getInt(BUNDLE_ID) : 0;
+        cardList = b != null ? b.getIntegerArrayList(BUNDLE_CARDLIST) : null;
         Log.d(TAG, "View activity: id=" + loyaltyCardId);
     }
 
@@ -208,7 +212,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
                 return;
             }
 
-            int transitionRight = incomingIntentExtras.getInt("transition_right", -1);
+            int transitionRight = incomingIntentExtras.getInt(BUNDLE_TRANSITION_RIGHT, -1);
             if (transitionRight == 1) {
                 // right side transition
                 overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
@@ -572,8 +576,8 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         // Restart activity with new card id and index
         Intent intent = getIntent();
         Bundle b = intent.getExtras();
-        b.putInt("id", loyaltyCardId);
-        b.putInt("transition_right", transitionRight ? 1 : 0);
+        b.putInt(BUNDLE_ID, loyaltyCardId);
+        b.putInt(BUNDLE_TRANSITION_RIGHT, transitionRight ? 1 : 0);
         intent.putExtras(b);
         intent.setFlags(intent.getFlags() | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(intent);

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -426,10 +426,14 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
         Utils.makeUserChooseBarcodeFromList(MainActivity.this, barcodeValuesList, new BarcodeValuesListDisambiguatorCallback() {
             @Override
             public void onUserChoseBarcode(BarcodeValues barcodeValues) {
+                CatimaBarcode barcodeType = barcodeValues.format();
+
                 Intent newIntent = new Intent(getApplicationContext(), LoyaltyCardEditActivity.class);
                 Bundle newBundle = new Bundle();
-                newBundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_TYPE, barcodeValues.format());
-                newBundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID, barcodeValues.content());
+
+                Bundle bundle = new Bundle();
+                bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID, barcodeValues.content());
+                bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_TYPE, barcodeType != null ? barcodeType.name() : null);
                 newBundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_ID, null);
                 if (group != null) {
                     newBundle.putString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP, group);

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -428,8 +428,9 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
             public void onUserChoseBarcode(BarcodeValues barcodeValues) {
                 Intent newIntent = new Intent(getApplicationContext(), LoyaltyCardEditActivity.class);
                 Bundle newBundle = new Bundle();
-                newBundle.putString(LoyaltyCardEditActivity.BUNDLE_BARCODETYPE, barcodeValues.format());
-                newBundle.putString(LoyaltyCardEditActivity.BUNDLE_CARDID, barcodeValues.content());
+                newBundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_TYPE, barcodeValues.format());
+                newBundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID, barcodeValues.content());
+                newBundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_ID, null);
                 if (group != null) {
                     newBundle.putString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP, group);
                 }
@@ -781,14 +782,14 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
             Intent intent = new Intent(this, LoyaltyCardViewActivity.class);
             intent.setAction("");
             final Bundle b = new Bundle();
-            b.putInt("id", loyaltyCard.id);
+            b.putInt(LoyaltyCardViewActivity.BUNDLE_ID, loyaltyCard.id);
 
             ArrayList<Integer> cardList = new ArrayList<>();
             for (int i = 0; i < mAdapter.getItemCount(); i++) {
                 cardList.add(mAdapter.getCard(i).id);
             }
 
-            b.putIntegerArrayList("cardList", cardList);
+            b.putIntegerArrayList(LoyaltyCardViewActivity.BUNDLE_CARDLIST, cardList);
             intent.putExtras(b);
 
             startActivity(intent);

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -428,18 +428,16 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
             public void onUserChoseBarcode(BarcodeValues barcodeValues) {
                 CatimaBarcode barcodeType = barcodeValues.format();
 
-                Intent newIntent = new Intent(getApplicationContext(), LoyaltyCardEditActivity.class);
-                Bundle newBundle = new Bundle();
-
+                Intent intent = new Intent(getApplicationContext(), LoyaltyCardEditActivity.class);
                 Bundle bundle = new Bundle();
                 bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID, barcodeValues.content());
                 bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_TYPE, barcodeType != null ? barcodeType.name() : null);
-                newBundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_ID, null);
+                bundle.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_BARCODE_ID, null);
                 if (group != null) {
-                    newBundle.putString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP, group);
+                    bundle.putString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP, group);
                 }
-                newIntent.putExtras(newBundle);
-                startActivity(newIntent);
+                intent.putExtras(bundle);
+                startActivity(intent);
             }
 
             @Override

--- a/app/src/main/java/protect/card_locker/ManageGroupCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/ManageGroupCursorAdapter.java
@@ -33,7 +33,7 @@ public class ManageGroupCursorAdapter extends LoyaltyCardCursorAdapter {
 
     @Override
     public void onBindViewHolder(LoyaltyCardListItemViewHolder inputHolder, Cursor inputCursor) {
-        LoyaltyCard loyaltyCard = LoyaltyCard.toLoyaltyCard(inputCursor);
+        LoyaltyCard loyaltyCard = LoyaltyCard.fromCursor(inputCursor);
         Boolean overlayValue = mInGroupOverlay.get(loyaltyCard.id);
         if ((overlayValue != null ? overlayValue : isLoyaltyCardInGroup(loyaltyCard.id))) {
             mAnimationItemsIndex.put(inputCursor.getPosition(), true);

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -291,7 +291,9 @@ public class ScanActivity extends CatimaAppCompatActivity {
         Utils.makeUserChooseBarcodeFromList(this, barcodeValuesList, new BarcodeValuesListDisambiguatorCallback() {
             @Override
             public void onUserChoseBarcode(BarcodeValues barcodeValues) {
-                returnResult(barcodeValues.content(), barcodeValues.format());
+                CatimaBarcode barcodeType = barcodeValues.format();
+
+                returnResult(barcodeValues.content(), barcodeType != null ? barcodeType.name() : null);
             }
 
             @Override

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -82,7 +82,7 @@ public class ScanActivity extends CatimaAppCompatActivity {
 
     private void extractIntentFields(Intent intent) {
         final Bundle b = intent.getExtras();
-        cardId = b != null ? b.getString(LoyaltyCardEditActivity.BUNDLE_CARDID) : null;
+        cardId = b != null ? b.getString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID) : null;
         addGroup = b != null ? b.getString(LoyaltyCardEditActivity.BUNDLE_ADDGROUP) : null;
         Log.d(TAG, "Scan activity: id=" + cardId);
     }
@@ -338,7 +338,7 @@ public class ScanActivity extends CatimaAppCompatActivity {
 
         // Buttons
         builder.setPositiveButton(getString(R.string.ok), (dialog, which) -> {
-            returnResult(input.getText().toString(), "");
+            returnResult(input.getText().toString(), null);
         });
         builder.setNegativeButton(getString(R.string.cancel), (dialog, which) -> dialog.cancel());
         AlertDialog dialog = builder.create();
@@ -373,7 +373,7 @@ public class ScanActivity extends CatimaAppCompatActivity {
             Intent i = new Intent(getApplicationContext(), BarcodeSelectorActivity.class);
             if (cardId != null) {
                 final Bundle b = new Bundle();
-                b.putString("initialCardId", cardId);
+                b.putString(LoyaltyCard.BUNDLE_LOYALTY_CARD_CARD_ID, cardId);
                 i.putExtras(b);
             }
             manualAddLauncher.launch(i);

--- a/app/src/main/java/protect/card_locker/ShortcutHelper.java
+++ b/app/src/main/java/protect/card_locker/ShortcutHelper.java
@@ -133,8 +133,7 @@ class ShortcutHelper {
         // one replace it.
         intent.setFlags(intent.getFlags() | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         final Bundle bundle = new Bundle();
-        bundle.putInt("id", loyaltyCard.id);
-        bundle.putBoolean("view", true);
+        bundle.putInt(LoyaltyCardViewActivity.BUNDLE_ID, loyaltyCard.id);
         intent.putExtras(bundle);
 
         Bitmap iconBitmap = Utils.retrieveCardImage(context, loyaltyCard.id, ImageLocationType.icon);

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -268,7 +268,7 @@ public class Utils {
             Log.i(TAG, "Read barcode id: " + contents);
             Log.i(TAG, "Read format: " + format);
 
-            return Collections.singletonList(new BarcodeValues(format, contents));
+            return Collections.singletonList(new BarcodeValues(format != null ? CatimaBarcode.fromName(format) : null, contents));
         }
 
         throw new UnsupportedOperationException("Unknown request code for parseSetBarcodeActivityResult");
@@ -323,7 +323,7 @@ public class Utils {
                 Log.i(TAG, "Read barcode id: " + barcodeResult.getText());
                 Log.i(TAG, "Read format: " + barcodeResult.getBarcodeFormat().name());
 
-                barcodeValuesList.add(new BarcodeValues(barcodeResult.getBarcodeFormat().name(), barcodeResult.getText()));
+                barcodeValuesList.add(new BarcodeValues(CatimaBarcode.fromBarcode(barcodeResult.getBarcodeFormat()), barcodeResult.getText()));
             }
 
             return barcodeValuesList;
@@ -344,7 +344,7 @@ public class Utils {
         CharSequence[] barcodeDescriptions = new CharSequence[barcodeValuesList.size()];
         for (int i = 0; i < barcodeValuesList.size(); i++) {
             BarcodeValues barcodeValues = barcodeValuesList.get(i);
-            CatimaBarcode catimaBarcode = CatimaBarcode.fromName(barcodeValues.format());
+            CatimaBarcode catimaBarcode = barcodeValues.format();
 
             String barcodeContent = barcodeValues.content();
             // Shorten overly long barcodes
@@ -353,9 +353,9 @@ public class Utils {
             }
 
             if (barcodeValues.note() != null) {
-                barcodeDescriptions[i] = String.format("%s: %s (%s)", barcodeValues.note(), catimaBarcode.prettyName(), barcodeContent);
+                barcodeDescriptions[i] = String.format("%s: %s (%s)", barcodeValues.note(), catimaBarcode != null ? catimaBarcode.prettyName() : context.getString(R.string.noBarcode), barcodeContent);
             } else {
-                barcodeDescriptions[i] = String.format("%s (%s)", catimaBarcode.prettyName(), barcodeContent);
+                barcodeDescriptions[i] = String.format("%s (%s)", catimaBarcode != null ? catimaBarcode.prettyName() : context.getString(R.string.noBarcode), barcodeContent);
             }
         }
 

--- a/app/src/main/java/protect/card_locker/importexport/CatimaExporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/CatimaExporter.java
@@ -64,7 +64,7 @@ public class CatimaExporter implements Exporter {
         Cursor cardCursor = DBHelper.getLoyaltyCardCursor(database);
         while (cardCursor.moveToNext()) {
             // For each card
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cardCursor);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cardCursor);
 
             // For each image
             for (ImageLocationType imageLocationType : ImageLocationType.values()) {
@@ -142,7 +142,7 @@ public class CatimaExporter implements Exporter {
         Cursor cardCursor = DBHelper.getLoyaltyCardCursor(database);
 
         while (cardCursor.moveToNext()) {
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cardCursor);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cardCursor);
 
             printer.printRecord(card.id,
                     card.store,
@@ -176,7 +176,7 @@ public class CatimaExporter implements Exporter {
         Cursor cardCursor2 = DBHelper.getLoyaltyCardCursor(database);
 
         while (cardCursor2.moveToNext()) {
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cardCursor2);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cardCursor2);
 
             for (Group group : DBHelper.getLoyaltyCardGroups(database, card.id)) {
                 printer.printRecord(card.id, group._id);

--- a/app/src/test/java/protect/card_locker/ImportExportTest.java
+++ b/app/src/test/java/protect/card_locker/ImportExportTest.java
@@ -174,7 +174,7 @@ public class ImportExportTest {
         int index = 1;
 
         while (cursor.moveToNext()) {
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cursor);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cursor);
 
             String expectedStore = String.format("store, \"%4d", index);
             String expectedNote = String.format("note, \"%4d", index);
@@ -200,7 +200,7 @@ public class ImportExportTest {
         Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
 
         while (cursor.moveToNext()) {
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cursor);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cursor);
 
             // ID goes up for duplicates (b/c the cursor orders by store), down for originals
             int index = card.id > numCards ? card.id - numCards : numCards - card.id + 1;
@@ -236,7 +236,7 @@ public class ImportExportTest {
 
         while (index < 10) {
             cursor.moveToNext();
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cursor);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cursor);
 
             String expectedStore = String.format("store, \"%4d", index);
             String expectedNote = String.format("note, \"%4d", index);
@@ -258,7 +258,7 @@ public class ImportExportTest {
 
         index = 1;
         while (cursor.moveToNext() && index < 5) {
-            LoyaltyCard card = LoyaltyCard.toLoyaltyCard(cursor);
+            LoyaltyCard card = LoyaltyCard.fromCursor(cursor);
 
             String expectedStore = String.format("store, \"%4d", index);
             String expectedNote = String.format("note, \"%4d", index);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardCursorAdapterTest.java
@@ -137,7 +137,7 @@ public class LoyaltyCardCursorAdapterTest {
         assertEquals(4, cursor.getCount());
 
         assertTrue(cursor.moveToFirst());
-        LoyaltyCard loyaltyCard = LoyaltyCard.toLoyaltyCard(cursor);
+        LoyaltyCard loyaltyCard = LoyaltyCard.fromCursor(cursor);
         assertEquals("storeD", loyaltyCard.store);
         View view = createView(cursor);
         ConstraintLayout star = view.findViewById(R.id.star);
@@ -146,7 +146,7 @@ public class LoyaltyCardCursorAdapterTest {
         assertEquals(View.GONE, archive.getVisibility());
 
         assertTrue(cursor.moveToNext());
-        loyaltyCard = LoyaltyCard.toLoyaltyCard(cursor);
+        loyaltyCard = LoyaltyCard.fromCursor(cursor);
         assertEquals("storeC", loyaltyCard.store);
         view = createView(cursor);
         star = view.findViewById(R.id.star);
@@ -155,7 +155,7 @@ public class LoyaltyCardCursorAdapterTest {
         assertEquals(View.GONE, archive.getVisibility());
 
         assertTrue(cursor.moveToNext());
-        loyaltyCard = LoyaltyCard.toLoyaltyCard(cursor);
+        loyaltyCard = LoyaltyCard.fromCursor(cursor);
         assertEquals("storeB", loyaltyCard.store);
         view = createView(cursor);
         star = view.findViewById(R.id.star);
@@ -164,7 +164,7 @@ public class LoyaltyCardCursorAdapterTest {
         assertEquals(View.VISIBLE, archive.getVisibility());
 
         assertTrue(cursor.moveToNext());
-        loyaltyCard = LoyaltyCard.toLoyaltyCard(cursor);
+        loyaltyCard = LoyaltyCard.fromCursor(cursor);
         assertEquals("storeA", loyaltyCard.store);
         view = createView(cursor);
         star = view.findViewById(R.id.star);

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -364,7 +364,7 @@ public class LoyaltyCardViewActivityTest {
             System.out.println();
 
             if (!newCard) {
-                cardId = (int) DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+                cardId = (int) DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
             } else {
                 cardId = null;
             }
@@ -612,7 +612,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -632,7 +632,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -651,7 +651,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -676,7 +676,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         LoyaltyCardEditActivity activity = (LoyaltyCardEditActivity) activityController.get();
@@ -715,7 +715,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -748,7 +748,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -773,7 +773,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -824,7 +824,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -865,7 +865,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -897,7 +897,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -931,7 +931,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -968,7 +968,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1005,7 +1005,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1050,7 +1050,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1071,7 +1071,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1092,7 +1092,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1112,7 +1112,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1132,7 +1132,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1163,7 +1163,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
@@ -1200,7 +1200,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         AppCompatActivity activity = (AppCompatActivity) activityController.get();
@@ -1296,7 +1296,7 @@ public class LoyaltyCardViewActivityTest {
         final Context context = ApplicationProvider.getApplicationContext();
         SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null, 0);
 
         ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         AppCompatActivity activity = (AppCompatActivity) activityController.get();

--- a/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
+++ b/app/src/test/java/protect/card_locker/LoyaltyCardViewActivityTest.java
@@ -37,9 +37,11 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.test.core.app.ApplicationProvider;
 
 import com.google.android.material.bottomappbar.BottomAppBar;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -347,7 +349,12 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void noDataLossOnResumeOrRotate() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
+
         registerMediaStoreIntentHandler();
+
+        Integer cardId;
 
         for (boolean newCard : new boolean[]{false, true}) {
             System.out.println();
@@ -356,21 +363,14 @@ public class LoyaltyCardViewActivityTest {
             System.out.println("=====");
             System.out.println();
 
-            ActivityController activityController;
-
             if (!newCard) {
-                activityController = createActivityWithLoyaltyCard(true);
+                cardId = (int) DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
             } else {
-                activityController = Robolectric.buildActivity(LoyaltyCardEditActivity.class).create();
+                cardId = null;
             }
 
+            ActivityController activityController = createActivityWithLoyaltyCard(true, cardId);
             LoyaltyCardEditActivity activity = (LoyaltyCardEditActivity) activityController.get();
-            final Context context = activity.getApplicationContext();
-            SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-
-            if (!newCard) {
-                DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
-            }
 
             activityController.start();
             activityController.visible();
@@ -403,9 +403,9 @@ public class LoyaltyCardViewActivityTest {
             storeField.setText("correct store");
             noteField.setText("correct note");
             LoyaltyCardEditActivity.formatDateField(context, validFromField, validFromDate);
-            activity.updateTempState(LoyaltyCardField.validFrom, validFromDate);
+            activity.setLoyaltyCardValidFrom(validFromDate);
             LoyaltyCardEditActivity.formatDateField(context, expiryField, expiryDate);
-            activity.updateTempState(LoyaltyCardField.expiry, expiryDate);
+            activity.setLoyaltyCardExpiry(expiryDate);
             balanceField.setText("100");
             balanceTypeField.setText(currency.getSymbol());
             cardIdField.setText("12345678");
@@ -461,6 +461,9 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithoutParametersCannotCreateLoyaltyCard() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
+
         ActivityController activityController = Robolectric.buildActivity(LoyaltyCardEditActivity.class).create();
         activityController.start();
         activityController.visible();
@@ -468,7 +471,6 @@ public class LoyaltyCardViewActivityTest {
 
         Activity activity = (Activity) activityController.get();
 
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
         assertEquals(0, DBHelper.getLoyaltyCardCount(database));
 
         final EditText storeField = activity.findViewById(R.id.storeNameEdit);
@@ -583,18 +585,20 @@ public class LoyaltyCardViewActivityTest {
         assertEquals(true, activity.isFinishing());
     }
 
-    private ActivityController createActivityWithLoyaltyCard(boolean editMode) {
+    private ActivityController createActivityWithLoyaltyCard(boolean editMode, @Nullable Integer loyaltyCardId) {
         Intent intent = new Intent();
         final Bundle bundle = new Bundle();
-        bundle.putInt("id", 1);
 
         Class clazz;
 
         if (editMode) {
-            bundle.putBoolean("update", true);
+            if (loyaltyCardId != null) {
+                bundle.putInt(LoyaltyCardEditActivity.BUNDLE_ID, loyaltyCardId);
+                bundle.putBoolean(LoyaltyCardEditActivity.BUNDLE_UPDATE, true);
+            }
             clazz = LoyaltyCardEditActivity.class;
         } else {
-            bundle.putBoolean("view", true);
+            bundle.putInt(LoyaltyCardViewActivity.BUNDLE_ID, loyaltyCardId);
             clazz = LoyaltyCardViewActivity.class;
         }
 
@@ -605,12 +609,14 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardEditModeCheckDisplay() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
+
 
         activityController.start();
         activityController.visible();
@@ -623,12 +629,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardViewModeCheckDisplay() {
-        ActivityController activityController = createActivityWithLoyaltyCard(false);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -641,12 +648,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardWithBarcodeUpdateBarcode() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -665,12 +673,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardWithReceiptUpdateReceiptCancel() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        LoyaltyCardEditActivity activity = (LoyaltyCardEditActivity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        LoyaltyCardEditActivity activity = (LoyaltyCardEditActivity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -703,12 +712,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardNoExpirySetExpiry() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -735,12 +745,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardExpirySetNoExpiry() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, new Date(), new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -759,12 +770,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardNoBalanceSetBalance() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -809,12 +821,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardBalanceSetNoBalance() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("10.00"), Currency.getInstance("USD"), EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -849,12 +862,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardSameAsCardIDUpdateBarcodeID() {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -880,12 +894,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardSameAsCardIDUpdateCardID() {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, null, EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -913,12 +928,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardDifferentFromCardIDUpdateCardIDUpdate() {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -949,12 +965,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithLoyaltyCardDifferentFromCardIDUpdateCardIDDoNotUpdate() {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, EAN_BARCODE_DATA, "123456", EAN_BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -985,11 +1002,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void checkMenu() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(false);
-        Activity activity = (Activity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -1011,15 +1030,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithMissingLoyaltyCard() throws IOException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
+        ActivityController activityController = createActivityWithLoyaltyCard(true, 1);
         Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
-        activityController.resume();
 
         // The activity should find that the card is missing and shut down
-
         assertTrue(activity.isFinishing());
 
         // Make sure the activity can close down
@@ -1030,11 +1047,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithoutParametersViewBack() {
-        ActivityController activityController = createActivityWithLoyaltyCard(false);
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
 
         activityController.start();
         activityController.visible();
@@ -1049,11 +1068,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startWithoutColors() {
-        ActivityController activityController = createActivityWithLoyaltyCard(false);
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
 
         activityController.start();
         activityController.visible();
@@ -1068,11 +1089,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startLoyaltyCardWithoutColorsSave() throws IOException, ParseException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, null, 0, null,0);
 
         activityController.start();
         activityController.visible();
@@ -1086,11 +1109,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void startLoyaltyCardWithExplicitNoBarcodeSave() throws IOException, ParseException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
         Activity activity = (Activity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
 
         activityController.start();
         activityController.visible();
@@ -1104,12 +1129,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void removeBarcodeFromLoyaltyCard() throws IOException, ParseException {
-        ActivityController activityController = createActivityWithLoyaltyCard(true);
-        Activity activity = (Activity) activityController.get();
-        final Context context = activity.getApplicationContext();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(true, (int) cardId);
+        Activity activity = (Activity) activityController.get();
 
         activityController.start();
         activityController.visible();
@@ -1119,7 +1145,7 @@ public class LoyaltyCardViewActivityTest {
         checkAllFields(activity, ViewMode.UPDATE_CARD, "store", "note", context.getString(R.string.anyDate), context.getString(R.string.never), "0", context.getString(R.string.points), BARCODE_DATA, context.getString(R.string.sameAsCardId), BARCODE_TYPE.prettyName(), null, null);
 
         // Complete empty barcode selection successfully
-        selectBarcodeWithResult(activity, BARCODE_DATA, "", true);
+        selectBarcodeWithResult(activity, BARCODE_DATA, null, true);
         activityController.resume();
 
         // Check if the barcode type is NO_BARCODE as expected
@@ -1134,11 +1160,14 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void checkPushStarIcon() {
-        ActivityController activityController = createActivityWithLoyaltyCard(false);
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         Activity activity = (Activity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
         activityController.start();
         activityController.visible();
         activityController.resume();
@@ -1168,11 +1197,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void checkBarcodeFullscreenWorkflow() {
-        ActivityController activityController = createActivityWithLoyaltyCard(false);
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         AppCompatActivity activity = (AppCompatActivity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, BARCODE_TYPE, Color.BLACK, 0, null,0);
 
         activityController.start();
         activityController.visible();
@@ -1262,11 +1293,13 @@ public class LoyaltyCardViewActivityTest {
 
     @Test
     public void checkNoBarcodeFullscreenWorkflow() {
-        ActivityController activityController = createActivityWithLoyaltyCard(false);
+        final Context context = ApplicationProvider.getApplicationContext();
+        SQLiteDatabase database = TestHelpers.getEmptyDb(context).getWritableDatabase();
 
+        long cardId = DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
+
+        ActivityController activityController = createActivityWithLoyaltyCard(false, (int) cardId);
         AppCompatActivity activity = (AppCompatActivity) activityController.get();
-        SQLiteDatabase database = TestHelpers.getEmptyDb(activity).getWritableDatabase();
-        DBHelper.insertLoyaltyCard(database, "store", "note", null, null, new BigDecimal("0"), null, BARCODE_DATA, null, null, Color.BLACK, 0, null,0);
 
         activityController.start();
         activityController.visible();


### PR DESCRIPTION
This allows us to send any (partial) loyalty card into the edit activity, granting us greater flexibility in what kind of scan result we can parse