### PR TITLE
Expose barcode encoding in content provider

### DIFF
--- a/app/src/main/java/protect/card_locker/contentprovider/CardsContentProvider.java
+++ b/app/src/main/java/protect/card_locker/contentprovider/CardsContentProvider.java
@@ -32,7 +32,7 @@ public class CardsContentProvider extends ContentProvider {
         public static final String MAJOR_COLUMN = "major";
         public static final String MINOR_COLUMN = "minor";
         public static final int MAJOR = 1;
-        public static final int MINOR = 0;
+        public static final int MINOR = 1;
     }
 
     private static final int URI_VERSION = 0;
@@ -52,7 +52,7 @@ public class CardsContentProvider extends ContentProvider {
             LoyaltyCardDbIds.CARD_ID,
             LoyaltyCardDbIds.BARCODE_ID,
             LoyaltyCardDbIds.BARCODE_TYPE,
-            // FIXME: Expose BARCODE_ENCODING but without ever exposing the null value (so apps using this don't have to guess)
+            LoyaltyCardDbIds.BARCODE_ENCODING,
             LoyaltyCardDbIds.STAR_STATUS,
             LoyaltyCardDbIds.LAST_USED,
             LoyaltyCardDbIds.ARCHIVE_STATUS,

--- a/app/src/test/java/protect/card_locker/contentprovider/CardsContentProviderTest.java
+++ b/app/src/test/java/protect/card_locker/contentprovider/CardsContentProviderTest.java
@@ -75,7 +75,7 @@ public class CardsContentProviderTest {
             assertArrayEquals("column names", new String[]{"major", "minor"}, cursor.getColumnNames());
             cursor.moveToNext();
             assertEquals("major version", 1, cursor.getInt(cursor.getColumnIndexOrThrow("major")));
-            assertEquals("minor version", 0, cursor.getInt(cursor.getColumnIndexOrThrow("minor")));
+            assertEquals("minor version", 1, cursor.getInt(cursor.getColumnIndexOrThrow("minor")));
         }
     }
 
@@ -114,7 +114,7 @@ public class CardsContentProviderTest {
             final String[] expectedColumns = new String[]{
                     "_id", "store", "validfrom", "expiry", "balance", "balancetype",
                     "note", "headercolor", "cardid", "barcodeid",
-                    "barcodetype", "starstatus", "lastused", "archive"
+                    "barcodetype", "barcodeencoding", "starstatus", "lastused", "archive"
             };
 
             assertEquals("number of columns", expectedColumns.length, cursor.getColumnCount());
@@ -136,6 +136,7 @@ public class CardsContentProviderTest {
             final String actualCardId = cursor.getString(cursor.getColumnIndexOrThrow("cardid"));
             final String actualBarcodeId = cursor.getString(cursor.getColumnIndexOrThrow("barcodeid"));
             final String actualBarcodeType = cursor.getString(cursor.getColumnIndexOrThrow("barcodetype"));
+            final String actualBarcodeEncoding = cursor.getString(cursor.getColumnIndexOrThrow("barcodeencoding"));
             final int actualHeaderColor = cursor.getInt(cursor.getColumnIndexOrThrow("headercolor"));
             final int actualStarred = cursor.getInt(cursor.getColumnIndexOrThrow("starstatus"));
             final long actualLastUsed = cursor.getLong(cursor.getColumnIndexOrThrow("lastused"));
@@ -151,6 +152,7 @@ public class CardsContentProviderTest {
             assertEquals("CardId", cardId, actualCardId);
             assertEquals("BarcodeId", barcodeId, actualBarcodeId);
             assertEquals("BarcodeType", barcodeType.format().name(), actualBarcodeType);
+            assertEquals("barcodeEncoding", barcodeEncoding.name(), actualBarcodeEncoding);
             assertEquals("HeaderColorColumn", headerColor, actualHeaderColor);
             assertEquals("Starred", starStatus, actualStarred);
             assertEquals("LastUsed", lastUsed, actualLastUsed);

--- a/docs/CONTENT_PROVIDER.md
+++ b/docs/CONTENT_PROVIDER.md
@@ -37,26 +37,27 @@ A major version change implies breaking changes (eg. columns being renamed or re
 | Column  | Type  | Description       | Value |
 |---------|-------|-------------------|-------|
 | `major` | `int` | The major version | `1`   |
-| `minor` | `int` | The minor version | `0`   |
+| `minor` | `int` | The minor version | `1`   |
 
 ### /cards
 
-| Column        | Type     | Description                |
-|---------------|----------|----------------------------|
-| `_id`         | `int`    | Unique card ID |
-| `store`       | `String` | Card name |
-| `validfrom`   | `long`   | Timestamp from which the card is valid (unix epoch millis). |
-| `expiry`      | `long`   | Expiration timestamp (unix epoch millis). |
-| `balance`     | `String` | Current balance, as a string-formatted big decimal. |
-| `balancetype` | `String` | Balance currency code, ISO 4217. |
-| `note`        | `String` | A note. |
-| `headercolor` | `int`    | Header color, in RGBA. |
-| `cardid`      | `String` | Card ID. |
-| `barcodeid`   | `String` | Barcode value. If empty, it's the same as the card ID. |
-| `barcodetype` | `String` | The barcode type name, matching [com.google.zxing.BarcodeFormat](https://zxing.github.io/zxing/apidocs/com/google/zxing/BarcodeFormat.html). |
-| `starstatus`  | `int`    | 1 if starred, 0 if not |
-| `lastused`    | `long`   | Timestamp of last card usage (unix epoch millis). |
-| `archive`     | `int`    | 1 if archived, 0 if not |
+| Column            | Type     | Description                |
+|-------------------|----------|----------------------------|
+| `_id`             | `int`    | Unique card ID |
+| `store`           | `String` | Card name |
+| `validfrom`       | `long`   | Timestamp from which the card is valid (unix epoch millis). |
+| `expiry`          | `long`   | Expiration timestamp (unix epoch millis). |
+| `balance`         | `String` | Current balance, as a string-formatted big decimal. |
+| `balancetype`     | `String` | Balance currency code, ISO 4217. |
+| `note`            | `String` | A note. |
+| `headercolor`     | `int`    | Header color, in RGBA. |
+| `cardid`          | `String` | Card ID. |
+| `barcodeid`       | `String` | Barcode value. If empty, it's the same as the card ID. |
+| `barcodetype`     | `String` | The barcode type name, matching [com.google.zxing.BarcodeFormat](https://zxing.github.io/zxing/apidocs/com/google/zxing/BarcodeFormat.html). |
+| `barcodeencoding` | `String` | The barcode encoding used to render the barcode, matching a [StandardCharset](https://developer.android.com/reference/java/nio/charset/StandardCharsets)'s `.name()` output. Only `ISO-8859-1` and `UTF-8` are user selectable. |
+| `starstatus`      | `int`    | 1 if starred, 0 if not |
+| `lastused`        | `long`   | Timestamp of last card usage (unix epoch millis). |
+| `archive`         | `int`    | 1 if archived, 0 if not |
 
 ### /groups
 


### PR DESCRIPTION
This will allow Gadgetbridge to know the barcode encoding is used, allowing for watches to correctly show UTF-8 barcodes

Fixes #2890 