### PR TITLE
Fix list widget opening on previous card sometimes

### DIFF
--- a/app/src/main/java/protect/card_locker/ListWidget.kt
+++ b/app/src/main/java/protect/card_locker/ListWidget.kt
@@ -69,7 +69,9 @@ class ListWidget : AppWidgetProvider() {
             if (hasCards) {
                 // If we have cards, create the list
                 views = RemoteViews(context.packageName, R.layout.list_widget)
-                val templateIntent = Intent(context, LoyaltyCardViewActivity::class.java)
+                val templateIntent = Intent(context, LoyaltyCardViewActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
                 val pendingIntent = PendingIntent.getActivity(
                     context,
                     0,


### PR DESCRIPTION
Fixes #2945 

I realize again why this was missed: apps behave *subtly* different when ran inside Android studio. Only when first stopping the debug app in Android Studio can this behaviour be reproduced.