### PR TITLE
Temporarily opt ucrop activity out of Android 15 edge-to-edge

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -179,7 +179,7 @@
 
         <activity
             android:name=".UCropWrapper"
-            android:theme="@style/AppTheme.NoActionBar" />
+            android:theme="@style/TempUCropAndroid15WorkaroundTheme" />
 
         <provider
             android:name=".contentprovider.CardsContentProvider"

--- a/app/src/main/res/values-v35/themes.xml
+++ b/app/src/main/res/values-v35/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- FIXME: Remove this workaround as soon as uCrop no longer needs it: https://github.com/Yalantis/uCrop/issues/913 -->
+    <style name="TempUCropAndroid15WorkaroundTheme" parent="AppTheme.NoActionBar">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,7 @@
 <resources>
+    <!-- FIXME: Remove this workaround as soon as uCrop no longer needs it: https://github.com/Yalantis/uCrop/issues/913 -->
+    <style name="TempUCropAndroid15WorkaroundTheme" parent="AppTheme.NoActionBar">
+    </style>
 
     <style name="AppTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="colorPrimary">@color/md_theme_light_primary</item>


### PR DESCRIPTION
This should be reverted as soon as
https://github.com/Yalantis/uCrop/issues/913 is fixed