### PR TITLE
Limit max line count to 5 on main view

### DIFF
--- a/app/src/main/res/layout/loyalty_card_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_layout.xml
@@ -151,6 +151,8 @@
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
             android:textAppearance="?attr/textAppearanceBody2"
+            android:maxLines="5"
+            android:ellipsize="end"
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintTop_toBottomOf="@+id/store"


### PR DESCRIPTION
This prevents cards with very long notes to take up the entire screen or more. This effect is worse with more columns.