### PR TITLE
Target Android 16

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,12 +11,12 @@ kotlin {
 
 android {
     namespace = "protect.card_locker"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "me.hackerchick.catima"
         minSdk = 21
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 152
         versionName = "2.38.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -144,12 +144,10 @@
             android:name=".preferences.SettingsActivity"
             android:label="@string/settings"
             android:theme="@style/AppTheme.NoActionBar" />
-        <!-- FIXME: locked screenOrientation is a workaround for https://github.com/CatimaLoyalty/Android/issues/1715, remove when https://github.com/CatimaLoyalty/Android/issues/513 is fixed -->
         <activity
             android:name=".ImportExportActivity"
             android:label="@string/importExport"
             android:exported="true"
-            android:screenOrientation="locked"
             android:theme="@style/AppTheme.NoActionBar">
 
             <!-- ZIP Intent Filter -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -144,6 +144,7 @@
             android:name=".preferences.SettingsActivity"
             android:label="@string/settings"
             android:theme="@style/AppTheme.NoActionBar" />
+        <!-- FIXME: ImportExportActivity cancels import on rotation -->
         <activity
             android:name=".ImportExportActivity"
             android:label="@string/importExport"

--- a/app/src/main/java/protect/card_locker/ImportExportTask.java
+++ b/app/src/main/java/protect/card_locker/ImportExportTask.java
@@ -99,7 +99,7 @@ public class ImportExportTask implements CompatCallable<ImportExportResult> {
 
         // Create components
         TextView progressDialogTextView = new TextView(activity);
-        progressDialogTextView.setText(R.string.pleaseDoNotRotateTheDevice);
+        progressDialogTextView.setText(R.string.pleaseDoNotRotateTheDevice); // FIXME: Instead of telling the user to not rotate, rotation should not cancel the import
         ProgressBar progressDialogProgressBar = new ProgressBar(activity);
         progressDialogProgressBar.setIndeterminate(true);
 

--- a/app/src/main/java/protect/card_locker/ImportExportTask.java
+++ b/app/src/main/java/protect/card_locker/ImportExportTask.java
@@ -1,12 +1,17 @@
 package protect.card_locker;
 
 import android.app.Activity;
-import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
-import android.widget.Toast;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,7 +37,7 @@ public class ImportExportTask implements CompatCallable<ImportExportResult> {
     private char[] password;
     private TaskCompleteListener listener;
 
-    private ProgressDialog progress;
+    private AlertDialog progress;
 
     /**
      * Constructor which will setup a task for exporting to the given file
@@ -88,12 +93,36 @@ public class ImportExportTask implements CompatCallable<ImportExportResult> {
     }
 
     public void onPreExecute() {
-        progress = new ProgressDialog(activity);
-        progress.setTitle(doImport ? R.string.importing : R.string.exporting);
+        MaterialAlertDialogBuilder progressDialogBuilder = new MaterialAlertDialogBuilder(activity);
+        progressDialogBuilder.setCancelable(false);  // Don't cancel if user taps next to dialog
+        progressDialogBuilder.setTitle(doImport ? R.string.importing : R.string.exporting);
 
-        progress.setOnCancelListener(dialog -> cancel());
-        progress.setOnDismissListener(dialog -> cancel());
+        // Create components
+        TextView progressDialogTextView = new TextView(activity);
+        progressDialogTextView.setText(R.string.pleaseDoNotRotateTheDevice);
+        ProgressBar progressDialogProgressBar = new ProgressBar(activity);
+        progressDialogProgressBar.setIndeterminate(true);
 
+        // Create LinearLayout (to put the components below each other)
+        LinearLayout progressDialogLayout = new LinearLayout(activity);
+        progressDialogLayout.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams progressDialogLayoutParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        );
+        int contentPadding = activity.getResources().getDimensionPixelSize(R.dimen.alert_dialog_content_padding);
+        progressDialogLayoutParams.setMargins(contentPadding, contentPadding / 2, contentPadding, 0);
+
+        // Put components in layout
+        progressDialogLayout.addView(progressDialogTextView, progressDialogLayoutParams);
+        progressDialogLayout.addView(progressDialogProgressBar, progressDialogLayoutParams);
+
+        // Create and show dialog
+        progressDialogBuilder.setView(progressDialogLayout);
+        progressDialogBuilder.setNeutralButton(R.string.cancel, (dialogInterface, i) -> cancel());
+        progressDialogBuilder.setOnCancelListener(dialogInterface -> cancel());
+        progressDialogBuilder.setOnDismissListener(dialogInterface -> cancel());
+        progress = progressDialogBuilder.create();
         progress.show();
     }
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -262,19 +262,6 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         settings = new Settings(this);
 
-        String cardOrientation = settings.getCardViewOrientation();
-        if (cardOrientation.equals(getString(R.string.settings_key_follow_sensor_orientation))) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
-        } else if (cardOrientation.equals(getString(R.string.settings_key_lock_on_opening_orientation))) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
-        } else if (cardOrientation.equals(getString(R.string.settings_key_portrait_orientation))) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        } else if (cardOrientation.equals(getString(R.string.settings_key_landscape_orientation))) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-        } else {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-        }
-
         if (savedInstanceState != null) {
             mainImageIndex = savedInstanceState.getInt(STATE_IMAGEINDEX);
             isFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN);

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -74,10 +74,6 @@ public class Settings {
         return getBoolean(R.string.settings_key_display_barcode_max_brightness, true);
     }
 
-    public String getCardViewOrientation() {
-        return getString(R.string.settings_key_card_orientation, getResString(R.string.settings_key_follow_system_orientation));
-    }
-
     public boolean getKeepScreenOn() {
         return getBoolean(R.string.settings_key_keep_screen_on, true);
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -47,9 +47,6 @@
     <string name="settings">الإعدادات</string>
     <string name="settings_light_theme">فاتحة</string>
     <string name="settings_dark_theme">داكنة</string>
-    <string name="settings_card_orientation">اتجاه الشاشة</string>
-    <string name="settings_portrait_orientation">الوضع الرأسي</string>
-    <string name="settings_landscape_orientation">الوضع الأفقي</string>
     <string name="settings_theme">مظهر</string>
     <string name="settings_display_barcode_max_brightness">شاشة ساطعة</string>
     <string name="importSuccessful">تم استيراد البيانات</string>
@@ -181,9 +178,7 @@
     <string name="about_title_fmt">حول <xliff:g id="app_name">%s</xliff:g></string>
     <string name="debug_version_fmt">نسخة: <xliff:g id="version">%s</xliff:g></string>
     <string name="settings_system_theme">النظام</string>
-    <string name="settings_lock_on_opening_orientation">قفل على الاتجاه عند فتح البطاقة</string>
     <string name="app_resources">موارد الطرف الثالث الحرة: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_follow_system_orientation">نظام المتابعة</string>
     <string name="groups">مجموعات</string>
     <string name="settings_keep_screen_on">حافظ على الشاشة قيد التشغيل</string>
     <string name="intent_import_card_from_url_share_text">اريد مشاركة بطاقة معك</string>
@@ -289,7 +284,6 @@
     <string name="addWithoutBarcode">إضافة بدون باركود</string>
     <string name="field_must_not_be_empty">يجب ألا يكون الحقل فارغا</string>
     <string name="app_name">كاتيما</string>
-    <string name="settings_follow_sensor_orientation">التدوير دائمًا ( تجاهل إعدادات النظام)</string>
     <string name="add_manually_warning_title">الفحص موصى به</string>
     <string name="continue_">استمر</string>
     <string name="spend">انفق</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -84,11 +84,6 @@
     <string name="settings_system_theme">Сістэмная</string>
     <string name="settings_light_theme">Светлая</string>
     <string name="settings_dark_theme">Цёмная</string>
-    <string name="settings_card_orientation">Арыентацыя экрана</string>
-    <string name="settings_follow_sensor_orientation">Заўсёды паварочваць (ігнаруе налады сістэмы)</string>
-    <string name="settings_portrait_orientation">Партрэтная</string>
-    <string name="settings_landscape_orientation">Альбомная</string>
-    <string name="settings_lock_on_opening_orientation">Зафіксаваць арыентацыю, якая выкарыстоўваецца пры адкрыцці карты</string>
     <string name="settings_keep_screen_on_summary">Адключае тайм-аўт экрана падчас прагляду карты</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Прадухіляць блакіроўку экрана</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Адключае блакіроўку экрана падчас прагляду карты</string>
@@ -267,7 +262,6 @@
     <string name="addFromImage">Выбраць малюнак з галерэі</string>
     <string name="settings_keep_screen_on">Трымаць экран уключаным</string>
     <string name="app_resources">Бясплатныя староннія рэсурсы: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_follow_system_orientation">Як у сістэме</string>
     <string name="leaveWithoutSaveTitle">Выйсці</string>
     <string name="settings_allow_content_provider_read_title">Дазволіць іншым праграмам доступ да маіх даных</string>
     <string name="settings_display_barcode_max_brightness">Павялічваць яркасць экрану</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -193,11 +193,6 @@
     </plurals>
     <string name="settings_oled_dark">Черен фон за тъмната тема</string>
     <string name="include_if_asking_support">Ако искате да потърсите поддръжка, включете следната информация:</string>
-    <string name="settings_card_orientation">Завъртане на екрана</string>
-    <string name="settings_follow_system_orientation">Според системата</string>
-    <string name="settings_portrait_orientation">Портрет</string>
-    <string name="settings_landscape_orientation">Пейзаж</string>
-    <string name="settings_lock_on_opening_orientation">Като при отваряне на картата</string>
     <string name="duplicateCard">Дублиране</string>
     <string name="archive">Архивиране</string>
     <string name="unarchive">Изваждане от архива</string>
@@ -265,7 +260,6 @@
     <string name="addWithoutBarcode">Добавяне на карта без щрихкод</string>
     <string name="field_must_not_be_empty">Полето не трябва да е празно</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Винаги да се завърта (пренебрегва системната настройка)</string>
     <string name="continue_">Продължаване</string>
     <string name="add_manually_warning_title">Препоръчително е да сканирате</string>
     <string name="add_manually_warning_message">Стойностите от щрихкода и отбелязаните на картата числа в някои случаи се различават. По тази причина при ръчно въвеждане картата може да не работи. Препоръчително е да сканирате щрихкода с камерата. Желаете ли да продължите въпреки това?</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -110,9 +110,6 @@
     <string name="about_title_fmt"><xliff:g id="app_name">%s</xliff:g>টির সম্পর্কে</string>
     <string name="app_resources">মুক্ত সম্পদ যেগুলি আমার নয়: <xliff:g id="app_resources_list">%s</xliff:g></string>
     <string name="thumbnailDescription">থাম্বনেইল</string>
-    <string name="settings_card_orientation">বারকোড অভিমুখ</string>
-    <string name="settings_follow_system_orientation">সিস্টেমের অনুসারে</string>
-    <string name="settings_portrait_orientation">প্রতিকৃতি</string>
     <string name="barcodeImageDescriptionWithType">ছবি <xliff:g>%s</xliff:g> বারকোড</string>
     <string name="exportName">রপ্তানি</string>
     <string name="failedParsingImportUriError">আমদানির URI-টি বোঝা যাচ্ছে না</string>
@@ -138,8 +135,6 @@
     <string name="selectBarcodeTitle">বারকোড নির্বাচন করুন</string>
     <string name="settings">সেটিংস</string>
     <string name="settings_dark_theme">অন্ধকার</string>
-    <string name="settings_landscape_orientation">অনুভূমিক</string>
-    <string name="settings_lock_on_opening_orientation">কার্ড খোলার সময় যে অভিমুখ থাকে সেটিতে লক করে দেবেন</string>
     <string name="group_name_already_in_use">গ্রুপটির নাম আগে একবার ব্যবহার করে ফেলেছেন</string>
     <string name="group_edit">গ্রুপ সম্পাদনা করুন</string>
     <string name="group_updated">গ্রুপটি আপডেট করা হল</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -73,6 +73,5 @@
     <string name="permissionReadCardsLabel">কাটিমা কার্ডস পড়ুন</string>
     <string name="storageReadPermissionRequired">এই কাজটির জন্য ফোনের স্টোরেজ দেখার অনুমতি লাগবে…</string>
     <string name="exportFailedTitle">রপ্তানি ব্যর্থ</string>
-    <string name="settings_card_orientation">বারকোড অভিমুখ (ওরিয়েন্টেশন)</string>
     <string name="app_name">ক্যাটিমা</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -35,7 +35,6 @@
     <string name="settings_light_theme">Tema clar</string>
     <string name="settings_system_theme">Tema de sistema</string>
     <string name="settings_dark_theme">Tema Fosc</string>
-    <string name="settings_card_orientation">Orientació de la pantalla</string>
     <string name="settings_allow_content_provider_read_title">Permet altres apps a accedir a les meves dades</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Desactiva el bloqueix la pantalla mentre es visualitza la targeta</string>
     <string name="settings_allow_content_provider_read_summary">Les aplicacions han de seguir demanant permís per tenir-hi accés</string>
@@ -104,15 +103,12 @@
     <string name="cardId">Id. de la Targeta</string>
     <string name="barcodeType">Tipus de codi de barres</string>
     <string name="noBarcode">Sense codi de barres</string>
-    <string name="settings_portrait_orientation">Vertical</string>
     <string name="yes">Si</string>
     <string name="addFromPdfFile">Seleccioni un PDF</string>
     <string name="errorReadingFile">No s\'ha pogut llegir el fitxer</string>
     <string name="failedLaunchingFileManager">No s\'ha pogut trobar un gestor de fitxers compatible</string>
     <string name="multipleBarcodesFoundPleaseChooseOne">Quin dels següents codis de barres prefereix utilitzar?</string>
     <string name="pageWithNumber">Pàgina <xliff:g>%d</xliff:g></string>
-    <string name="settings_follow_system_orientation">Seguir el sistema</string>
-    <string name="settings_landscape_orientation">Horitzontal</string>
     <string name="intent_import_card_from_url_share_text">Vull compartir una targeta amb tu</string>
     <string name="takePhoto">Fer una foto</string>
     <string name="help_translate_this_app">Ajuda a traduïr aquesta app</string>
@@ -134,7 +130,6 @@
     <string name="barcodeImageDescriptionWithType">Codi de barres <xliff:g>%s</xliff:g></string>
     <string name="about_title_fmt">Sobre <xliff:g id="app_name">%s</xliff:g></string>
     <string name="debug_version_fmt">Versió: <xliff:g id="version">%s</xliff:g></string>
-    <string name="settings_follow_sensor_orientation">Sempre rota (ignora la configuració de sistema)</string>
     <string name="settings_display_barcode_max_brightness_summary">Alguns escàners ho necesiten</string>
     <string name="settings_keep_screen_on">Mantenir la pantalla encesa</string>
     <string name="settings_keep_screen_on_summary">Desactiva el bloqueix de la pantalla mentre mostra una targeta</string>
@@ -179,7 +174,6 @@
     <string name="noCardExistsError">No s\'ha pogut trobar aquesta targeta</string>
     <string name="failedParsingImportUriError">No s\'ha pogut analitzar la URI d\'importació</string>
     <string name="openFrontImageInGalleryApp">Obrir la imatge frontal a l\'app de galeria</string>
-    <string name="settings_lock_on_opening_orientation">En obrir la targeta, bloquejar la orientació de la pantalla</string>
     <string name="settings_use_volume_keys_navigation_summary">Utilitza els botons de volum per canviar la targeta que es mostra</string>
     <string name="updateBarcodeQuestionText">Ha canviat el valor ID. Vol actualitzar també el codi de barres per uter utilitzar el mateix valor?</string>
     <string name="settings_sky_blue_theme">Blau fluix</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -197,14 +197,9 @@
     </plurals>
     <string name="settings_oled_dark">Čistě černé pozadí pro tmavý motiv</string>
     <string name="include_if_asking_support">Pokud chcete požádat o podporu, uveďte následující informace:</string>
-    <string name="settings_follow_system_orientation">Podle orientace systému</string>
-    <string name="settings_portrait_orientation">Na výšku</string>
-    <string name="settings_lock_on_opening_orientation">Ponechat orientaci jako při otevření karty</string>
     <string name="archive">Archivovat</string>
     <string name="unarchive">Vrátit z archivu</string>
     <string name="unarchived">Karta vrácena z archivu</string>
-    <string name="settings_card_orientation">Orientace obrazovky</string>
-    <string name="settings_landscape_orientation">Na šířku</string>
     <string name="duplicateCard">Duplikovat</string>
     <string name="archived">Karta archivována</string>
     <string name="failedLaunchingPhotoPicker">Nepodařilo se najít podporovaný nástroj pro výběr obrázků</string>
@@ -271,7 +266,6 @@
     <string name="addWithoutBarcode">Přidat kartu bez čárového kódu</string>
     <string name="field_must_not_be_empty">Položka nesmí být prázdná</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Vždy otáčet (ignoruje nastavení systému)</string>
     <string name="continue_">Pokračovat</string>
     <string name="add_manually_warning_title">Doporučuje se skenování</string>
     <string name="add_manually_warning_message">U některých karet se hodnota čárového kódu liší od čísla napsaného na kartě. Z tohoto důvodu nemusí ruční zadání čárového kódu vždy fungovat. Doporučujeme místo toho naskenovat čárový kód pomocí fotoaparátu. Chcete přesto pokračovat?</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -100,10 +100,6 @@
     <string name="group_name_already_in_use">Gruppenavn allerede i brug</string>
     <string name="editGroup">Redigerer Gruppe: <xliff:g>%s</xliff:g></string>
     <string name="importFidme">Importer fra FidMe</string>
-    <string name="settings_card_orientation">Skærm orientation</string>
-    <string name="settings_follow_system_orientation">Følg system</string>
-    <string name="settings_portrait_orientation">Portræt</string>
-    <string name="settings_landscape_orientation">Landskab</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Deaktiver låseskærm når et kort er åbent</string>
     <string name="groupsList">Grupper: <xliff:g>%s</xliff:g></string>
     <string name="expiryStateSentence">Udløber: <xliff:g>%s</xliff:g></string>
@@ -133,10 +129,8 @@
     <string name="setBarcodeId">Vælg stregkode værdi</string>
     <string name="sameAsCardId">Samme som ID</string>
     <string name="settings_system_theme">System</string>
-    <string name="settings_lock_on_opening_orientation">Lås til orientation når kort åbnes</string>
     <string name="settings_keep_screen_on_summary">Deaktiver skærm tids slukning når et kort er åbent</string>
     <string name="group_edit">Rediger gruppe</string>
-    <string name="settings_follow_sensor_orientation">Altid roter (ignorer system indstillinger)</string>
     <string name="chooseImportType">Importer data fra</string>
     <string name="importVoucherVault">Importer fra Voucher Vault</string>
     <string name="settings_use_volume_keys_navigation">Skift kort ved brug af lydstyrke knapperne</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -192,16 +192,11 @@
     </plurals>
     <string name="settings_oled_dark">Komplett schwarzer Hintergrund im dunklen Design</string>
     <string name="include_if_asking_support">Wenn Du Unterstützung haben möchtest, gib bitte folgende Informationen an:</string>
-    <string name="settings_follow_system_orientation">System folgen</string>
-    <string name="settings_landscape_orientation">Querformat</string>
-    <string name="settings_portrait_orientation">Hochformat</string>
     <string name="duplicateCard">Duplizieren</string>
     <string name="unarchive">Aus dem Archiv wiederherstellen</string>
-    <string name="settings_card_orientation">Bildschirm-Ausrichtung</string>
     <string name="unarchived">Karte aus dem Archiv wiederhergestellt</string>
     <string name="archive">Archivieren</string>
     <string name="archived">Karte archiviert</string>
-    <string name="settings_lock_on_opening_orientation">Kartenausrichtung nach dem Öffnen beibehalten</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> Karte (<xliff:g id="archivedCount">%2$d</xliff:g> archiviert)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> Karten (<xliff:g id="archivedCount">%2$d</xliff:g> archiviert)</item>
@@ -265,7 +260,6 @@
     <string name="field_must_not_be_empty">Feld darf nicht leer sein</string>
     <string name="manually_enter_barcode_instructions">Trage die Kartenummer oder Text deiner Karte ein und drücke auf den Barcode, der wie der auf deiner Karte aussieht.</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Immer drehen (ignoriert Systemeinstellungen)</string>
     <string name="continue_">Fortfahren</string>
     <string name="add_manually_warning_title">Scannen empfohlen</string>
     <string name="add_manually_warning_message">In einigen Geschäften weicht der Wert des Barcodes von dem auf der Karte angegebenen Wert ab. Aus diesem Grund funktioniert die manuelle Eingabe des Barcodes in einigen Fällen nicht. Es wird empfohlen, stattdessen den Barcode mit deiner Kamera zu scannen. Möchtest du dennoch fortfahren?</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -159,12 +159,7 @@
     </plurals>
     <string name="app_copyright_old">Βασισμένο στο Loyalty Card Keychain
 \nπνευματικά δικαιώματα © 2016-2020 Branden Archer</string>
-    <string name="settings_follow_system_orientation">Ακολούθηση συστήματος</string>
-    <string name="settings_card_orientation">Προσανατολισμός οθόνης</string>
-    <string name="settings_portrait_orientation">Πορτραίτο</string>
-    <string name="settings_landscape_orientation">Οριζόντια</string>
     <string name="app_copyright_fmt" tools:ignore="PluralsCandidate">Πνευματικά δικαιώματα © 2019-<xliff:g>%d</xliff:g> Sylvia van Os</string>
-    <string name="settings_lock_on_opening_orientation">Κλείδωμα τρέχοντος προσανατολισμού όταν ανοίγει μία κάρτα</string>
     <string name="intent_import_card_from_url_share_text">Θέλω να μοιραστώ μία κάρτα μαζί σου</string>
     <string name="enter_group_name">Εισάγετε όνομα ομάδας</string>
     <string name="groups">Ομάδες</string>
@@ -239,7 +234,6 @@
     <string name="icon_header_click_text">Πατήστε παρατεταμένα για επεξεργασία του εικονιδίου</string>
     <string name="openFrontImageInGalleryApp">Ανοίξτε την εμπρόσθια εικόνα στη συλλογή εικόνων</string>
     <string name="storageReadPermissionRequired">Δικαίωμα ανάγνωσης του χώρου αποθήκευσης απαραίτητο για αυτήν την ενέργεια…</string>
-    <string name="settings_follow_sensor_orientation">Πάντα σε περιστροφή (αγνοεί τις ρυθμίσεις του συστήματος)</string>
     <string name="validFromDate">Ισχύει από</string>
     <string name="anyDate">Οποιαδήποτε ημερομηνία</string>
     <string name="chooseValidFromDate">Επιλέξτε έγκυρη ημερομηνία από</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -213,10 +213,6 @@
     <string name="cameraPermissionDeniedTitle">Fotilo neatingebla</string>
     <string name="noCameraPermissionDirectToSystemSetting">Por skani strikodojn Catima bezonas atingorajton al via fotilo. Klaku ĉi tie por ŝanĝi viajn permesajn agordojn.</string>
     <string name="app_copyright_short">Kopirajto © Sylvia van Os kaj kontribuantoj</string>
-    <string name="settings_card_orientation">Orientiĝo de strikodo</string>
-    <string name="settings_follow_system_orientation">Laŭ la sistemo</string>
-    <string name="settings_portrait_orientation">Vertikala</string>
-    <string name="settings_landscape_orientation">Horizontala</string>
     <string name="settings_display_barcode_max_brightness_summary">Bezonata por ke iuj skaniloj funkciu</string>
     <string name="unsupportedBarcodeType">Ne eblas montri ĉi tiun strikodspecon. Ĝi eble estos subtenata en posta versio de la apo.</string>
     <string name="importVoucherVaultMessage">Elektu la <i>vouchervault.json</i> eksporton de Voucher Vault kiun vi volas importi.
@@ -254,8 +250,6 @@
     <string name="pageWithNumber">Paĝo <xliff:g>%d</xliff:g></string>
     <string name="settings_system_locale">Sistemo</string>
     <string name="app_resources">Liberaj triaj risurcoj: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_follow_sensor_orientation">Ĉiam turni (ignori la agordojn de la sistemo)</string>
-    <string name="settings_lock_on_opening_orientation">Fiksi al la orientiĝo uzata dum malfermado de la karto</string>
     <string name="importCatimaMessage">Elektu la <i>catima.zip</i> eksporton kiun vi volas importi.
 \nKreu ĝin unue en la importi/eksporti menuo en alia Catima apo elektante \'eksporti\' tie.</string>
     <string name="importFidme">Importi el FidMe</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -58,7 +58,6 @@
     <string name="about_title_fmt">Acerca de <xliff:g id="app_name">%s</xliff:g></string>
     <string name="editBarcode">Editar código de barras</string>
     <string name="removeImage">Remover imágen</string>
-    <string name="settings_portrait_orientation">Vertical</string>
     <string name="takePhoto">Tomar una foto</string>
     <string name="cameraPermissionDeniedTitle">No se pudo acceder a la cámara</string>
     <string name="wrongValueForBarcodeType">El valor no es válido para el tipo de código de barras seleccionado</string>
@@ -68,7 +67,6 @@
     <string name="debug_version_fmt">Versión: <xliff:g id="version">%s</xliff:g></string>
     <string name="backImageDescription">Imágen dorsal</string>
     <string name="noCameraPermissionDirectToSystemSetting">Para escanear códigos de barra, Catima necesitará acceso a la cámara. Presione aquí para cambiar la configuración de sus permisos.</string>
-    <string name="settings_lock_on_opening_orientation">Bloquear a la orientación utilizada al abrir la tarjeta</string>
     <string name="app_loyalty_card_keychain">Cartera para Tarjetas de Fidelización</string>
     <string name="importOptionFilesystemTitle">Importar desde su sistema de archivos</string>
     <string name="leaveWithoutSaveTitle">Salir</string>
@@ -101,7 +99,6 @@
     <string name="settings_keep_screen_on">Mantener la pantalla encendida</string>
     <string name="setBarcodeId">Establecer valor del código de barras</string>
     <string name="importCatima">Importar desde Catima</string>
-    <string name="settings_follow_system_orientation">Seguir el sistema</string>
     <string name="intent_import_card_from_url_share_text">Quiero compartirte una tarjeta</string>
     <string name="addFromImage">Seleccione una imágen desde la galería</string>
     <string name="app_copyright_short">Copyright © Sylvia van Os y colaboradores</string>
@@ -114,7 +111,6 @@
     <string name="about">Acerca de</string>
     <string name="sameAsCardId">Igual que el código</string>
     <string name="importOptionFilesystemButton">Desde el sistema de archivos</string>
-    <string name="settings_landscape_orientation">Horizontal</string>
     <string name="privacy_policy">Política de Privacidad</string>
     <string name="enter_group_name">Ingrese el nombre del grupo</string>
     <string name="addManually">Ingresar el código de barras manualmente</string>
@@ -145,7 +141,6 @@
     <string name="settings">Configuración</string>
     <string name="selectBarcodeTitle">Seleccione el código de barras</string>
     <string name="importSuccessful">Datos importados</string>
-    <string name="settings_card_orientation">Orientación del código de barras</string>
     <string name="app_libraries">Librerías externas: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="app_resources">Recursos externos: <xliff:g id="app_resources_list">%s</xliff:g></string>
     <string name="app_name">Catima</string>
@@ -197,7 +192,6 @@
     <string name="settings_blue_theme">Azul</string>
     <string name="app_contributors">Hecho posible por: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="barcodeLongPressMessage">Solo se puede abrir imágenes en la aplicación de galería</string>
-    <string name="settings_follow_sensor_orientation">Siempre rotar (ignora configuración del sistema)</string>
     <string name="yes">Si</string>
     <string name="no">No</string>
     <string name="passwordRequired">Ingresa la contraseña</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -159,20 +159,15 @@
     <string name="settings_system_locale">Sistema</string>
     <string name="settings_locale">Idioma</string>
     <string name="noGroupCards">Este grupo está vacío</string>
-    <string name="settings_landscape_orientation">Horizontal</string>
     <plurals name="balancePoints">
         <item quantity="one"><xliff:g>%s</xliff:g> punto</item>
         <item quantity="many"><xliff:g>%s</xliff:g> puntos</item>
         <item quantity="other"><xliff:g>%s</xliff:g> puntos</item>
     </plurals>
     <string name="barcodeImageDescriptionWithType">Imagen <xliff:g>%s</xliff:g> código de barras</string>
-    <string name="settings_card_orientation">Orientación de pantalla</string>
-    <string name="settings_portrait_orientation">Formato vertical</string>
     <string name="group_edit">Editar grupo</string>
     <string name="group_updated">Grupo actualizado</string>
     <string name="noGiftCardsGroup">Crea algunas tarjetas y luego asígnelas al grupo aquí</string>
-    <string name="settings_follow_system_orientation">Segue el sistema</string>
-    <string name="settings_lock_on_opening_orientation">Bloqueo a la orientación utilizada al abrir la tarjeta</string>
     <string name="sort_by_most_recently_used">Lo más usado recientemente</string>
     <string name="sort_by_expiry">Caducidad</string>
     <string name="version_history">Historial de versiones</string>
@@ -271,7 +266,6 @@
     <string name="addWithoutBarcode">Añadir una tarjeta sin código de barras</string>
     <string name="field_must_not_be_empty">Este campo no debe estar vacío</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Girar siempre (ignora la configuración del sistema)</string>
     <string name="continue_">Continuar</string>
     <string name="add_manually_warning_title">Se recomienda escanear</string>
     <string name="add_manually_warning_message">En algunas tiendas, el valor del código de barras difiere del número escrito en la tarjeta. Por este motivo, es posible que la introducción manual del código de barras no siempre funcione. Se recomienda encarecidamente escanear el código de barras con la cámara. ¿Aún desea continuar?</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -46,9 +46,6 @@
     <string name="settings_dark_theme">Tume kujundus</string>
     <string name="thumbnailDescription">Pisipilt</string>
     <string name="settings_theme">Kujundus</string>
-    <string name="settings_card_orientation">Ekraanipaigutuse suund</string>
-    <string name="settings_follow_sensor_orientation">Alati pööra (eira süsteemset paigutust)</string>
-    <string name="settings_landscape_orientation">Rõhtvaade</string>
     <string name="settings_display_barcode_max_brightness">Tee ekraan eredamaks</string>
     <string name="app_license">Copyleft-tüüpi autoriõiguste alusel loodud avatud lähtekoodiga tarkvara, mis on avaldatud GPLv3+ all</string>
     <string name="settings_keep_screen_on">Hoia ekraan sisselülitatuna</string>
@@ -87,9 +84,6 @@
     <string name="starImage">Lemmikut märkiv täht</string>
     <string name="settings">Seadistused</string>
     <string name="settings_system_theme">Süsteemi kujundus</string>
-    <string name="settings_follow_system_orientation">Järgi süsteemset paigutust</string>
-    <string name="settings_portrait_orientation">Püstvaade</string>
-    <string name="settings_lock_on_opening_orientation">Kaardivaate avamisel lukusta paigutus</string>
     <string name="settings_display_barcode_max_brightness_summary">See on vajalik mõnede skännerite toimimiseks</string>
     <string name="expiryStateSentenceExpired">Aegus: <xliff:g>%s</xliff:g></string>
     <string name="settings_allow_content_provider_read_summary">Selle valiku sisselülitamisel peavad muud rakendused lisaks küsima õigust vaadata kaartide andmeid</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -90,9 +90,6 @@
     <string name="settings_theme">تم</string>
     <string name="settings_system_theme">سیستم</string>
     <string name="settings_dark_theme">تیره</string>
-    <string name="settings_card_orientation">جهت صفحه نمایش</string>
-    <string name="settings_follow_sensor_orientation">همیشه قابل چرخش باشد (بدون در نظر گرفتن تنظیمات سیستم)</string>
-    <string name="settings_portrait_orientation">عمودی</string>
     <string name="settings_keep_screen_on">روشن نگه داشتن صفحه نمایش</string>
     <string name="settings_keep_screen_on_summary">غیرفعال سازی مهلت صفحه نمایش هنگام مشاهده کارت</string>
     <string name="settings_disable_lockscreen_while_viewing_card">جلوگیری از قفل شدن صفحه</string>
@@ -100,12 +97,10 @@
     <string name="settings_allow_content_provider_read_summary">برنامه ها باید برای گرفتن مجوز درخواست کنند</string>
     <string name="importSuccessful">داده وارد شد</string>
     <string name="thumbnailDescription">تصویر کوچک</string>
-    <string name="settings_landscape_orientation">افقی</string>
     <string name="settings_light_theme">روشن</string>
     <string name="settings_display_barcode_max_brightness_summary">برای کارکرد برخی اسکنر ها ضروری است</string>
     <string name="settings_display_barcode_max_brightness">روشنایی صفحه</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">جلوگیری از قفل شدن صفحه هنگام مشاهده کارت</string>
-    <string name="settings_follow_system_orientation">پیروی از سیستم</string>
     <string name="intent_import_card_from_url_share_text">میخواهم یک کارت را با تو به اشتراک بگذارم</string>
     <string name="settings_use_volume_keys_navigation">جابجایی میان کارت ها با استفاده از کلید های صدا</string>
     <string name="settings_use_volume_keys_navigation_summary">از کلید های صدا برای تغیر کارت نمایشی استفاده کنید</string>
@@ -135,7 +130,6 @@
     <string name="importLoyaltyCardKeychain">وارد کردن از جاکلیدی کارت وفاداری</string>
     <string name="importLoyaltyCardKeychainMessage">فایل خروجی <i>LoyaltyCardKeychain.csv</i> خود را از جاسوئیچی کارت وفاداری برای وارد کردن انتخاب کنید.\nآن را از منوی وارد/صادر‌کردن در جاسوئیچی کارت وفاداری با فشردن دکمه صادر‌کردن ابتدا ایجاد کنید.</string>
     <string name="app_resources">منابع آزاد از طرف شخص ثالث: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_lock_on_opening_orientation">قفل به جهت استفاده شده در هنگام بازکردن کارت</string>
     <plurals name="groupCardCount">
         <item quantity="one"><xliff:g>%d</xliff:g> کارت</item>
         <item quantity="other"><xliff:g>%d</xliff:g> کارت</item>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -197,14 +197,10 @@
     <string name="rate_this_app">Arvostele tämä sovellus</string>
     <string name="noGiftCardsGroup">Lisää kortteja ja lisää ne ryhmään täällä.</string>
     <string name="barcodeImageDescriptionWithType">Kuva <xliff:g>%s</xliff:g> viivakoodi</string>
-    <string name="settings_follow_system_orientation">Seuraa järjestelmää</string>
-    <string name="settings_portrait_orientation">Pysty</string>
-    <string name="settings_landscape_orientation">Vaaka</string>
     <string name="unarchived">Kortti on poistettu arkistosta</string>
     <string name="unarchive">Poista arkistosta</string>
     <string name="archived">Kortti arkistoitu</string>
     <string name="failedLaunchingPhotoPicker">Tuettua galleriasovellusta ei löytynyt</string>
-    <string name="settings_card_orientation">Näytön suunta</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> kortti (<xliff:g id="archivedCount">%2$d</xliff:g> arkistoitu)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> korttia (<xliff:g id="archivedCount">%2$d</xliff:g> arkistoitu)</item>
@@ -223,7 +219,6 @@
     <string name="currentBalanceSentence">Nykyinen saldo: <xliff:g>%s</xliff:g></string>
     <string name="newBalanceSentence">Uusi saldo: <xliff:g>%s</xliff:g></string>
     <string name="cameraPermissionDeniedTitle">Ei pääsyä kameraan</string>
-    <string name="settings_lock_on_opening_orientation">Lukitse suunta, kun korttia avataan</string>
     <string name="noCameraPermissionDirectToSystemSetting">Viivakoodien lukeminen vaatii, että Catimalla on käyttöoikeus kameraan. Napauta tästä muuttaaksesi oikeuksia.</string>
     <string name="updateBalance">Päivitä saldo</string>
     <string name="cameraPermissionRequired">Tämä toiminto vaatii oikeuden käyttää kameraa…</string>
@@ -269,7 +264,6 @@
     <string name="app_name">Catima</string>
     <string name="balanceParsingFailed">Virheellinen saldo</string>
     <string name="view_online">Näytä verkossa</string>
-    <string name="settings_follow_sensor_orientation">Kierrä aina (ohittaa järjestelmän asetukset)</string>
     <string name="continue_">Jatka</string>
     <string name="add_manually_warning_title">Skannausta suositellaan</string>
     <string name="spend">Kuluta</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -197,11 +197,6 @@
     </plurals>
     <string name="settings_oled_dark">Fond noir pour le thème sombre</string>
     <string name="include_if_asking_support">Si vous voulez demander de l\'aide, incluez les informations suivantes :</string>
-    <string name="settings_card_orientation">Orientation de l\'écran</string>
-    <string name="settings_follow_system_orientation">Suivre le système</string>
-    <string name="settings_portrait_orientation">Portrait</string>
-    <string name="settings_landscape_orientation">Paysage</string>
-    <string name="settings_lock_on_opening_orientation">Garder l\'orientation utilisée pour ouvrir la carte</string>
     <string name="duplicateCard">Dupliquer</string>
     <string name="archive">Archiver</string>
     <string name="unarchive">Désarchiver</string>
@@ -271,7 +266,6 @@
     <string name="addWithoutBarcode">Ajouter une carte sans code-barres</string>
     <string name="field_must_not_be_empty">Le champ ne peut pas être vide</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Toujours pivoter (ignore les paramètres du système)</string>
     <string name="add_manually_warning_title">Scan recommandé</string>
     <string name="continue_">Continuer</string>
     <string name="add_manually_warning_message">Pour certaines cartes, la valeur du code-barres diffère du numéro inscrit sur la carte. Pour cette raison, la saisie manuelle d’un code-barres peut ne pas toujours fonctionner. Il est recommandé de scanner le code-barres avec votre appareil photo. Voulez-vous toujours continuer ?</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -60,10 +60,6 @@
     <string name="selectBarcodeTitle">Elixir código de barras</string>
     <string name="settings">Axustes</string>
     <string name="settings_theme">Decorado</string>
-    <string name="settings_follow_sensor_orientation">Rotar sempre (ignora o axuste do sistema)</string>
-    <string name="settings_portrait_orientation">Retrato</string>
-    <string name="settings_landscape_orientation">Paisaxe</string>
-    <string name="settings_lock_on_opening_orientation">Fixar a orientación ao abrir a tarxeta</string>
     <string name="settings_display_barcode_max_brightness">Brillo da pantalla</string>
     <string name="settings_keep_screen_on_summary">Evita que se apague a pantalla cando se ve unha tarxeta</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Evitar bloqueo da pantalla</string>
@@ -265,11 +261,9 @@
     <string name="thumbnailDescription">Miniatura</string>
     <string name="starImage">Estrela de favorita</string>
     <string name="settings_system_theme">Sistema</string>
-    <string name="settings_follow_system_orientation">Seguir ao sistema</string>
     <string name="settings_display_barcode_max_brightness_summary">Preciso para que algúns escáneres funcionen</string>
     <string name="settings_keep_screen_on">Manter pantalla acendida</string>
     <string name="settings_dark_theme">Escuro</string>
-    <string name="settings_card_orientation">Orientación da pantalla</string>
     <string name="group_updated">Grupo actualizado</string>
     <string name="all">Todo</string>
     <string name="deleteConfirmationGroup">Eliminar grupo?</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -53,10 +53,6 @@
     <string name="settings_dark_theme">गाढ़ा (काला)</string>
     <string name="settings">सेटिंग्स</string>
     <string name="settings_system_theme">सिस्टम</string>
-    <string name="settings_card_orientation">स्क्रीन अभिमुखता</string>
-    <string name="settings_landscape_orientation">क्षैतिज (लैंडस्केप)</string>
-    <string name="settings_follow_system_orientation">सिस्टम का पालन करें</string>
-    <string name="settings_portrait_orientation">लंबवत (पोट्रैट)</string>
     <string name="settings_display_barcode_max_brightness">स्क्रीन की चमक बढ़ाएं</string>
     <string name="settings_keep_screen_on">स्क्रीन को चालू रखें</string>
     <string name="cameraPermissionDeniedTitle">कैमरे की अनुमति नहीं मिली</string>
@@ -70,7 +66,6 @@
     <string name="importExportHelp">आपके डाटा को बैकअप करना उसे दूसरे डिवाइस में भेजना संभव कर देता है</string>
     <string name="barcodeImageDescriptionWithType"><xliff:g>%s</xliff:g> का बारकोड</string>
     <string name="settings_disable_lockscreen_while_viewing_card">स्क्रीन को लॉक होने से रोकें</string>
-    <string name="settings_lock_on_opening_orientation">कार्ड खोलते समय प्रयुक्त अभिमुख अवस्था को प्रतिबंधित करें</string>
     <string name="intent_import_card_from_url_share_text">मैं तुम्हें एक कार्ड भेजना चाहता हूँ</string>
     <string name="selectBarcodeTitle">बारकोड चुनें</string>
     <string name="thumbnailDescription">छोटा चित्र</string>
@@ -214,7 +209,6 @@
     <string name="app_contributors">इनके द्वारा संभव बनाया गया: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="sort">क्रमबद्ध करें</string>
     <string name="show_note">नोट दिखाएँ</string>
-    <string name="settings_follow_sensor_orientation">हमेशा घुमाएँ (सिस्टम सेटिंग्स को अनदेखा करें)</string>
     <string name="importFidmeMessage">आयात करने के लिए FidMe से अपना निर्यात चुनें, और उसके बाद मैन्युअल रूप से बारकोड प्रकार चुनें।\nडेटा सुरक्षा चुनकर और फिर मेरा डेटा निकालें दबाकर इसे अपनी FidMe प्रोफ़ाइल से बनाएँ।</string>
     <string name="importLoyaltyCardKeychainMessage">आयात करने के लिए Loyalty Card Keychain से अपना निर्यात चुनें।\nइसे लॉयल्टी कार्ड कीचेन में आयात/निर्यात मेनू से निर्यात बटन दबाकर बनाएँ।</string>
     <string name="updateBarcodeQuestionText">आपने आईडी बदल दी. क्या आप समान मान का उपयोग करने के लिए बारकोड को भी अपडेट करना चाहते हैं?</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -123,8 +123,6 @@
     <string name="noCameraPermissionDirectToSystemSetting">Za snimanje crtičnih kodova Catima treba pristup tvojoj kameri. Dodirni ovdje za mijenjanje postavki dozvola.</string>
     <string name="app_libraries">Slobodne biblioteke trećih strana: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="selectBarcodeTitle">Odaberi crtični kod</string>
-    <string name="settings_portrait_orientation">Uspravno</string>
-    <string name="settings_lock_on_opening_orientation">Odredi orijentaciju koja se koristi prilikom otvaranja kartice</string>
     <string name="group_edit">Uredi grupu</string>
     <string name="group_name_already_in_use">Ime grupe se već koristi</string>
     <string name="noBarcodeFound">Nijedan crtični kod nije pronađen</string>
@@ -163,8 +161,6 @@
     <string name="storageReadPermissionRequired">Za ovu radnju je potrebna dozvola za čitanje spremljenih podataka …</string>
     <string name="cameraPermissionRequired">Za ovu radnju je potrebna dozvola za pristup kameri …</string>
     <string name="app_license">Copylefted libre softver, GPLv3+ licenca</string>
-    <string name="settings_card_orientation">Orijentacija ekrana</string>
-    <string name="settings_follow_system_orientation">Slijedi sustav</string>
     <string name="balanceSentence">Saldo: <xliff:g>%s</xliff:g></string>
     <string name="importFidmeMessage">Odaberi tvoju iz FidMe izvezenu <i>idme-export-request-xxxxxx.zip</i> datoteku koju želiš uvesti i ručno odaberi vste crtičnog koda nakon toga. 
 \nStvori je putem tvog FidMe profila biranjem „Zaštita podataka” a zatim pritisni „Dekomprimiraj moje podatke”.</string>
@@ -201,7 +197,6 @@
     <string name="app_copyright_fmt" tools:ignore="PluralsCandidate">Autorska prava © 2019. – <xliff:g>%d.</xliff:g> Sylvia van Os i doprinositelji</string>
     <string name="debug_version_fmt">Verzija: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_resources">Slobodni resursi trećih strana: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_landscape_orientation">Ležeće</string>
     <string name="group_name_is_empty">Ime grupe ne smije biti prazno</string>
     <string name="group_updated">Grupa je aktualizirana</string>
     <string name="all">Sve</string>
@@ -275,7 +270,6 @@
     <string name="settings_category_title_privacy">Privatnost</string>
     <string name="settings_keep_screen_on_summary">Deaktivira isključivanje ekrana tijekom prikaza kartice</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Uvijek okreni (zanemaruje postavke sustava)</string>
     <string name="continue_">Nastavi</string>
     <string name="add_manually_warning_message">Za neke trgovine se vrijednost crtičnog koda razlikuje od broja na kartici. Zbog toga ručno upisivanje crtičnog koda možda neće uvijek funkcionirati. Preporučuje se snimanje crtičnog koda pomoću kamere. Želiš li svejedno nastaviti?</string>
     <string name="add_manually_warning_title">Preporučuje se snimanje</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -194,7 +194,6 @@
 \nLétrehozhatja az Importálás/exportálás menüből az Exportálást megnyomva egy másik Catima alkalmazásban.</string>
     <string name="importFidmeMessage">Válassza ki a FidMeből exportált <i>fidme-export-request-xxxxxx.zip</i> fájl majd importálja be, és utána válassza a kézi vonalkódbeírást.
 \nEzt hozza létre a FidMe-profiljában az Adatvédelem rész választásával, majd a Saját adatok kinyerése megnyomásával.</string>
-    <string name="settings_card_orientation">Képernyő tájolása</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> kártya (<xliff:g id="archivedCount">%2$d</xliff:g> archiválva)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> kártya (<xliff:g id="archivedCount">%2$d</xliff:g> archiválva)</item>
@@ -203,10 +202,6 @@
     <string name="failedLaunchingPhotoPicker">Nem található támogatott galéria alkalmazás</string>
     <string name="previousCard">Előző</string>
     <string name="nextCard">Következő</string>
-    <string name="settings_portrait_orientation">Álló</string>
-    <string name="settings_follow_system_orientation">Rendszer követése</string>
-    <string name="settings_lock_on_opening_orientation">A használt tájolás zárolása a kártya megnyitásakor</string>
-    <string name="settings_landscape_orientation">Fekvő</string>
     <string name="settings_oled_dark">Teljesen fekete háttér a sötét témánál</string>
     <string name="include_if_asking_support">Ha támogatás akar kérni, ossza meg az alábbi információkat:</string>
     <string name="archive">Archiválás</string>
@@ -269,7 +264,6 @@
     <string name="app_copyright_fmt" tools:ignore="PluralsCandidate">Copyright © 2019–<xliff:g>%d</xliff:g> Sylvia van Os és közreműködők</string>
     <string name="show_archived_cards">Archivált kártyák megjelenítése</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Mindig forgassa (figyelmen kívül hagyja a rendszerbeállításokat)</string>
     <string name="amountParsingFailed">Hibás érték</string>
     <string name="add_manually_warning_title">Szkennelés ajánlott</string>
     <string name="add_manually_warning_message">Egyes boltoknál a kártyán levő számsor különbözik a vonalkódtól. Emiatt a manuális szám beírás nem minden esetben fog működni. Erősen ajánlott inkább a vonalkód szkennelése kamerával. Biztosan folytatja?</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -192,11 +192,6 @@
     <string name="failedLaunchingPhotoPicker">Tidak dapat menemukan aplikasi galeri yang didukung</string>
     <string name="previousCard">Sebelumnya</string>
     <string name="nextCard">Berikutnya</string>
-    <string name="settings_card_orientation">Orientasi layar</string>
-    <string name="settings_follow_system_orientation">Ikuti sistem</string>
-    <string name="settings_portrait_orientation">Potret</string>
-    <string name="settings_landscape_orientation">Lanskap</string>
-    <string name="settings_lock_on_opening_orientation">Kunci ke orientasi yang digunakan saat membuka kartu</string>
     <plurals name="balancePoints">
         <item quantity="other"><xliff:g>%s</xliff:g> poin</item>
     </plurals>
@@ -263,7 +258,6 @@
     <string name="addWithoutBarcode">Tambah kartu tanpa barcode</string>
     <string name="field_must_not_be_empty">Isian tidak boleh kosong</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Selalu rotasi (abaikan pengaturan sistem)</string>
     <string name="add_manually_warning_title">Pemindaian sangat dianjurkan</string>
     <string name="continue_">Lanjut</string>
     <string name="failedLaunchingFileManager">Tidak dapat menemukan pengelola file yang didukung</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -201,16 +201,11 @@
     </plurals>
     <string name="settings_oled_dark">Sfondo nero puro per il tema scuro</string>
     <string name="include_if_asking_support">Se vuoi richiedere supporto, includi le seguenti informazioni:</string>
-    <string name="settings_card_orientation">Orientamento dello schermo</string>
-    <string name="settings_follow_system_orientation">Segui il sistema</string>
     <string name="duplicateCard">Duplica</string>
     <string name="archive">Archivia</string>
     <string name="unarchive">Disarchivia</string>
     <string name="unarchived">Carta non archiviata</string>
     <string name="archived">Carta archiviata</string>
-    <string name="settings_portrait_orientation">Verticale</string>
-    <string name="settings_landscape_orientation">Orizzontale</string>
-    <string name="settings_lock_on_opening_orientation">Blocca sull\'orientamento utilizzato all\'apertura della carta</string>
     <string name="failedLaunchingPhotoPicker">Impossibile trovare un\'app galleria supportata</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> carta (<xliff:g id="archivedCount">%2$d</xliff:g> archiviata)</item>
@@ -275,7 +270,6 @@
     <string name="addWithoutBarcode">Aggiungere una carta senza codice a barre</string>
     <string name="field_must_not_be_empty">Il campo non deve essere vuoto</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Ruota sempre (ignora le impostazioni di sistema)</string>
     <string name="add_manually_warning_title">Consigliata scansione</string>
     <string name="continue_">Successivo</string>
     <string name="add_manually_warning_message">In alcuni negozi, il valore del codice a barre differisce dal numero scritto sulla carta. Per questo motivo, l\'inserimento manuale del codice a barre potrebbe non funzionare sempre. Si consiglia di scansionare il codice a barre con la fotocamera. Vuoi continuare lo stesso?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -186,15 +186,10 @@
     <string name="chooseValidFromDate">有効期限を選択</string>
     <string name="anyDate">無期限</string>
     <string name="app_name">Catima</string>
-    <string name="settings_card_orientation">画面の向き</string>
     <string name="settings_display_barcode_max_brightness_summary">仕事をするためにいくつかのスキャナーが必要</string>
-    <string name="settings_follow_system_orientation">システムに従う</string>
     <string name="storageReadPermissionRequired">このアクションのためにストレージの読み取り権限を許可…</string>
     <string name="cameraPermissionDeniedTitle">カメラへアクセスできません</string>
-    <string name="settings_follow_sensor_orientation">自動回転 (システムを無視)</string>
     <string name="cameraPermissionRequired">このアクションのためにカメラへのアクセス権限の許可…</string>
-    <string name="settings_landscape_orientation">横</string>
-    <string name="settings_portrait_orientation">縦</string>
     <string name="noGiftCardsGroup">いくつかのカードを作って、それらをこのグループにアサインします。</string>
     <string name="noCameraPermissionDirectToSystemSetting">バーコードをスキャンするためには、Catimaはカメラへのアクセスを必要とします。ここをタップして権限設定の変更をお願いします。</string>
     <string name="importCards">カードをインポート</string>
@@ -219,7 +214,6 @@
     <string name="failedToOpenUrl">ブラウザーをインストールしてください</string>
     <string name="previousCard">前へ</string>
     <string name="nextCard">次へ</string>
-    <string name="settings_lock_on_opening_orientation">カードを開いた時の向きに固定</string>
     <string name="settings_oled_dark">ダークテーマで黒い背景を使用する</string>
     <string name="settings_oled_dark_summary">有機ELディスプレイでの電池の使用量を削減します</string>
     <string name="action_more_options">オプション</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -205,7 +205,6 @@
     <string name="app_copyright_old">Loyalty Card Keychain 기반
 \n저작권 © 2016–2020 Branden Archer</string>
     <string name="app_resources">자유 타사 리소스: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_lock_on_opening_orientation">카드를 열 때 사용되는 방향으로 고정</string>
     <string name="editGroup">그룹 편집: <xliff:g>%s</xliff:g></string>
     <string name="frontImageDescription">전면 사진</string>
     <string name="backImageDescription">후면 사진</string>
@@ -213,10 +212,6 @@
     <string name="importCards">카드 가져오기</string>
     <string name="updateBalanceTitle">지출하거나 수령한 금액은 얼마입니까?</string>
     <string name="newBalanceSentence">새 잔액: <xliff:g>%s</xliff:g></string>
-    <string name="settings_card_orientation">화면 방향</string>
-    <string name="settings_follow_system_orientation">기기 설정 따르기</string>
-    <string name="settings_portrait_orientation">세로</string>
-    <string name="settings_landscape_orientation">가로</string>
     <string name="noGroupCards">이 그룹은 비어 있습니다</string>
     <string name="app_loyalty_card_keychain">로열티 카드 키체인</string>
     <string name="privacy_policy">개인 정보 정책</string>
@@ -264,7 +259,6 @@
     <string name="addWithoutBarcode">바코드가 없는 카드 추가</string>
     <string name="app_name">Catima</string>
     <string name="add_manually_warning_title">스캔을 권장합니다</string>
-    <string name="settings_follow_sensor_orientation">항상 회전 (시스템 설정 무시)</string>
     <string name="continue_">계속</string>
     <string name="addFromPdfFile">PDF 파일 선택</string>
     <string name="errorReadingFile">파일을 읽을 수 없습니다</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -190,7 +190,6 @@
     <string name="noGiftCardsGroup">Sukurkite keletą kortelių ir priskirkite jas grupei čia.</string>
     <string name="setIcon">Nustatyti piktogramą</string>
     <string name="selectColor">Pasirinkti spalvą</string>
-    <string name="settings_card_orientation">Ekrano orientacija</string>
     <string name="failedLaunchingPhotoPicker">Nepavyko rasti palaikomos galerijos programėlės</string>
     <string name="previousCard">Ankstesnė</string>
     <string name="nextCard">Kita</string>
@@ -220,10 +219,6 @@
     <string name="welcome">Sveiki užėję į Catima</string>
     <string name="showMoreInfo">Rodyti informaciją</string>
     <string name="settings_oled_dark">Visiškai juodas fonas tamsiajai temai</string>
-    <string name="settings_follow_system_orientation">Sekti sistemą</string>
-    <string name="settings_portrait_orientation">Portretas</string>
-    <string name="settings_landscape_orientation">Gulsčias</string>
-    <string name="settings_lock_on_opening_orientation">Užfiksuoti padėtį, kuri naudojama atidarant kortelę</string>
     <string name="cameraPermissionDeniedTitle">Nepavyko pasiekti kameros</string>
     <string name="noCameraPermissionDirectToSystemSetting">Skanuoti brūkšniniams kodams Catima reikės gauti leidimo naudotis jūsų kamera. Spustelkite čia norėdami pakeisti leidimų nustatymus.</string>
     <plurals name="balancePoints">
@@ -246,7 +241,6 @@
     <string name="switchToFrontImage">Perjungti į priekinį vaizdą</string>
     <string name="openFrontImageInGalleryApp">Atidarykite priekinį vaizdą galerijos programėlėje</string>
     <string name="donate">Aukoti</string>
-    <string name="settings_follow_sensor_orientation">Visada sukti (nekreipiant dėmesio į sistemos nustatymus)</string>
     <string name="settings_keep_screen_on_summary">Išjungti ekrano užmigdymą kol peržiūrite kortelę</string>
     <string name="manually_enter_barcode_instructions">Įveskite ID numerį arba tekstą ant jūsų kortelės ir paspauskite brūkšninį kodą, kuris atrodo kaip ant jūsų kortelės.</string>
     <string name="addWithoutBarcode">Pridėti kortelę be brūkšninio kodo</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -157,11 +157,6 @@
     <string name="debug_version_fmt">Versija: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_libraries">Trešo pušu bibliotēkas: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="app_resources">Trešo pušu avoti: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_card_orientation">Ekrāna novietojums</string>
-    <string name="settings_follow_system_orientation">Izmantot sistēmas</string>
-    <string name="settings_portrait_orientation">Stateniski</string>
-    <string name="settings_landscape_orientation">Līmeniski</string>
-    <string name="settings_lock_on_opening_orientation">Izmantot novietojumu, kāds bija kartes atvēršanas brīdī</string>
     <string name="enter_group_name">Ievadīt kopas nosaukumu</string>
     <string name="groups">Kopas</string>
     <string name="group_edit">Labot kopu</string>
@@ -273,7 +268,6 @@
     <string name="spend">Tērēt</string>
     <string name="receive">Saņemt</string>
     <string name="amountParsingFailed">Nederīga summa</string>
-    <string name="settings_follow_sensor_orientation">Vienmēr pagriezt (neņem vērā sistēmas iestatījumus)</string>
     <string name="validFromDate">Derīga no</string>
     <string name="setBarcodeHeight">Iestatīt svītrkoda augstumu</string>
     <string name="switchToFrontImage">Pārslēgties uz priekšpuses attēlu</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -75,20 +75,14 @@
     <string name="selectBarcodeTitle">बारकोड निवडा</string>
     <string name="app_libraries">Libre third-party libraries: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="app_resources">Libre third-party resources: <xliff:g id="app_resources_list">%s</xliff:g></string>
-    <string name="settings_portrait_orientation">पोट्रेट</string>
     <string name="settings_dark_theme">गडद</string>
     <string name="settings_system_theme">प्रणाली</string>
     <string name="starImage">आवड</string>
-    <string name="settings_follow_system_orientation">सिस्टिम अनुसरण</string>
-    <string name="settings_landscape_orientation">आडवे</string>
     <string name="settings_theme">थीम</string>
     <string name="settings_light_theme">उजळ</string>
     <string name="settings">सेटिंग्ज</string>
-    <string name="settings_card_orientation">स्क्रीन ओरिएंटेशन</string>
     <string name="thumbnailDescription">लघुप्रतिमा</string>
     <string name="settings_keep_screen_on_summary">कार्ड पाहताना स्क्रीन टाइमआउट बंद करते</string>
-    <string name="settings_follow_sensor_orientation">नेहमी फिरवा (सिस्टम सेटिंग्ज दुर्लक्षित करेल)</string>
-    <string name="settings_lock_on_opening_orientation">कार्ड उघडताना वापरला जाणारा लॉक टू ओरिएंटेशन</string>
     <string name="settings_display_barcode_max_brightness">स्क्रीन उजळवा</string>
     <string name="settings_display_barcode_max_brightness_summary">काही स्कॅनर्सना काम करण्यासाठी आवश्यक</string>
     <string name="settings_keep_screen_on">स्क्रीन चालू ठेवा</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -197,16 +197,11 @@
     </plurals>
     <string name="settings_oled_dark">Svart bakgrunn for mørk drakt</string>
     <string name="include_if_asking_support">Inkluder følgende info hvis du vil ha hjelp:</string>
-    <string name="settings_card_orientation">Skjermorientering</string>
-    <string name="settings_landscape_orientation">Liggende</string>
-    <string name="settings_lock_on_opening_orientation">Lås til sideretning brukt ved åpning av kort</string>
     <string name="duplicateCard">Dupliser</string>
     <string name="archive">Arkiver</string>
     <string name="unarchive">Opphev arkivering</string>
     <string name="archived">Kort arkivert</string>
     <string name="unarchived">Kort flyttet tilbake fra arkiv</string>
-    <string name="settings_follow_system_orientation">Følg systemet</string>
-    <string name="settings_portrait_orientation">Stående</string>
     <string name="failedLaunchingPhotoPicker">Fant ikke noe støttet galleriprogram</string>
     <string name="previousCard">Forrige</string>
     <string name="nextCard">Neste</string>
@@ -274,7 +269,6 @@
     <string name="amountParsingFailed">Ugyldig beløp</string>
     <string name="spend">Utgifter</string>
     <string name="receive">Motta</string>
-    <string name="settings_follow_sensor_orientation">Alltid roter (ignorerer systeminnstilling)</string>
     <string name="add_manually_warning_message">I noen butikker er strekkoden forskjellig fra nummeret på kortet. Som følge av dette kan det hende at å skrive inn strekkoden ikke virker. Det anbefales å skanne strekkoden med kameraet istedenfor. Vil du fortsette?</string>
     <string name="pageWithNumber">Side <xliff:g>%d</xliff:g></string>
     <string name="addFromPdfFile">Velg en PDF-fil</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -193,16 +193,11 @@
     </plurals>
     <string name="settings_oled_dark">Zwarte achtergrond gebruiken bij donker thema</string>
     <string name="include_if_asking_support">Als je ondersteuning wilt, voorzie je verzoek dan van de volgende informatie:</string>
-    <string name="settings_card_orientation">Barcode-oriëntatie</string>
-    <string name="settings_follow_system_orientation">Systeeminstellingen volgen</string>
-    <string name="settings_portrait_orientation">Verticaal</string>
-    <string name="settings_lock_on_opening_orientation">Oriëntatie vergrendelen na openen van kaart</string>
     <string name="duplicateCard">Klonen</string>
     <string name="archive">Archiveren</string>
     <string name="unarchive">Dearchiveren</string>
     <string name="archived">De kaart is gearchiveerd</string>
     <string name="unarchived">De kaart is gedearchiveerd</string>
-    <string name="settings_landscape_orientation">Horizontaal</string>
     <string name="failedLaunchingPhotoPicker">Er is geen ondersteunde afbeeldingkiezer aangetroffen</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> kaart (<xliff:g id="archivedCount">%2$d</xliff:g> gearchiveerd)</item>
@@ -265,7 +260,6 @@
     <string name="addWithoutBarcode">Kaart zonder barcode toevoegen</string>
     <string name="field_must_not_be_empty">Dit veld is vereist</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Altijd draaien (negeert systeeminstellingen)</string>
     <string name="add_manually_warning_title">Scannen wordt aangeraden</string>
     <string name="add_manually_warning_message">Bij sommige kaarten wijkt de barcodewaarde af van het nummer op de kaart. Hierdoor werkt het handmatig invoeren van een barcode niet altijd. Het wordt aangeraden om in plaats daarvan de barcode met je camera te scannen. Wilt u nog steeds doorgaan?</string>
     <string name="continue_">Ga door</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -206,13 +206,8 @@
     </plurals>
     <string name="include_if_asking_support">Jeśli chcesz poprosić o pomoc, podaj następujące informacje:</string>
     <string name="settings_oled_dark">Całkowicie czarne tło dla ciemnego motywu</string>
-    <string name="settings_card_orientation">Orientacja ekranu</string>
-    <string name="settings_follow_system_orientation">Śledź orientację systemową</string>
     <string name="duplicateCard">Duplikuj</string>
     <string name="starred">Oznaczone gwiazdką</string>
-    <string name="settings_landscape_orientation">Poziomowy</string>
-    <string name="settings_lock_on_opening_orientation">Blokuj do ustawionej orientacji przy otwieraniu karty</string>
-    <string name="settings_portrait_orientation">Portretowy</string>
     <string name="archive">Archiwum</string>
     <string name="unarchive">Cofnij archiwizację</string>
     <string name="archived">Karta zarchiwizowana</string>
@@ -281,7 +276,6 @@
     <string name="addWithoutBarcode">Dodaj kartę bez kodu kreskowego</string>
     <string name="field_must_not_be_empty">Pole nie może być puste</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Zawsze obracaj (ignoruje ustawienia systemowe)</string>
     <string name="continue_">Kontynuuj</string>
     <string name="addFromPdfFile">Wybierz plik PDF</string>
     <string name="errorReadingFile">Nie można odczytać pliku</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -77,8 +77,6 @@
         <item quantity="other"><xliff:g>%d</xliff:g> cartões</item>
     </plurals>
     <string name="noCameraFoundGuideText">Seu dispositivo parece não ter uma câmera. Se tiver, tente reiniciar o dispositivo. Caso contrário, tente usar o botão \"Mais opções\" abaixo para adicionar um código de barras manualmente.</string>
-    <string name="settings_follow_system_orientation">Padrão do sistema</string>
-    <string name="settings_lock_on_opening_orientation">Bloquear para orientação usada ao abrir o cartão</string>
     <string name="importCatimaMessage">Selecione o arquivo exportado do Catima para importação. \nFaça isso a partir do menu \"Importar/Exportar\" em outro aplicativo Catima tocando em Exportar.</string>
     <string name="importLoyaltyCardKeychain">Importar do Loyalty Card Keychain</string>
     <string name="importLoyaltyCardKeychainMessage">Selecione o arquivo exportado do Loyalty Card Keychain, para importação. \nFaça isso a partir do menu \"Importar/Exportar\" no Loyalty Card Keychain tocando em Exportar.</string>
@@ -221,15 +219,11 @@
     <string name="settings_display_barcode_max_brightness_summary">Necessário para alguns scanners funcionarem</string>
     <string name="balanceSentence">Saldo: <xliff:g>%s</xliff:g></string>
     <string name="balance">Saldo</string>
-    <string name="settings_follow_sensor_orientation">Sempre girar (ignora as configurações do sistema)</string>
     <string name="settings_theme">Tema</string>
     <string name="settings_light_theme">Claro</string>
     <string name="settings_system_theme">Sistema</string>
     <string name="settings_dark_theme">Escuro</string>
     <string name="moveBarcodeToTopOfScreen">Mover o código de barras para o topo da tela</string>
-    <string name="settings_card_orientation">Orientação da tela</string>
-    <string name="settings_portrait_orientation">Retrato</string>
-    <string name="settings_landscape_orientation">Paisagem</string>
     <string name="settings_keep_screen_on_summary">Desativa o tempo limite de tela enquanto estiver vendo um cartão</string>
     <string name="importSuccessful">Dados importados</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Desativa bloqueio de tela enquanto estiver vendo um cartão</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -204,11 +204,6 @@
     <string name="include_if_asking_support">Se quiser pedir ajuda, inclua as seguintes informações:</string>
     <string name="duplicateCard">Duplicar</string>
     <string name="archive">Arquivar</string>
-    <string name="settings_card_orientation">Orientação do ecrã</string>
-    <string name="settings_follow_system_orientation">Definido no sistema</string>
-    <string name="settings_portrait_orientation">Retrato</string>
-    <string name="settings_landscape_orientation">Paisagem</string>
-    <string name="settings_lock_on_opening_orientation">Bloqueio da orientação usada ao abrir o cartão</string>
     <string name="unarchive">Desarquivar</string>
     <string name="archived">Cartão arquivado</string>
     <string name="unarchived">Cartão desarquivado</string>
@@ -281,7 +276,6 @@
     <string name="spend">Gastar</string>
     <string name="receive">Receber</string>
     <string name="amountParsingFailed">Montante inválido</string>
-    <string name="settings_follow_sensor_orientation">Rodar sempre (ignora as definições do sistema)</string>
     <string name="addFromPdfFile">Selecionar um ficheiro PDF</string>
     <string name="errorReadingFile">Não foi possível ler o ficheiro</string>
     <string name="multipleBarcodesFoundPleaseChooseOne">Qual dos códigos de barras encontrados pretende utilizar?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -20,7 +20,6 @@
     <string name="cameraPermissionDeniedTitle">Não foi possível acessar a câmera</string>
     <string name="importOptionFilesystemButton">A partir do Sistema de Arquivos</string>
     <string name="about">Sobre</string>
-    <string name="settings_portrait_orientation">Retrato</string>
     <string name="settings_display_barcode_max_brightness">Iluminar a tela</string>
     <string name="settings_display_barcode_max_brightness_summary">Necessário para alguns scanners funcionarem</string>
     <string name="groups">Grupos</string>
@@ -103,13 +102,8 @@
     <string name="settings_system_theme">Sistema</string>
     <string name="settings_light_theme">Claro</string>
     <string name="settings_dark_theme">Escuro</string>
-    <string name="settings_card_orientation">Orientação da tela</string>
-    <string name="settings_follow_system_orientation">Padrão do sistema</string>
-    <string name="settings_follow_sensor_orientation">Sempre girar (ignora as configurações do sistema)</string>
-    <string name="settings_landscape_orientation">Paisagem</string>
     <string name="settings_keep_screen_on">Manter tela ligada</string>
     <string name="settings_keep_screen_on_summary">Desativa o tempo limite de tela enquanto estiver vendo um cartão</string>
-    <string name="settings_lock_on_opening_orientation">Bloquear para orientação usada ao abrir o cartão</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Previnir bloqueio de tela</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Desativa bloqueio de tela enquanto estiver vendo um cartão</string>
     <string name="settings_allow_content_provider_read_title">Permitir que outros aplicativos acessem meus dados</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -105,7 +105,6 @@
     <string name="help_translate_this_app">Ajutați la traducerea aplicației</string>
     <string name="sort_by_expiry">Expirare</string>
     <string name="add_a_card_in_a_different_way">Adăugați un card într-o altă modalitate</string>
-    <string name="settings_portrait_orientation">Portret</string>
     <string name="takePhoto">Faceți o poză</string>
     <string name="validFromDate">Valid de la data de</string>
     <string name="cameraPermissionDeniedTitle">Camera nu a putut fi accesată</string>
@@ -118,7 +117,6 @@
     <string name="backImageDescription">Imagine din spate</string>
     <string name="view_online">Vizualizați online</string>
     <string name="noCameraPermissionDirectToSystemSetting">Pentru a scana codurile de bare, Catima necesită acces la cameră. Apăsați aici pentru a schimba setările permisiunilor dvs.</string>
-    <string name="settings_lock_on_opening_orientation">Blocați orientația folosită când deschideți cardul</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="turn_flashlight_on">Porniți lanterna</string>
     <string name="height">Înălțime</string>
@@ -173,7 +171,6 @@
     <string name="show_note">Afișați notița</string>
     <string name="report_error">Raportați o eroare</string>
     <string name="switchToBackImage">Comutați către imaginea din spate</string>
-    <string name="settings_follow_system_orientation">Urmează setările sistemului</string>
     <string name="reverse">...în ordine inversă</string>
     <string name="settings_brown_theme">Maro</string>
     <string name="app_contributors">Făcut posibil de: <xliff:g id="app_contributors">%s</xliff:g></string>
@@ -200,7 +197,6 @@
     <string name="failedGeneratingShareURL">Nu s-a putut genera un URL partajabil. Vă rugăm să raportați aceasta eroare.</string>
     <string name="selectColor">Selectați o culoare</string>
     <string name="setBarcodeHeight">Setați înălțimea codului de bare</string>
-    <string name="settings_landscape_orientation">Orizontal</string>
     <string name="privacy_policy">Politica de Confidențialitate</string>
     <string name="openBackImageInGalleryApp">Deschideți imaginea din spate în aplicația galerie</string>
     <string name="settings_system_locale">Sistem</string>
@@ -238,7 +234,6 @@
     <string name="settings_violet_theme">Mov</string>
     <string name="include_if_asking_support">Dacă doriți să cereți ajutor, includeți informațiile următoare:</string>
     <string name="show_archived_cards">Afișați cardurile arhivate</string>
-    <string name="settings_card_orientation">Orientare ecran</string>
     <string name="app_libraries">Listă de biblioteci libere de la terți: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="updateBalanceTitle">Cât de mult ați cheltuit sau primit?</string>
     <string name="settings_blue_theme">Albastru</string>
@@ -271,7 +266,6 @@
     <string name="settings_keep_screen_on_summary">Dezactivează temporizatorul de ecran când vizualizați un card</string>
     <string name="rate_this_app">Acordați o recenzie acestei aplicații</string>
     <string name="credits">Contribuitori</string>
-    <string name="settings_follow_sensor_orientation">Rotește întotdeauna (ignora setările de sistem)</string>
     <string name="continue_">Continua</string>
     <string name="add_manually_warning_title">Se recomandă scanarea</string>
     <string name="add_manually_warning_message">Pentru unele magazine, valoarea codului de bare diferă de numărul scris pe card. Din acest motiv, este posibil ca introducerea manuală a unui cod de bare să nu funcționeze întotdeauna. În schimb, este recomandat să scanați codul de bare cu camera dvs. Mai vrei să continui?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -203,14 +203,9 @@
     </plurals>
     <string name="settings_oled_dark">Чёрный фон для тёмной темы</string>
     <string name="include_if_asking_support">Если вы хотите запросить поддержку, укажите следующую информацию:</string>
-    <string name="settings_portrait_orientation">Портретная</string>
-    <string name="settings_landscape_orientation">Альбомная</string>
-    <string name="settings_lock_on_opening_orientation">Фиксировать ориентацию при открытии карты</string>
     <string name="archive">Архивировать</string>
     <string name="unarchive">Разархивировать</string>
-    <string name="settings_follow_system_orientation">Как в системе</string>
     <string name="duplicateCard">Дублировать</string>
-    <string name="settings_card_orientation">Ориентация экрана</string>
     <string name="archived">Карта архивирована</string>
     <string name="unarchived">Карта разархивирована</string>
     <string name="failedLaunchingPhotoPicker">Не найдено приложение для выбора изображений</string>
@@ -277,7 +272,6 @@
     <string name="addWithoutBarcode">Добавить карту без штрих-кода</string>
     <string name="field_must_not_be_empty">Поле не может быть пустым</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Всегда поворачивать (игнорировать системные настройки)</string>
     <string name="add_manually_warning_title">Рекомендуется сканирование</string>
     <string name="continue_">Продолжить</string>
     <string name="add_manually_warning_message">В некоторых картах значение штрих-кода отличается от написанного на карте номера, из-за чего введение штрих-кода вручную не всегда работает. Вместо этого рекомендуется отсканировать штрих-код камерой. Продолжить?</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -183,8 +183,6 @@
     <string name="noGiftCardsGroup">Zatiaľ nemáte žiadne vernostné karty. Keď nejaké pridáte, môžete ich priradiť ku skupine tu</string>
     <string name="noCameraPermissionDirectToSystemSetting">Na skenovanie čiarových kódov potrebuje Catima prístup k fotoaparátu. Ťuknite sem a zmeňte nastavenia oprávnení.</string>
     <string name="importCards">Importovať karty</string>
-    <string name="settings_card_orientation">Orientácia obrazovky</string>
-    <string name="settings_lock_on_opening_orientation">Zamknúť na orientáciu použitú pri otváraní karty</string>
     <string name="app_loyalty_card_keychain">Kľúčenka vernostných kariet</string>
     <string name="settings_oled_dark">Čisto čierne pozadie pre tmavú tému</string>
     <string name="failedToRetrieveImageFile">Nepodarilo sa získať súbor obrázku</string>
@@ -227,9 +225,6 @@
     <string name="barcodeLongPressMessage">V aplikácii galéria je možné otvoriť iba obrázky</string>
     <string name="cameraPermissionDeniedTitle">Nepodarilo sa získať prístup k fotoaparátu</string>
     <string name="storageReadPermissionRequired">Pre túto akciu je potrebné oprávnenie na čítanie úložiska…</string>
-    <string name="settings_follow_system_orientation">Podľa systému</string>
-    <string name="settings_portrait_orientation">Na výšku</string>
-    <string name="settings_landscape_orientation">Na šírku</string>
     <string name="importFidmeMessage">Vyberte svoj <i>fidme-export-request-xxxxxx.zip</i> export zo služby FidMe pre import a potom vyberte typy čiarových kódov ručne.
 \nVytvorte ho z profilu FidMe tak, že najprv vyberiete položku Ochrana údajov a potom stlačíte tlačidlo Extrahovať moje údaje.</string>
     <string name="currentBalanceSentence">Aktuálny zostatok: <xliff:g>%s</xliff:g></string>
@@ -275,7 +270,6 @@
     <string name="app_copyright_fmt" tools:ignore="PluralsCandidate">Copyright © 2019–<xliff:g>%d</xliff:g> Sylvia van Os a prispievatelia</string>
     <string name="show_archived_cards">Zobraziť archivované karty</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Vždy otočiť (ignoruje nastavenie systému)</string>
     <string name="continue_">Pokračovať</string>
     <string name="spend">Utratené</string>
     <string name="receive">Prijaté</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -159,11 +159,6 @@
         <item quantity="few"><xliff:g>%d</xliff:g> izbrane</item>
         <item quantity="other"><xliff:g>%d</xliff:g> izbranih</item>
     </plurals>
-    <string name="settings_card_orientation">Orientacija zaslona</string>
-    <string name="settings_follow_system_orientation">Sledi sistemu</string>
-    <string name="settings_portrait_orientation">Pokončno</string>
-    <string name="settings_landscape_orientation">Ležeče</string>
-    <string name="settings_lock_on_opening_orientation">Ohrani usmerjenost uporabljeno pri odpiranju kartice</string>
     <string name="setIcon">Nastavi sličico</string>
     <string name="showMoreInfo">Prikaži informacije</string>
     <string name="updateBalance">Posodobi stanje</string>
@@ -244,7 +239,6 @@
     <string name="app_copyright_fmt" tools:ignore="PluralsCandidate">Avtorske pravice © 2019–<xliff:g>%d</xliff:g> Sylvia van Os in drugi sodelujoči</string>
     <string name="permissionReadCardsLabel">Preberi kartice Catima</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Vedno obrni (prezri sistemske nastavitve)</string>
     <string name="settings_keep_screen_on_summary">Med ogledom kartice ohrani vključen zaslon</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Med ogledom kartice onemogoči zaklepanje zaslona</string>
     <string name="settings_allow_content_provider_read_title">Dovoli drugim aplikacijam dostop do mojih podatkov</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -57,15 +57,9 @@
     <string name="settings_system_theme">Sistem</string>
     <string name="settings_light_theme">Svetla</string>
     <string name="settings_dark_theme">Tamna</string>
-    <string name="settings_follow_system_orientation">Kao sistem</string>
-    <string name="settings_follow_sensor_orientation">Uvek rotiraj (ignoriše sistemska podešavanja)</string>
-    <string name="settings_portrait_orientation">Uspravno</string>
-    <string name="settings_landscape_orientation">Položeno</string>
-    <string name="settings_lock_on_opening_orientation">Zaključavanje orijentacije koja se koristi prilikom otvaranja kartice</string>
     <string name="settings_display_barcode_max_brightness">Osvetli ekran</string>
     <string name="settings_display_barcode_max_brightness_summary">Neophodno za rad nekih čitača</string>
     <string name="selectBarcodeTitle">Odaberi bar-kod</string>
-    <string name="settings_card_orientation">Orijentacija ekrana</string>
     <string name="thumbnailDescription">Naslovna fotografija</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Spreči zaključavanje ekrana</string>
     <string name="settings_allow_content_provider_read_title">Dozvoli drugim aplikacijama da pristupe mojim podacima</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -193,13 +193,8 @@
     <string name="include_if_asking_support">Om du vill be om hjälp, inkludera då följande information:</string>
     <string name="settings_oled_dark">Helsvart bakgrund för mörkt tema</string>
     <string name="failedLaunchingPhotoPicker">Kunde inte hitta kompatibelt bildprogram</string>
-    <string name="settings_card_orientation">Streckkodsriktning</string>
-    <string name="settings_portrait_orientation">Porträtt</string>
-    <string name="settings_landscape_orientation">Landskap</string>
-    <string name="settings_lock_on_opening_orientation">Lås aktuell riktning när kort öppnas</string>
     <string name="unarchive">Ta tillbaks från arkiv</string>
     <string name="archived">Kort arkiverat</string>
-    <string name="settings_follow_system_orientation">Spårsystem</string>
     <string name="duplicateCard">Kopiera</string>
     <string name="unarchived">Kort återläst från arkiv</string>
     <string name="nextCard">Nästa</string>
@@ -265,7 +260,6 @@
     <string name="addWithoutBarcode">Lägg till kort utan streckkod</string>
     <string name="field_must_not_be_empty">Obligatoriskt fält</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Rotera automatiskt (ignorerar systeminställningar)</string>
     <string name="continue_">Fortsätt</string>
     <string name="settings_column_count_5">5</string>
     <string name="settings_column_count_6">6</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -111,14 +111,8 @@
     <string name="settings_system_theme">மண்டலம்</string>
     <string name="settings_light_theme">ஒளி</string>
     <string name="settings_dark_theme">இருண்ட</string>
-    <string name="settings_card_orientation">திரை நோக்குநிலை</string>
-    <string name="settings_follow_system_orientation">அமைப்பைப் பின்தொடரவும்</string>
     <string name="settings_keep_screen_on">திரையை தொடர்ந்து வைத்திருங்கள்</string>
-    <string name="settings_follow_sensor_orientation">எப்போதும் சுழற்றுங்கள் (கணினி அமைப்புகளை புறக்கணிக்கிறது)</string>
     <string name="settings_keep_screen_on_summary">ஒரு அட்டையைப் பார்க்கும்போது திரை நேரத்தை முடக்குகிறது</string>
-    <string name="settings_portrait_orientation">உருவப்படம்</string>
-    <string name="settings_landscape_orientation">நிலப்பரப்பு</string>
-    <string name="settings_lock_on_opening_orientation">அட்டையைத் திறக்கும்போது பயன்படுத்தப்படும் நோக்குநிலைக்கு பூட்டு</string>
     <string name="settings_display_barcode_max_brightness">திரை ஒளி</string>
     <string name="settings_display_barcode_max_brightness_summary">சில ச்கேனர்கள் வேலை செய்ய தேவை</string>
     <string name="settings_disable_lockscreen_while_viewing_card">திரை பூட்டைத் தடுக்கவும்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -197,14 +197,9 @@
     </plurals>
     <string name="settings_oled_dark">Koyu tema için saf siyah arka plan</string>
     <string name="include_if_asking_support">Destek talep etmek istiyorsanız, aşağıdaki bilgileri ekleyin:</string>
-    <string name="settings_follow_system_orientation">Sistemi takip et</string>
-    <string name="settings_portrait_orientation">Dikey</string>
-    <string name="settings_landscape_orientation">Yatay</string>
     <string name="duplicateCard">Çoğalt</string>
     <string name="unarchive">Arşivden çıkar</string>
     <string name="archived">Kart arşivlendi</string>
-    <string name="settings_card_orientation">Ekran yönü</string>
-    <string name="settings_lock_on_opening_orientation">Kartı açarken kullanılan yönü kilitle</string>
     <string name="unarchived">Kart arşivden çıkarıldı</string>
     <string name="archive">Arşivle</string>
     <string name="failedLaunchingPhotoPicker">Desteklenen bir galeri uygulaması bulunamadı</string>
@@ -269,7 +264,6 @@
     <string name="addWithoutBarcode">Barkodsuz bir kart ekle</string>
     <string name="field_must_not_be_empty">Alan boş olamaz</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Her zaman döndür (sistem ayarlarını yok sayar)</string>
     <string name="continue_">Devam et</string>
     <string name="add_manually_warning_title">Tarama yapılması tavsiye edilir</string>
     <string name="add_manually_warning_message">Bazı mağazalarda barkod değeri kartta yazan sayıdan farklıdır. Bu nedenle, bir barkodu elle girmek her zaman işe yaramayabilir. Bunun yerine barkodu kameranızla taramanız şiddetle tavsiye edilir. Yine de devam etmek istiyor musunuz?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -204,13 +204,8 @@
     </plurals>
     <string name="include_if_asking_support">Якщо ви хочете отримати техпідтримку, додайте цю інформацію:</string>
     <string name="unarchive">Розархівувати</string>
-    <string name="settings_card_orientation">Орієнтація екрана</string>
-    <string name="settings_follow_system_orientation">Як у системі</string>
     <string name="duplicateCard">Дублювати</string>
     <string name="archive">Архівувати</string>
-    <string name="settings_portrait_orientation">Вертикальна</string>
-    <string name="settings_landscape_orientation">Горизонтальна</string>
-    <string name="settings_lock_on_opening_orientation">Фіксація орієнтації під час відкриття картки</string>
     <string name="archived">Картка архівована</string>
     <string name="unarchived">Картка розархівована</string>
     <plurals name="groupCardCountWithArchived">
@@ -277,7 +272,6 @@
     <string name="addWithoutBarcode">Додати картку без штрих-коду</string>
     <string name="field_must_not_be_empty">Поле вводу не повинно бути порожнім</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">Завжди обертати (ігнорувати системні налаштування)</string>
     <string name="add_manually_warning_message">Для деяких карток значення штрих-коду відрізняється від номера, вказаного на картці. Через це введення штрих-коду вручну не завжди може працювати. Рекомендується замість цього відсканувати штрих-код за допомогою камери. Ви все одно хочете продовжити?</string>
     <string name="continue_">Продовжити</string>
     <string name="add_manually_warning_title">Рекомендується відсканувати</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -18,7 +18,6 @@
     <string name="help_translate_this_app">Giúp dịch ứng dụng này</string>
     <string name="sort_by_expiry">Ngày hết hạn</string>
     <string name="add_a_card_in_a_different_way">Thêm thẻ theo cách khác</string>
-    <string name="settings_portrait_orientation">Dọc</string>
     <string name="takePhoto">Chụp ảnh</string>
     <string name="storeName">Tên</string>
     <string name="validFromDate">Có hiệu lực từ</string>
@@ -34,7 +33,6 @@
     <string name="backImageDescription">Ảnh mặt sau</string>
     <string name="view_online">Xem online</string>
     <string name="noCameraPermissionDirectToSystemSetting">Để quét mã vạch, Catima sẽ cần truy cập vào camera của bạn. Nhấn vào đây để thay đổi cài đặt việc cấp quyền.</string>
-    <string name="settings_lock_on_opening_orientation">Cố định hướng hiện thị màng hình khi đang mở thẻ</string>
     <string name="app_loyalty_card_keychain">Loyalty Card Keychain</string>
     <string name="turn_flashlight_on">Mở đèn pin</string>
     <string name="importOptionFilesystemTitle">Nhập dữ liệu từ hệ thống</string>
@@ -112,7 +110,6 @@
     <string name="show_note">Hiện ghi chú</string>
     <string name="report_error">Báo Lỗi</string>
     <string name="passwordRequired">Xin mời nhập mật khẩu</string>
-    <string name="settings_follow_system_orientation">Hệ thống theo dõi</string>
     <string name="intent_import_card_from_url_share_text">Tôi muốn chia sẻ thẻ với bạn</string>
     <string name="star">Đánh dấu ưa thích</string>
     <string name="addFromImage">Chọn ảnh từ thư viện ảnh</string>
@@ -148,7 +145,6 @@
     <string name="failedGeneratingShareURL">Không tạo được URL chia sẻ. Xin hãy báo cáo sự cố này.</string>
     <string name="selectColor">Chọn màu</string>
     <string name="setBarcodeHeight">Đặt chiều cao cho mã vạch</string>
-    <string name="settings_landscape_orientation">Ngang</string>
     <string name="privacy_policy">Chính Sách Quyền Riêng Tư</string>
     <string name="enter_group_name">Nhập tên nhóm</string>
     <string name="addCardTitle">Thêm Thẻ</string>
@@ -214,7 +210,6 @@
     <string name="show_archived_cards">Hiện thẻ lưu trữ</string>
     <string name="selectBarcodeTitle">Chọn Mã Vạch</string>
     <string name="importSuccessful">Nhập dữ liệu xong</string>
-    <string name="settings_card_orientation">Hướng màn hình</string>
     <string name="app_libraries">Thư viện mở từ bên thứ 3: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="updateBalanceTitle">Bạn đã chi tiêu hoặc nhận được bao nhiêu?</string>
     <string name="editCardTitle">Sửa Thẻ</string>
@@ -263,7 +258,6 @@
     <string name="failedToRetrieveImageFile">Không thể truy xuất tệp hình ảnh</string>
     <string name="app_contributors">Được thực hiện bởi: <xliff:g id="app_contributors">%s</xliff:g></string>
     <string name="app_license">Phần mềm miễn phí có bản quyền theo giấy phép GPLv3+</string>
-    <string name="settings_follow_sensor_orientation">Luôn xoay (bỏ qua thiết đặt hệ thống)</string>
     <string name="continue_">Tiếp tục</string>
     <string name="add_manually_warning_title">Nên quét</string>
     <string name="spend">Tiêu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -189,11 +189,6 @@
     <string name="failedLaunchingPhotoPicker">找不到支持的图片选择应用</string>
     <string name="previousCard">前一张</string>
     <string name="nextCard">下一张</string>
-    <string name="settings_card_orientation">屏幕</string>
-    <string name="settings_landscape_orientation">横向</string>
-    <string name="settings_follow_system_orientation">跟随系统</string>
-    <string name="settings_lock_on_opening_orientation">使用上次打开卡片时的朝向</string>
-    <string name="settings_portrait_orientation">竖向</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="other"><xliff:g>%1$d</xliff:g> 张卡 (<xliff:g id="archivedCount">%2$d</xliff:g> 张已归档)</item>
     </plurals>
@@ -259,7 +254,6 @@
     <string name="addWithoutBarcode">不使用条形码添加卡片</string>
     <string name="field_must_not_be_empty">字段不能为空</string>
     <string name="app_name">Catima</string>
-    <string name="settings_follow_sensor_orientation">始终旋转（忽略系统设置）</string>
     <string name="add_manually_warning_title">建议扫描</string>
     <string name="continue_">继续</string>
     <string name="add_manually_warning_message">某些卡片的二维码值和刻在卡上的数字并不一样。由于这个原因，手动输入二维码可能并不总是有用。这种情况下，建议你用相机扫描二维码。你仍要继续吗？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -190,7 +190,6 @@
     <string name="translate_platform">於 Weblate</string>
     <string name="options">選項</string>
     <string name="include_if_asking_support">如果您想請求協助，請附上以下訊息：</string>
-    <string name="settings_card_orientation">螢幕方向</string>
     <string name="failedToRetrieveImageFile">無法擷取圖片檔案</string>
     <string name="barcodeLongPressMessage">圖庫應用程式僅可開啟圖片</string>
     <string name="duplicateCard">重複</string>
@@ -201,15 +200,11 @@
     <plurals name="groupCardCountWithArchived">
         <item quantity="other"><xliff:g>%1$d</xliff:g> 張卡片 (<xliff:g id="archivedCount">%2$d</xliff:g> 張已封存)</item>
     </plurals>
-    <string name="settings_portrait_orientation">直向</string>
-    <string name="settings_follow_system_orientation">跟隨系統</string>
-    <string name="settings_landscape_orientation">橫向</string>
     <string name="failedToOpenUrl">先安裝網頁瀏覽器</string>
     <string name="failedLaunchingPhotoPicker">無法找到支援的圖庫應用程式</string>
     <string name="previousCard">上一張</string>
     <string name="nextCard">下一張</string>
     <string name="welcome">歡迎使用卡提碼</string>
-    <string name="settings_lock_on_opening_orientation">開啟卡片時鎖定的方向</string>
     <string name="importCards">導入卡片</string>
     <string name="noCameraPermissionDirectToSystemSetting">卡提碼需要鏡頭使用權才能夠掃描條碼， 點擊這裏更變你的權限設定。</string>
     <string name="validFromDate">生效</string>
@@ -261,7 +256,6 @@
     <string name="enter_card_id">輸入卡片上的 ID 或文字</string>
     <string name="settings_display_barcode_max_brightness_summary">一些條碼掃描器需要此設定方能運作</string>
     <string name="field_must_not_be_empty">欄位不能為空</string>
-    <string name="settings_follow_sensor_orientation">始終旋轉（忽略系統設定）</string>
     <string name="add_manually_warning_title">建議掃描</string>
     <string name="failedLaunchingFileManager">找不到支援的檔案管理器</string>
     <string name="addFromPdfFile">選擇一個 PDF 檔案</string>

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -161,22 +161,6 @@
         <item>zh-rTW</item>
     </string-array>
 
-    <string-array name="card_orientation_values">
-        <item>@string/settings_key_follow_system_orientation</item>
-        <item>@string/settings_key_follow_sensor_orientation</item>
-        <item>@string/settings_key_lock_on_opening_orientation</item>
-        <item>@string/settings_key_portrait_orientation</item>
-        <item>@string/settings_key_landscape_orientation</item>
-    </string-array>
-
-    <string-array name="card_orientation_values_strings">
-        <item>@string/settings_follow_system_orientation</item>
-        <item>@string/settings_follow_sensor_orientation</item>
-        <item>@string/settings_lock_on_opening_orientation</item>
-        <item>@string/settings_portrait_orientation</item>
-        <item>@string/settings_landscape_orientation</item>
-    </string-array>
-
     <array name="letter_tile_colors">
         <item>#f16364</item>
         <item>#f58559</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -352,4 +352,5 @@
     <string name="card_list_widget_empty">After you add some loyalty cards in Catima, they will appear here. If you have cards, make sure they are not all archived.</string>
     <string name="cardWithNumber">Card <xliff:g>%d</xliff:g></string>
     <string name="cardWithNumberAndLocale">Card <xliff:g>%d</xliff:g> (<xliff:g>%s</xliff:g>)</string>
+    <string name="pleaseDoNotRotateTheDevice">Please do not rotate the device, as this will cancel the action</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,18 +92,6 @@
     <string name="settings_key_light_theme" translatable="false">light</string>
     <string name="settings_dark_theme">Dark</string>
     <string name="settings_key_dark_theme" translatable="false">dark</string>
-    <string name="settings_card_orientation">Screen orientation</string>
-    <string name="settings_key_card_orientation" translatable="false">pref_card_orientation</string>
-    <string name="settings_follow_system_orientation">Follow system</string>
-    <string name="settings_key_follow_system_orientation" translatable="false">follow_system</string>
-    <string name="settings_follow_sensor_orientation">Always rotate (ignores system settings)</string>
-    <string name="settings_key_follow_sensor_orientation" translatable="false">follow_sensor</string>
-    <string name="settings_portrait_orientation">Portrait</string>
-    <string name="settings_key_portrait_orientation" translatable="false">portrait</string>
-    <string name="settings_landscape_orientation">Landscape</string>
-    <string name="settings_key_landscape_orientation" translatable="false">landscape</string>
-    <string name="settings_lock_on_opening_orientation">Lock to orientation used when opening the card</string>
-    <string name="settings_key_lock_on_opening_orientation" translatable="false">lock_on_opening</string>
     <string name="settings_key_max_font_size_scale" translatable="false">pref_max_font_size_scale</string>
     <string name="settings_display_barcode_max_brightness">Brighten screen</string>
     <string name="settings_display_barcode_max_brightness_summary">Necessary for some scanners to work</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -93,16 +93,6 @@
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
 
-        <ListPreference
-            android:defaultValue="@string/settings_key_follow_system_orientation"
-            android:entries="@array/card_orientation_values_strings"
-            android:entryValues="@array/card_orientation_values"
-            android:key="@string/settings_key_card_orientation"
-            android:title="@string/settings_card_orientation"
-            app:iconSpaceReserved="false"
-            app:singleLineTitle="false"
-            app:useSimpleSummaryProvider="true" />
-
         <SwitchPreferenceCompat
             android:widgetLayout="@layout/preference_material_switch"
             android:defaultValue="true"


### PR DESCRIPTION
Fixes #2407

- [x] Remove "Screen orientation" feature, as it will no longer be possible to support this feature.
- [x] Unlock rotation on the import/export screen, add a warning to "please don't rotate your screen" as it'll kill the import. See d24366a3ba17bea17c1536f2083a7b615ea5b1f4.

This code is depressing to write, I don't want to remove a feature that is generally liked. I will probably get yelled at again for this. But well, Google is just plain out removing it, it's literally outside of my control :(