### PR TITLE
Set up ACRA with email crash alerts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,7 +87,6 @@ android {
 }
 
 dependencies {
-
     // AndroidX
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
@@ -107,6 +106,11 @@ dependencies {
     implementation("org.apache.commons:commons-csv:1.9.0")
     implementation("com.jaredrummler:colorpicker:1.1.0")
     implementation("net.lingala.zip4j:zip4j:2.11.5")
+
+    // Crash reporting
+    val acraVersion = "5.11.4"
+    implementation("ch.acra:acra-mail:$acraVersion")
+    implementation("ch.acra:acra-dialog:$acraVersion")
 
     // SpotBugs
     implementation("io.wcm.tooling.spotbugs:io.wcm.tooling.spotbugs.annotations:1.0.0")

--- a/app/src/main/java/protect/card_locker/LoyaltyCardLockerApplication.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardLockerApplication.java
@@ -4,6 +4,12 @@ import android.app.Application;
 
 import androidx.appcompat.app.AppCompatDelegate;
 
+import org.acra.ACRA;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.DialogConfigurationBuilder;
+import org.acra.config.MailSenderConfigurationBuilder;
+import org.acra.data.StringFormat;
+
 import protect.card_locker.preferences.Settings;
 
 public class LoyaltyCardLockerApplication extends Application {
@@ -12,6 +18,26 @@ public class LoyaltyCardLockerApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
+        // Initialize crash reporter
+        ACRA.init(this, new CoreConfigurationBuilder()
+                //core configuration:
+                .withBuildConfigClass(BuildConfig.class)
+                .withReportFormat(StringFormat.KEY_VALUE_LIST)
+                .withPluginConfigurations(
+                        new DialogConfigurationBuilder()
+                                .withText(String.format(getString(R.string.acra_catima_has_crashed), getString(R.string.app_name)))
+                                .withCommentPrompt(getString(R.string.acra_explain_crash))
+                                .withResTheme(R.style.AppTheme)
+                                .build(),
+                        new MailSenderConfigurationBuilder()
+                                .withMailTo("catima.g9ex3@hackerchick.me")
+                                .withSubject(String.format(getString(R.string.acra_crash_email_subject), getString(R.string.app_name)))
+                                .withReportAsFile(false)
+                                .build()
+                )
+        );
+
+        // Set theme
         Settings settings = new Settings(this);
         AppCompatDelegate.setDefaultNightMode(settings.getTheme());
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,4 +346,7 @@
     <string name="exportCancelled">Export cancelled</string>
     <string name="useFrontImage">Use front image</string>
     <string name="useBackImage">Use back image</string>
+    <string name="acra_catima_has_crashed">We\'re sorry, but <xliff:g id="app_name">%s</xliff:g> has crashed. Please help us fix this issue by sending us an error report.</string>
+    <string name="acra_explain_crash">If possible, please add more details on what you were doing here:</string>
+    <string name="acra_crash_email_subject"><xliff:g id="app_name">%s</xliff:g> crash report</string>
 </resources>


### PR DESCRIPTION
This relates to #2106. However, I wouldn't call this a fix as the email notification method is likely to confuse non-technical users.

This MR mostly exists to show how relatively easy ACRA is and to have a quick reference to a branch that can be used for users who are experienced with sideloading but not so much with Scoop (which is a very small subset).