### PR TITLE
Issue-2118: Protect app_name

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,11 +33,7 @@ jobs:
         flavor: [Foss, Gplay]
     steps:
       - uses: actions/checkout@v5
-      - name: Fail on bad translations
-        run: if grep -ri "&lt;xliff" app/src/main/res/values*/strings.xml; then echo "Invalidly escaped translations found"; exit 1; fi
       - uses: gradle/actions/wrapper-validation@v5
-      - name: Check app_name consistency
-        run: bash .scripts/check_app_name.sh
       - name: set up OpenJDK 21
         run: |
           sudo apt-get update

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -1,0 +1,34 @@
+name: i18n check
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - staging
+      - trying
+  pull_request:
+    branches:
+      - main
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Fail on bad translations
+        run: if grep -ri "&lt;xliff" app/src/main/res/values*/strings.xml; then echo "Invalidly escaped translations found"; exit 1; fi
+      - name: Check app_name consistency
+        run: bash .scripts/check_app_name.sh

--- a/.scripts/check_app_name.sh
+++ b/.scripts/check_app_name.sh
@@ -12,34 +12,41 @@ NC='\033[0m'    # No Color
 # Vars
 SUCCESS=1
 CANONICAL_TITLE="Catima"
-ALLOWLIST=("ar" "bn" "fa" "fa-IR" "he-IL" "hi" "hi-IN" "kn" "kn-IN" "ml" "mrx" "ta" "ta-IN" "zh-rTW" "zh-TW")
+ALLOWLIST=("ar" "bn" "fa" "fa-IR" "he-IL" "hi" "hi-IN" "kn" "kn-IN" "ml" "mr" "ta" "ta-IN" "zh-rTW" "zh-TW")  # TODO: Link values and fastlane with different codes together
 
 function get_lang() {
-    LANG_DIRNAME=$(dirname $FILE | xargs basename)
+    LANG_DIRNAME=$(dirname "$FILE" | xargs basename)
     LANG=${LANG_DIRNAME#values-}    # Fetch lang name
     LANG=${LANG#values}             # Handle "app/src/main/res/values"
     LANG=${LANG:-en}                # Default to en
 }
 
+# FIXME: This function should use its own variables and return a success/fail status, instead of working on global variables
 function check() {
-    if [[ ${ALLOWLIST[@]} =~ ${LANG} || -z ${APP_NAME} ]]; then
+    # FIXME: This allows inconsistency between values and fastlane if the app name is not Catima
+    # When the app name is not Catima, it should still check if title.txt and strings.xml use the same app name (or start)
+    if echo "${ALLOWLIST[*]}" | grep -w -q "${LANG}" || [[ -z ${APP_NAME} ]]; then
         return 0
+    fi
 
-    elif [[ ! ${APP_NAME} =~ ^${CANONICAL_TITLE} ]]; then
-        if [[ ${FILE} =~ "title.txt" ]]; then
+    if [[ ${FILE} == *"title.txt" ]]; then
+        if [[ ! ${APP_NAME} =~ ^${CANONICAL_TITLE} ]]; then
             echo -e "${RED}Error: ${LIGHTCYAN}title in $FILE ($LANG) is ${RED}'$APP_NAME'${LIGHTCYAN}, expected to start with ${GREEN}'$CANONICAL_TITLE'. ${NC}"
-        else
-            echo -e "${RED}Error: ${LIGHTCYAN}app_name in $FILE ($LANG) is ${RED}'$APP_NAME'${LIGHTCYAN}, expected ${GREEN}'$CANONICAL_TITLE'. ${NC}"
+            SUCCESS=0
         fi
-
-        SUCCESS=0
+    else
+        if [[ ${APP_NAME} != "${CANONICAL_TITLE}" ]]; then
+            echo -e "${RED}Error: ${LIGHTCYAN}app_name in $FILE ($LANG) is ${RED}'$APP_NAME'${LIGHTCYAN}, expected ${GREEN}'$CANONICAL_TITLE'. ${NC}"
+            SUCCESS=0
+        fi
     fi
 }
 
+# FIXME: This checks all title.txt and strings.xml files separately, but it needs to check if the title.txt and strings.xml match for a language as well
 echo -e "${LIGHTCYAN}Checking title.txt's. ${NC}"
 
-find fastlane/metadata/android/* -maxdepth 1 -type f -name "title.txt" | while read FILE; do
-    APP_NAME=$(head -n 1 $FILE)
+find fastlane/metadata/android/* -maxdepth 1 -type f -name "title.txt" | while read -r FILE; do
+    APP_NAME=$(head -n 1 "$FILE")
 
     get_lang
     check
@@ -47,7 +54,9 @@ done
 
 echo -e "${LIGHTCYAN}Checking string.xml's. ${NC}"
 
-find app/src/main/res/values* -maxdepth 1 -type f -name "strings.xml" | while read FILE; do
+find app/src/main/res/values* -maxdepth 1 -type f -name "strings.xml" | while read -r FILE; do
+    # FIXME: This only checks app_name, but there are more strings with Catima inside it
+    # It should check the original English text for all strings that contain Catima and ensure they use the correct app_name for consistency
     APP_NAME=$(grep -oP '<string name="app_name">\K[^<]+' "$FILE" | head -n1)
 
     get_lang


### PR DESCRIPTION
This PR fixes the issue in `check_app_name.sh` based on the work done in  #2645.
Issue - 
- `find | while` runs on subshell due to which changes made to `success` var don't reflect in current shell.

Related Issue -
- #2118