### PR TITLE
Refactor(DB): Replace rawQuery with query builder and use try-with-re…

### DIFF
--- a/app/src/main/java/protect/card_locker/MainActivity.java
+++ b/app/src/main/java/protect/card_locker/MainActivity.java
@@ -2,8 +2,6 @@ package protect.card_locker;
 
 import android.app.Activity;
 import android.app.SearchManager;
-import android.appwidget.AppWidgetManager;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;

--- a/app/src/test/java/protect/card_locker/DatabaseTest.java
+++ b/app/src/test/java/protect/card_locker/DatabaseTest.java
@@ -41,7 +41,7 @@ public class DatabaseTest {
     @Test
     public void addRemoveOneGiftCard() {
         assertEquals(0, DBHelper.getLoyaltyCardCount(mDatabase));
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -69,7 +69,7 @@ public class DatabaseTest {
 
     @Test
     public void updateGiftCard() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -96,7 +96,7 @@ public class DatabaseTest {
 
     @Test
     public void updateGiftCardOnlyStar() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "store", "note", null, null, new BigDecimal("0"), null, "cardId", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), DEFAULT_HEADER_COLOR, 0, null, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -133,7 +133,7 @@ public class DatabaseTest {
 
     @Test
     public void emptyGiftCardValues() {
-        long id = DBHelper.insertLoyaltyCard(mDatabase, "", "", null, null, new BigDecimal("0"), null, "", null, null, null, 0, null,0);
+        long id = DBHelper.insertLoyaltyCard(mDatabase, "", "", null, null, new BigDecimal("0"), null, "", null, null, null, 0, null, 0);
         boolean result = (id != -1);
         assertTrue(result);
         assertEquals(1, DBHelper.getLoyaltyCardCount(mDatabase));
@@ -168,34 +168,31 @@ public class DatabaseTest {
         }
 
         assertEquals(CARDS_TO_ADD, DBHelper.getLoyaltyCardCount(mDatabase));
+        try (Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase)) {
+            assertNotNull(cursor);
+            assertEquals(CARDS_TO_ADD, cursor.getCount());
 
-        Cursor cursor = DBHelper.getLoyaltyCardCursor(mDatabase);
-        assertNotNull(cursor);
+            cursor.moveToFirst();
 
-        assertEquals(CARDS_TO_ADD, cursor.getCount());
+            for (int index = 0; index < CARDS_TO_ADD; index++) {
+                assertEquals("store" + index, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STORE)));
+                assertEquals("note" + index, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.NOTE)));
+                assertEquals(0, cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.VALID_FROM)));
+                assertEquals(0, cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.EXPIRY)));
+                assertEquals("0", cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE)));
+                assertEquals(null, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE)));
+                assertEquals("cardId" + index, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.CARD_ID)));
+                assertEquals(null, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_ID)));
+                assertEquals(BarcodeFormat.UPC_A.toString(), cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE)));
+                assertEquals(index, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR)));
+                assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS)));
+                assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS)));
 
-        cursor.moveToFirst();
+                cursor.moveToNext();
+            }
 
-        for (int index = 0; index < CARDS_TO_ADD; index++) {
-            assertEquals("store" + index, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STORE)));
-            assertEquals("note" + index, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.NOTE)));
-            assertEquals(0, cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.VALID_FROM)));
-            assertEquals(0, cursor.getLong(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.EXPIRY)));
-            assertEquals("0", cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE)));
-            assertEquals(null, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE)));
-            assertEquals("cardId" + index, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.CARD_ID)));
-            assertEquals(null, cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_ID)));
-            assertEquals(BarcodeFormat.UPC_A.toString(), cursor.getString(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE)));
-            assertEquals(index, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.HEADER_COLOR)));
-            assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.STAR_STATUS)));
-            assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS)));
-
-            cursor.moveToNext();
+            assertTrue(cursor.isAfterLast());
         }
-
-        assertTrue(cursor.isAfterLast());
-
-        cursor.close();
     }
 
     @Test

--- a/app/src/test/java/protect/card_locker/TestHelpers.java
+++ b/app/src/test/java/protect/card_locker/TestHelpers.java
@@ -21,27 +21,28 @@ public class TestHelpers {
         SQLiteDatabase database = db.getWritableDatabase();
 
         // Make sure no files remain
-        Cursor cursor = DBHelper.getLoyaltyCardCursor(database);
-        cursor.moveToFirst();
-        while (!cursor.isAfterLast()) {
-            int cardID = cursor.getColumnIndex(DBHelper.LoyaltyCardDbIds.ID);
+        try(Cursor cursor = DBHelper.getLoyaltyCardCursor(database)){
+            cursor.moveToFirst();
+            while (!cursor.isAfterLast()) {
+                int cardID = cursor.getColumnIndex(DBHelper.LoyaltyCardDbIds.ID);
 
-            for (ImageLocationType imageLocationType : ImageLocationType.values()) {
-                try {
-                    Utils.saveCardImage(context.getApplicationContext(), null, cardID, imageLocationType);
-                } catch (FileNotFoundException ignored) {
+                for (ImageLocationType imageLocationType : ImageLocationType.values()) {
+                    try {
+                        Utils.saveCardImage(context.getApplicationContext(), null, cardID, imageLocationType);
+                    } catch (FileNotFoundException ignored) {
+                    }
                 }
+
+                cursor.moveToNext();
             }
 
-            cursor.moveToNext();
+            // Make sure DB is empty
+            database.execSQL("delete from " + DBHelper.LoyaltyCardDbIds.TABLE);
+            database.execSQL("delete from " + DBHelper.LoyaltyCardDbGroups.TABLE);
+            database.execSQL("delete from " + DBHelper.LoyaltyCardDbIdsGroups.TABLE);
+
+            return db;
         }
-
-        // Make sure DB is empty
-        database.execSQL("delete from " + DBHelper.LoyaltyCardDbIds.TABLE);
-        database.execSQL("delete from " + DBHelper.LoyaltyCardDbGroups.TABLE);
-        database.execSQL("delete from " + DBHelper.LoyaltyCardDbIdsGroups.TABLE);
-
-        return db;
     }
 
     /**


### PR DESCRIPTION
Fixes: #99 

All instances of `database.rawQuery()` that involved dynamic arguments have been converted to use the structured `database.query()` builder.

This change eliminates manual SQL string concatenation, which is a common source of bugs and security vulnerabilities. By using parameterized queries (? placeholders), we now fully protect against SQL injection.

Some Cursor objects are now initialized within try-with-resources blocks. This guarantees that every cursor is automatically and correctly closed, even if an exception is thrown during processing. This prevents Cursor leaks, which can lead to app instability and crashes.