### PR TITLE
fix: Crash after removing image while viewing image

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -1085,6 +1085,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
     }
 
     private void setMainImagePreviousNextButtons() {
+        // Ensure the main image index is valid. After a card update, some images (front/back/barcode)
+        // may have been removed, so the index should not exceed the number of available images.
+        if(mainImageIndex > imageTypes.size() - 1){
+            mainImageIndex = 0;
+        }
+
         if (imageTypes.size() < 2) {
             binding.mainLeftButton.setVisibility(View.INVISIBLE);
             binding.mainRightButton.setVisibility(View.INVISIBLE);


### PR DESCRIPTION
**Problem**

When a user edits a loyalty card in `LoyaltyEditCardActivity`, they can add new images (front/back), replace them via camera/gallery, or remove one or both images. After saving, `LoyaltyEditCardActivity` finishes and the app resumes in `LoyaltyViewCardActivity`.

At this point, the set of available images may have changed. However, mainImageIndex (used in `LoyaltyViewCardActivity` to display the currently visible image) may still point to an index that no longer exists. This can lead to out-of-bounds errors or an incorrect image being shown.


**Solution**

In `LoyaltyViewCardActivity`, after rebuilding the imageTypes list on resume, a validation check ensures that mainImageIndex does not exceed the maximum valid index (imageTypes.size() - 1). If it does, it is reset to 0.


**Why this solution**

- Keeps the fix localized in `LoyaltyViewCardActivity`, where images are displayed.
- Ensures that the app does not crash or show an invalid state after returning from editing.
- Resetting to 0 guarantees a safe fallback to a valid image, maintaining consistent UX.


**How to reproduce the issue**

1. Open a loyalty card in `LoyaltyViewCardActivity`.
2. Tap edit → in `LoyaltyEditCardActivity`, remove the image currently selected as the main image.
3. Tap save, which closes `LoyaltyEditCardActivity` and resumes `LoyaltyViewCardActivity`.
4. Without the fix, mainImageIndex may be invalid, causing errors or incorrect behavior.


**How to test the fix**

1. Open a card with multiple images and set the last image as main.
2. Edit the card and remove that last image.
3. Save and return to `LoyaltyViewCardActivity`.
4. Verify that the card displays properly, with mainImageIndex reset to a valid value (0 if needed).

### Issue
Fixes #2239  