### PR TITLE
Revert to targeting Android 14

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId = "me.hackerchick.catima"
         minSdk = 21
-        targetSdk = 35
+        targetSdk = 34
         versionCode = 145
         versionName = "2.34.3"
 

--- a/app/src/main/res/layout/barcode_selector_activity.xml
+++ b/app/src/main/res/layout/barcode_selector_activity.xml
@@ -4,8 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="fill_parent">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="fill_parent"

--- a/app/src/main/res/layout/import_export_activity.xml
+++ b/app/src/main/res/layout/import_export_activity.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                     xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                     android:layout_width="match_parent"
+                                                     android:layout_height="match_parent"
+                                                     android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/loyalty_card_view_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_view_layout.xml
@@ -8,8 +8,7 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -26,8 +25,7 @@
         android:layout_marginBottom="100dp"
         android:orientation="vertical"
         android:layout_marginStart="0dp"
-        android:layout_marginEnd="0dp"
-        android:fitsSystemWindows="true">
+        android:layout_marginEnd="0dp">
 
         <LinearLayout
             android:id="@+id/icon_container"
@@ -149,8 +147,7 @@
         android:id="@+id/fullscreen_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:fitsSystemWindows="false">
+        android:orientation="vertical">
 
         <ImageView
             android:importantForAccessibility="no"
@@ -209,13 +206,13 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:background="?attr/colorPrimary"
-        app:fabAlignmentMode="center"
-        app:fabCradleVerticalOffset="2dp"
-        android:fitsSystemWindows="true">
+        app:contentInsetLeft="0dp"
+        app:contentInsetStart="0dp"
+        app:contentInsetRight="0dp"
+        app:contentInsetEnd="0dp"
+        app:fabAlignmentMode="center">
 
         <LinearLayout
-            android:paddingTop="12dp"
-            android:paddingBottom="12dp"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layoutDirection="ltr">

--- a/app/src/main/res/layout/scan_activity.xml
+++ b/app/src/main/res/layout/scan_activity.xml
@@ -5,7 +5,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".ScanActivity">
 
     <com.google.android.material.appbar.AppBarLayout

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -31,7 +31,6 @@
         <item name="alertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog.Monet</item>
 
         <item name="windowActionModeOverlay">true</item>
-
     </style>
 
     <style name="ThemeOverlay.App.MaterialAlertDialog.Monet" parent="ThemeOverlay.Material3.MaterialAlertDialog">


### PR DESCRIPTION
This reverts commit https://github.com/CatimaLoyalty/Android/commit/ff08dbe5d53dea82ff8fd1a36796e9a56cca42d2.

I tried keeping the target at Android 15 and opting out of edge-to-edge
enforcement, but this is not a true compatibility mode and broke the
multi-selection UI in the main activity.