### PR TITLE
Don't show import cancelled text on import completion

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportTask.java
+++ b/app/src/main/java/protect/card_locker/ImportExportTask.java
@@ -91,18 +91,14 @@ public class ImportExportTask implements CompatCallable<ImportExportResult> {
         progress = new ProgressDialog(activity);
         progress.setTitle(doImport ? R.string.importing : R.string.exporting);
 
-        progress.setOnCancelListener(dialog -> cancel(doImport, true));
-        progress.setOnDismissListener(dialog -> cancel(doImport, true));
+        progress.setOnCancelListener(dialog -> cancel());
+        progress.setOnDismissListener(dialog -> cancel());
 
         progress.show();
     }
 
-    private void cancel(boolean isImport, boolean showToast) {
+    private void cancel() {
         ImportExportTask.this.stop();
-
-        if (showToast) {
-            Toast.makeText(activity, isImport ? R.string.importCancelled : R.string.exportCancelled, Toast.LENGTH_LONG).show();
-        }
     }
 
     protected ImportExportResult doInBackground(Void... nothing) {


### PR DESCRIPTION
Regression introduced in #1983. Fixes #2104.

Not completely happy with this but still an improvement.

The whole import/export flow needs to be completely redesigned still...