### PR TITLE
Use Sans fonts for app name

### DIFF
--- a/.scripts/generate_feature_graphic/generate_feature_graphic.sh
+++ b/.scripts/generate_feature_graphic/generate_feature_graphic.sh
@@ -37,12 +37,12 @@ for lang in "$script_location/../../fastlane/metadata/android/"*; do
     # We specifically need the Serif version because of the 200 weight
     case "$(basename "$lang")" in
       bg|el-GR|ru-RU|uk) sed -i "s/Lexend Deca/Noto Serif/" featureGraphic.svg ;;
-      hi-IN) sed -i -e "s/Yesteryear/Noto Serif Devanagari/" -e "s/Lexend Deca/Noto Serif Devanagari/" featureGraphic.svg ;;
+      hi-IN) sed -i -e "s/Yesteryear/Noto Sans Devanagari/" -e "s/Lexend Deca/Noto Serif Devanagari/" featureGraphic.svg ;;
       ja-JP) sed -i "s/Lexend Deca/Noto Serif CJK JP/" featureGraphic.svg ;;
       kn-IN) sed -i -e 's/font-size="150"/font-size="100"/' -e "s/Yesteryear/Noto Serif Kannada/" featureGraphic.svg ;;
       ko) sed -i "s/Lexend Deca/Noto Serif CJK KR/" featureGraphic.svg ;;
       zh-CN) sed -i "s/Lexend Deca/Noto Serif CJK SC/" featureGraphic.svg ;;
-      zh-TW) sed -i "s/Lexend Deca/Noto Serif CJK TC/" featureGraphic.svg ;;
+      zh-TW) sed -i -e "s/Yesteryear/Noto Sans CJK TC/" -e "s/Lexend Deca/Noto Serif CJK TC/" featureGraphic.svg ;;
       *) ;;
     esac
   fi


### PR DESCRIPTION
Sans could be "friendlier". This also fixes the new zh-TW picture not showing up