### PR TITLE
updated textSize, paddingStart, marginStart to be consistent with most of Android UI guidelines

### DIFF
--- a/app/src/main/res/layout/sorting_option.xml
+++ b/app/src/main/res/layout/sorting_option.xml
@@ -12,10 +12,10 @@
             android:id="@+id/checkBox_reverse"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:paddingStart="20dp"
+            android:layout_marginStart="16dp"
+            android:paddingStart="16dp"
             android:text="@string/reverse"
-            android:textSize="16sp"
+            android:textSize="18sp"
             android:textColor="?attr/colorOnSurfaceVariant"/>
 
     </LinearLayout>


### PR DESCRIPTION
### Description of the Problem:
The layout for the `CheckBox` in the `sorting_option.xml` was not properly spaced, resulting in a cluttered appearance and inconsistent alignment. 

### Solution:
I adjusted the `textSize`, `paddingStart`, and `marginStart` for the `CheckBox` to improve its readability and visual alignment within the `LinearLayout`. Specifically:
- Increased `textSize` to `18sp` for better readability.
- Set `paddingStart` and `marginStart` to `16dp` for consistent spacing around the checkbox.

### Why I Chose This Solution:
These changes adhere to common Android UI best practices, ensuring that the checkbox appears neatly aligned and readable across different screen sizes and densities.

### Testing:
The changes have been tested through unit tests, static analysis (Lint, SpotBugs), and manual UI verification on a live device/emulator.
