### PR TITLE
Re-add F-Droid

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ Copylefted libre software (GPLv3+) card management app.
 
 [![GitHub Version](https://img.shields.io/github/v/release/CatimaLoyalty/Android.svg?logo=github&label=GitHub)](https://github.com/CatimaLoyalty/Android/releases)
 [![IzzyOnDroid Version](https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/me.hackerchick.catima)](https://apt.izzysoft.de/fdroid/index/apk/me.hackerchick.catima)
+[![F-Droid Version](https://img.shields.io/f-droid/v/me.hackerchick.catima.svg?logo=f-droid&label=F-Droid)](https://f-droid.org/packages/me.hackerchick.catima/)
 [![Google Play Store Version](https://img.shields.io/endpoint?color=blue&logo=google-play&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dme.hackerchick.catima%26l%3DGoogle%2520Play%26m%3D%24version)](https://play.google.com/store/apps/details?id=me.hackerchick.catima)
 
 ![Android CI](https://github.com/CatimaLoyalty/Android/workflows/Android%20CI/badge.svg)
@@ -13,7 +14,8 @@ Copylefted libre software (GPLv3+) card management app.
 
 <a href="https://apt.izzysoft.de/fdroid/index/apk/me.hackerchick.catima" target="_blank">
 <img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height="90"/></a>
-
+<a href="https://f-droid.org/repository/browse/?fdid=me.hackerchick.catima" target="_blank">
+<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
 <a href="https://play.google.com/store/apps/details?id=me.hackerchick.catima" target="_blank">
 <img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>
 


### PR DESCRIPTION
While I would still strongly recommend using IzzyOnDroid (it's faster, it uses my signing key so you can switch to the official build and are not locked into anything, among other benefits) over F-Droid, given Google's constant ramping-up of FOSS-dev-hostile policies, putting my eggs into more baskets seems still better.

Imho, the order of preference should be:
IzzyOnDroid > F-Droid > Google Play

(GitHub should only really be used for those who have other tools to watch GitHub for updates)