### PR TITLE
Change Gradle Dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
 # Workaround for https://github.com/dependabot/dependabot-core/issues/6888
 registries:


### PR DESCRIPTION
This PR adds a 7-day dependency cooldown to the Gradle package ecosystem in Dependabot.

- Prevents Dependabot from opening PRs for library updates until the version is at least 7 days old.
- GitHub Actions updates remain weekly; cooldown is only applied to Gradle dependencies.

Original issue: #2853 