### PR TITLE
Target Android 15

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId = "me.hackerchick.catima"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 146
         versionName = "2.34.4"
 

--- a/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
@@ -45,6 +45,7 @@ public class BarcodeSelectorActivity extends CatimaAppCompatActivity implements 
         binding = BarcodeSelectorActivityBinding.inflate(getLayoutInflater());
         setTitle(R.string.selectBarcodeTitle);
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
         enableToolbarBackButton();

--- a/app/src/main/java/protect/card_locker/CardShortcutConfigure.java
+++ b/app/src/main/java/protect/card_locker/CardShortcutConfigure.java
@@ -36,6 +36,7 @@ public class CardShortcutConfigure extends CatimaAppCompatActivity implements Lo
         setResult(RESULT_CANCELED);
 
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         toolbar.setTitle(R.string.shortcutSelectCard);
         setSupportActionBar(toolbar);

--- a/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
+++ b/app/src/main/java/protect/card_locker/CatimaAppCompatActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.view.Window;
 
+import androidx.activity.EdgeToEdge;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -24,6 +25,7 @@ public class CatimaAppCompatActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
+        EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
         Utils.patchColors(this);
     }

--- a/app/src/main/java/protect/card_locker/ImportExportActivity.java
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.java
@@ -60,6 +60,7 @@ public class ImportExportActivity extends CatimaAppCompatActivity {
         binding = ImportExportActivityBinding.inflate(getLayoutInflater());
         setTitle(R.string.importExport);
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
         enableToolbarBackButton();

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -297,6 +297,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         super.onCreate(savedInstanceState);
         binding = LoyaltyCardEditActivityBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
 
         viewModel = new ViewModelProvider(this).get(LoyaltyCardEditActivityViewModel.class);
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -248,6 +248,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         super.onCreate(savedInstanceState);
         binding = LoyaltyCardViewLayoutBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
 

--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -229,6 +229,7 @@ public class MainActivity extends CatimaAppCompatActivity implements LoyaltyCard
 
         binding = MainActivityBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         setSupportActionBar(binding.toolbar);
         groupsTabLayout = binding.groups;
         contentMainBinding = ContentMainBinding.bind(binding.include.getRoot());

--- a/app/src/main/java/protect/card_locker/ManageGroupActivity.java
+++ b/app/src/main/java/protect/card_locker/ManageGroupActivity.java
@@ -48,6 +48,7 @@ public class ManageGroupActivity extends CatimaAppCompatActivity implements Mana
         super.onCreate(inputSavedInstanceState);
         binding = ActivityManageGroupBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
 

--- a/app/src/main/java/protect/card_locker/ManageGroupsActivity.java
+++ b/app/src/main/java/protect/card_locker/ManageGroupsActivity.java
@@ -42,6 +42,7 @@ public class ManageGroupsActivity extends CatimaAppCompatActivity implements Gro
         binding = ManageGroupsActivityBinding.inflate(getLayoutInflater());
         setTitle(R.string.groups);
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
         enableToolbarBackButton();

--- a/app/src/main/java/protect/card_locker/ScanActivity.java
+++ b/app/src/main/java/protect/card_locker/ScanActivity.java
@@ -100,6 +100,7 @@ public class ScanActivity extends CatimaAppCompatActivity {
         customBarcodeScannerBinding = CustomBarcodeScannerBinding.bind(binding.zxingBarcodeScanner);
         setTitle(R.string.scanCardBarcode);
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
         enableToolbarBackButton();

--- a/app/src/main/java/protect/card_locker/UCropWrapper.java
+++ b/app/src/main/java/protect/card_locker/UCropWrapper.java
@@ -25,6 +25,13 @@ public class UCropWrapper extends UCropActivity {
     public static final String UCROP_TOOLBAR_TYPEFACE_STYLE = "ucop_toolbar_typeface_style";
 
     @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Utils.applyWindowInsets(findViewById(android.R.id.content));
+    }
+
+    @Override
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         boolean darkMode = Utils.isDarkModeEnabled(this);

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -38,7 +39,10 @@ import androidx.annotation.RawRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.graphics.ColorUtils;
+import androidx.core.graphics.Insets;
 import androidx.core.os.LocaleListCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.core.widget.TextViewCompat;
 import androidx.exifinterface.media.ExifInterface;
@@ -1092,5 +1096,21 @@ public class Utils {
         } catch (CameraAccessException e) {
             return false;
         }
+    }
+
+    public static void applyWindowInsets(View root) {
+        /* This function basically fakes the activity being edge-to-edge. Useful for those activities that are really hard to get to behave well */
+        ViewCompat.setOnApplyWindowInsetsListener(root, (view, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+            ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+            layoutParams.leftMargin = insets.left;
+            layoutParams.bottomMargin = insets.bottom;
+            layoutParams.rightMargin = insets.right;
+            layoutParams.topMargin = insets.top;
+            view.setLayoutParams(layoutParams);
+
+            return WindowInsetsCompat.CONSUMED;
+        });
     }
 }

--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.java
@@ -42,6 +42,7 @@ public class SettingsActivity extends CatimaAppCompatActivity {
         binding = SettingsActivityBinding.inflate(getLayoutInflater());
         setTitle(R.string.settings);
         setContentView(binding.getRoot());
+        Utils.applyWindowInsets(binding.getRoot());
         Toolbar toolbar = binding.toolbar;
         setSupportActionBar(toolbar);
         enableToolbarBackButton();

--- a/app/src/main/res/layout/group_main.xml
+++ b/app/src/main/res/layout/group_main.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context="protect.card_locker.MainActivity"
+    tools:context="protect.card_locker.ManageGroupActivity"
     tools:showIn="@layout/main_activity">
 
     <TextView

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,6 @@ dependencyResolutionManagement {
             filter {
                 // limit jitpack repository to these groups
                 includeGroup("com.github.yalantis")
-                includeGroup("com.github.invissvenska")
             }
         }
     }


### PR DESCRIPTION
This also contains partial (but not complete) edge-to-edge support. Basically, whatever could easily support edge-to-edge had edge-to-edge added, but things that were too challenging were skipped for now.

TODO:

- [x] Fix UCropActivity

|                                            | Home | Scan | Barcode selector | View | Edit | Groups | Import/Export | Settings | About | Shortcut | Ucrop |
| ---------------------------------- | --------- | ------- | ------------------------ | ------- | ------ | ---------- | --------------------- | ------------ | --------- | ------------ | ---------- |
| 15 (gesture)                     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| 15 (gesture) (hor)            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| 15 (3-button)                    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| 15 (3-button) (hor)          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| pre-15 (gesture)              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| pre-15 (gesture) (hor)     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| pre-15 (3-button)            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| pre-15 (3-button) (hor)   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |