### PR TITLE
Bump compile SDK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ spotbugs {
 
 android {
     namespace = "protect.card_locker"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "me.hackerchick.catima"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.7.3" apply false
+    id("com.android.application") version "8.8.0" apply false
     id("com.github.spotbugs") version "5.1.4" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }


### PR DESCRIPTION
Forgot to include this with #2263.

Part of #2150.

This also contains a bump of AGP. Not directly related to the compileSdk change but as a general "Android versioning bump" it seemed fine to include it here.