### PR TITLE
Autolink in card ID dialog

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -406,7 +406,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
                 dialogContentPadding,
                 0
         );
-        infoTextview.setAutoLinkMask(Linkify.ALL);
+        infoTextview.setAutoLinkMask(Linkify.EMAIL_ADDRESSES | Linkify.PHONE_NUMBERS | Linkify.WEB_URLS);
         infoTextview.setTextIsSelectable(true);
 
         SpannableStringBuilder infoText = new SpannableStringBuilder();


### PR DESCRIPTION
Fixes #2969

Also migrates the info dialog away from deprecated Linkify.ALL which may even cause a crash in the worst case: https://developer.android.com/reference/android/text/util/Linkify#ALL