### PR TITLE
Workaround widget crash by disabling images on Android 12L and below

### DIFF
--- a/app/src/main/java/protect/card_locker/ListWidget.kt
+++ b/app/src/main/java/protect/card_locker/ListWidget.kt
@@ -101,7 +101,8 @@ class ListWidget : AppWidgetProvider() {
             setInt(R.id.item_container_foreground, "setBackgroundColor", headerColor)
             val icon = loyaltyCard.getImageThumbnail(context)
             // setImageViewIcon is not supported on Android 5, so force Android 5 down the text path
-            if (icon != null && Build.VERSION.SDK_INT >= 23) {
+            // FIXME: The icon flow causes a crash up to Android 12L, so SDK_INT is forced up from 23 to 33
+            if (icon != null && Build.VERSION.SDK_INT >= 33) {
                 setInt(R.id.item_container_foreground, "setBackgroundColor", foreground)
                 setImageViewIcon(R.id.item_image, Icon.createWithBitmap(icon))
                 setViewVisibility(R.id.item_text, View.INVISIBLE)


### PR DESCRIPTION
This is not a proper fix. It just disables the code path on Android 12L and below.

@midnightler and @benjsc, can you please confirm the build below at least stops the crashing? I definitely don't want to disable icons completely all the way up to 12L, but this could be a viable temporary workaround to not crash at least while we properly fix it.

[app-foss-debug.zip](https://github.com/user-attachments/files/22261776/app-foss-debug.zip)