### PR TITLE
Use monochrome icon for permission dialog

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <permission
         android:description="@string/permissionReadCardsDescription"
-        android:icon="@drawable/ic_launcher_foreground"
+        android:icon="@drawable/ic_launcher_monochrome"
         android:label="@string/permissionReadCardsLabel"
         android:name="${applicationId}.READ_CARDS"
         android:protectionLevel="dangerous" />


### PR DESCRIPTION
Still not sure why the icon is so horribly small, but this is much clearer

| Before | After |
| - | - |
| <img width="1116" height="1097" alt="image" src="https://github.com/user-attachments/assets/fb22dcf2-4d5a-434a-9a02-5763ee643c8e" /> | <img width="575" height="611" alt="image" src="https://github.com/user-attachments/assets/d67494f7-87f2-47fc-b0bf-d0d61d1d863f" /> |