### PR TITLE
Swap currency and balance fields to reduce chance of accidental conversions

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -123,8 +123,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
     ChipGroup groupsChips;
     AutoCompleteTextView validFromField;
     AutoCompleteTextView expiryField;
-    EditText balanceField;
     AutoCompleteTextView balanceCurrencyField;
+    EditText balanceField;
     TextView cardIdFieldView;
     AutoCompleteTextView barcodeIdField;
     AutoCompleteTextView barcodeTypeField;
@@ -148,9 +148,9 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
     boolean onRestoring = false;
     AlertDialog confirmExitDialog = null;
 
-    boolean validBalance = true;
     HashMap<String, Currency> currencies = new HashMap<>();
     HashMap<String, String> currencySymbols = new HashMap<>();
+    boolean validBalance = true;
 
     ActivityResultLauncher<Uri> mPhotoTakerLauncher;
     ActivityResultLauncher<Intent> mPhotoPickerLauncher;
@@ -193,14 +193,14 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         viewModel.setHasChanged(true);
     }
 
-    protected void setLoyaltyCardBalance(@NonNull BigDecimal balance) {
-        viewModel.getLoyaltyCard().setBalance(balance);
+    protected void setLoyaltyCardBalanceType(@Nullable Currency balanceType) {
+        viewModel.getLoyaltyCard().setBalanceType(balanceType);
 
         viewModel.setHasChanged(true);
     }
 
-    protected void setLoyaltyCardBalanceType(@Nullable Currency balanceType) {
-        viewModel.getLoyaltyCard().setBalanceType(balanceType);
+    protected void setLoyaltyCardBalance(@NonNull BigDecimal balance) {
+        viewModel.getLoyaltyCard().setBalance(balance);
 
         viewModel.setHasChanged(true);
     }
@@ -329,8 +329,8 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         groupsChips = binding.groupChips;
         validFromField = binding.validFromField;
         expiryField = binding.expiryField;
-        balanceField = binding.balanceField;
         balanceCurrencyField = binding.balanceCurrencyField;
+        balanceField = binding.balanceField;
         cardIdFieldView = binding.cardIdView;
         barcodeIdField = binding.barcodeIdField;
         barcodeTypeField = binding.barcodeTypeField;
@@ -372,33 +372,6 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
         addDateFieldTextChangedListener(expiryField, R.string.never, R.string.chooseExpiryDate, LoyaltyCardField.expiry);
 
         setMaterialDatePickerResultListener();
-
-        balanceField.setOnFocusChangeListener((v, hasFocus) -> {
-            if (!hasFocus && !onResuming && !onRestoring) {
-                if (balanceField.getText().toString().isEmpty()) {
-                    setLoyaltyCardBalance(BigDecimal.valueOf(0));
-                }
-
-                balanceField.setText(Utils.formatBalanceWithoutCurrencySymbol(viewModel.getLoyaltyCard().balance, viewModel.getLoyaltyCard().balanceType));
-            }
-        });
-
-        balanceField.addTextChangedListener(new SimpleTextWatcher() {
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                if (onResuming || onRestoring) return;
-                try {
-                    BigDecimal balance = Utils.parseBalance(s.toString(), viewModel.getLoyaltyCard().balanceType);
-                    setLoyaltyCardBalance(balance);
-                    balanceField.setError(null);
-                    validBalance = true;
-                } catch (ParseException e) {
-                    e.printStackTrace();
-                    balanceField.setError(getString(R.string.balanceParsingFailed));
-                    validBalance = false;
-                }
-            }
-        });
 
         balanceCurrencyField.addTextChangedListener(new SimpleTextWatcher() {
             @Override
@@ -449,6 +422,33 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                 currencyList.add(0, getString(R.string.points));
                 ArrayAdapter<String> currencyAdapter = new ArrayAdapter<>(LoyaltyCardEditActivity.this, android.R.layout.select_dialog_item, currencyList);
                 balanceCurrencyField.setAdapter(currencyAdapter);
+            }
+        });
+
+        balanceField.setOnFocusChangeListener((v, hasFocus) -> {
+            if (!hasFocus && !onResuming && !onRestoring) {
+                if (balanceField.getText().toString().isEmpty()) {
+                    setLoyaltyCardBalance(BigDecimal.valueOf(0));
+                }
+
+                balanceField.setText(Utils.formatBalanceWithoutCurrencySymbol(viewModel.getLoyaltyCard().balance, viewModel.getLoyaltyCard().balanceType));
+            }
+        });
+
+        balanceField.addTextChangedListener(new SimpleTextWatcher() {
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (onResuming || onRestoring) return;
+                try {
+                    BigDecimal balance = Utils.parseBalance(s.toString(), viewModel.getLoyaltyCard().balanceType);
+                    setLoyaltyCardBalance(balance);
+                    balanceField.setError(null);
+                    validBalance = true;
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    balanceField.setError(getString(R.string.balanceParsingFailed));
+                    validBalance = false;
+                }
             }
         });
 

--- a/app/src/main/res/layout/loyalty_card_edit_activity.xml
+++ b/app/src/main/res/layout/loyalty_card_edit_activity.xml
@@ -276,6 +276,24 @@
                     android:paddingTop="@dimen/inputPadding"
                     android:orientation="horizontal">
 
+                    <!-- Currency -->
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/balanceCurrencyView"
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1.0"
+                        android:hint="@string/currency"
+                        android:labelFor="@+id/balanceCurrencyField">
+
+                        <AutoCompleteTextView
+                            android:id="@+id/balanceCurrencyField"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="none"/>
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
                     <!-- Balance -->
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/balanceView"
@@ -292,24 +310,6 @@
                             android:layout_height="wrap_content"
                             android:inputType="numberDecimal"
                             android:digits="0123456789,." />
-
-                    </com.google.android.material.textfield.TextInputLayout>
-
-                    <!-- Currency -->
-                    <com.google.android.material.textfield.TextInputLayout
-                        android:id="@+id/balanceCurrencyView"
-                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1.0"
-                        android:hint="@string/currency"
-                        android:labelFor="@+id/balanceCurrencyField">
-
-                        <AutoCompleteTextView
-                            android:id="@+id/balanceCurrencyField"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:inputType="none"/>
 
                     </com.google.android.material.textfield.TextInputLayout>
                 </LinearLayout>


### PR DESCRIPTION
This swaps the currency and balance fields to reduce the risk of users entering a decimal value (1,23) first and having to changed to 1 due to the default currency (Points) having no decimals.

The changes in the LoyaltyCardEditActivity are purely cosmetic, just a swap of function order to more closely stick to the order in the XML layout file

| Before | After |
| - | - |
| <img width="575" height="1280" alt="image" src="https://github.com/user-attachments/assets/dbe8f5b6-0cd5-477a-845a-7bd9c67b8d09" /> | <img width="575" height="1280" alt="image" src="https://github.com/user-attachments/assets/692cf278-1163-4685-95f5-cc2a8c943f3b" /> |

Fixes #2847