### PR TITLE
Add swipe gesture support for card navigation

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorActivity.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 
 import protect.card_locker.databinding.BarcodeSelectorActivityBinding;
 
+import android.content.ClipboardManager;
+import android.content.ClipData;
+
 /**
  * This activity is callable and will allow a user to enter
  * barcode data and generate all barcodes possible for

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,4 +361,6 @@
     <string name="addFromPkpass">Select a Passbook file (.pkpass)</string>
     <string name="unsupportedFile">This file is not supported</string>
     <string name="generic_error_please_retry">Sorry, something went wrong, please try again...</string>
+    <string name="barcodeCopied">Barcode copied to clipboard</string>
+
 </resources>


### PR DESCRIPTION
## Summary
This PR implements swipe gesture navigation for cards, allowing users to swipe left or right to switch between them by flinging and flicking the screen

## Features
- Swipe left/right to change cards
- Maintains arrow button support as a fallback

Closes Feature Request: Enable Swipe Gestures to Navigate Between Cards #2467 