### PR TITLE
Allow copying barcode value on tap

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeSelectorAdapter.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorAdapter.java
@@ -9,6 +9,7 @@ import android.view.ViewTreeObserver;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 
@@ -65,6 +66,15 @@ public class BarcodeSelectorAdapter extends ArrayAdapter<CatimaBarcodeWithValue>
 
         View finalConvertView = convertView;
         convertView.setOnClickListener(view -> mListener.onRowClicked(position, finalConvertView));
+
+        // Add long click listener for copying to clipboard
+        viewHolder.text.setOnLongClickListener(v -> {
+            android.content.ClipboardManager clipboard = (android.content.ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+            android.content.ClipData clip = android.content.ClipData.newPlainText("barcodeValue", value);
+            clipboard.setPrimaryClip(clip);
+            Toast.makeText(getContext(), "Barcode copied to clipboard", Toast.LENGTH_SHORT).show();
+            return true;
+        });
 
         return convertView;
     }


### PR DESCRIPTION
### Overview
This pull request allows users to copy the barcode value by long-pressing on it. 

### Changes Made
- Added a long-click listener to the barcode text in the `BarcodeSelectorAdapter`.
- Implemented clipboard functionality to copy the barcode value with user feedback via a Toast message.

### Additional Notes
I have tested this feature, but there may still be some issues that I might have overlooked. I welcome any feedback for improvements.

### Related Issue
- Closes #2400 (if applicable, mention any related issue number)
