### PR TITLE
Ensure save button stays pressable while keyboard is visible in edit screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,13 +75,12 @@
         <activity
             android:name=".LoyaltyCardViewActivity"
             android:exported="true"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden" />
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".LoyaltyCardEditActivity"
             android:exported="true"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter
                 android:autoVerify="true"
                 android:label="@string/app_name">
@@ -119,8 +118,7 @@
         <activity
             android:name=".BarcodeSelectorActivity"
             android:label="@string/selectBarcodeTitle"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden" />
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".preferences.SettingsActivity"
             android:label="@string/settings"


### PR DESCRIPTION
Also cleans up some other unnecessary windowSoftInputMode configurations left over from years ago

Fixes #1967