### PR TITLE
Optimize resizeBitmap(): Skip resizing for already-small images

### DIFF
--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -593,6 +593,8 @@ public class Utils {
 
         double width = bitmap.getWidth();
         double height = bitmap.getHeight();
+        // early exit
+        if (Math.max(width, height) <= maxSize) return bitmap;
 
         if (height > width) {
             double scale = height / maxSize;

--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -593,8 +593,11 @@ public class Utils {
 
         double width = bitmap.getWidth();
         double height = bitmap.getHeight();
-        // early exit
-        if (Math.max(width, height) <= maxSize) return bitmap;
+
+        // Early exit
+        if (Math.max(width, height) <= maxSize) {
+            return bitmap;
+        }
 
         if (height > width) {
             double scale = height / maxSize;


### PR DESCRIPTION
This PR improves performance by avoiding unnecessary resizing in  `resizeBitmap()` function when the image dimensions are already within the `maxSize` constraint.

This makes import handling of small images more efficient and avoids unnecessary memory use.