### PR TITLE
Add unofficial support for espass

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
                 <data android:mimeType="application/pdf" />
                 <data android:mimeType="application/vnd.apple.pkpass" />
                 <data android:mimeType="application/vnd-com.apple.pkpass" />
+                <data android:mimeType="application/vnd.espass-espass" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
@@ -60,6 +61,7 @@
                 <data android:mimeType="application/pdf" />
                 <data android:mimeType="application/vnd.apple.pkpass" />
                 <data android:mimeType="application/vnd-com.apple.pkpass" />
+                <data android:mimeType="application/vnd.espass-espass" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -502,6 +502,11 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
                 parseResultList = Utils.retrieveBarcodesFromPdf(this, data);
             } else if (Arrays.asList("application/vnd.apple.pkpass", "application/vnd-com.apple.pkpass").contains(receivedType)) {
                 parseResultList = Utils.retrieveBarcodesFromPkPass(this, data);
+            } else if (receivedType.equals("application/vnd.espass-espass")) {
+                // FIXME: espass is not pkpass
+                // However, several users stated in https://github.com/CatimaLoyalty/Android/issues/2197 that the formats are extremely similar to the point they could rename an .espass file to .pkpass and have it imported
+                // So it makes sense to "unofficially" treat it as a PKPASS for now, even though not completely correct
+                parseResultList = Utils.retrieveBarcodesFromPkPass(this, data);
             } else {
                 Log.e(TAG, "Wrong mime-type");
                 return;


### PR DESCRIPTION
While espass files aren't pkpass files, they are so similar we can generally parse them fine with the pkpass parser. While this feature shouldn't be advertised as it is kinda hacky, it does make it easier for PassAndroid users to share cards with Catima users.

Helps with #2197, though not a real fix.