### PR TITLE
Create dependabot.yml

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/" 
+    schedule:
+      interval: "weekly" 
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
This configuration enables Dependabot to automatically check for outdated Gradle dependencies. It scans all build.gradle.kts files in the root and submodules once per week, and opens up to 5 pull requests with dependency updates.