### PR TITLE
fix: BarcodeSelectorAdapter properly fills adapter with barcode images instead of passing in null 

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeSelectorAdapter.java
+++ b/app/src/main/java/protect/card_locker/BarcodeSelectorAdapter.java
@@ -75,6 +75,9 @@ public class BarcodeSelectorAdapter extends ArrayAdapter<CatimaBarcodeWithValue>
         return viewHolder.image.getTag() != null && (boolean) viewHolder.image.getTag();
     }
 
+    // FIXME: The examples in the selector activity are always rendering using ISO-8859-1, even if UTF-8 is the selected type
+    // This needs some refactoring to properly retrieve the barcode encoding when rendering an active barcode
+    // This is the case for example when editing an active card, pressing the "Edit barcode" button, then "More options" and then "Enter the barcode manually"
     private void createBarcodeOption(final ImageView image, final String formatType, final String cardId, final TextView text) {
         final CatimaBarcode format = CatimaBarcode.fromName(formatType);
 


### PR DESCRIPTION
The flow from click add FAB in MainActivity -> Click More options -> Enter the barcode manually does not connect the barcode data to the adapters in the list and they all display blank white. After my changes, blank white is still displayed only when the user hasn't yet entered any barcode text.

This bug was introduced in commit 0c61abf4f06f391d138544eee77ec79b3736ac34 on September 27, 2025.


The project tests and linters were run and I tested to verify incorrect behaviour before these changes and correct behavior afterwards on a Pixel 7.