### PR TITLE
Add option to pause NFC while viewing a card

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,12 @@
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="23" />
 
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -10,6 +10,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
@@ -675,6 +676,20 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             }
 
             window.setAttributes(attributes);
+        }
+
+        // Pause NFC to prevent interference with barcode scanners
+        if (settings.getDisableNfcWhileViewingCard()) {
+            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(this);
+            if (nfcAdapter != null) {
+                nfcAdapter.enableReaderMode(this, tag -> {
+                    // Intentionally empty: pause all NFC tag discoveries
+                }, NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_NFC_B
+                        | NfcAdapter.FLAG_READER_NFC_F | NfcAdapter.FLAG_READER_NFC_V
+                        | NfcAdapter.FLAG_READER_NFC_BARCODE
+                        | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+                        | NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS, null);
+            }
         }
 
         loyaltyCard = DBHelper.getLoyaltyCard(this, database, loyaltyCardId);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -680,7 +680,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             window.setAttributes(attributes);
         }
 
-        // Pause NFC to prevent interference with barcode scanners
+        // Pause NFC to prevent NFC payments from triggering while showing a barcode
         if (settings.getDisableNfcWhileViewingCard()) {
             NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(this);
             if (nfcAdapter != null) {

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -54,6 +54,7 @@ import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.zxing.BarcodeFormat;
 
@@ -72,6 +73,7 @@ import java.util.function.Predicate;
 import protect.card_locker.async.TaskHandler;
 import protect.card_locker.databinding.LoyaltyCardViewLayoutBinding;
 import protect.card_locker.preferences.Settings;
+import protect.card_locker.preferences.SettingsActivity;
 
 public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements BarcodeImageWriterResultCallback {
     private LoyaltyCardViewLayoutBinding binding;
@@ -683,7 +685,14 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(this);
             if (nfcAdapter != null) {
                 nfcAdapter.enableReaderMode(this, tag -> {
-                    // Intentionally empty: pause all NFC tag discoveries
+                    Snackbar snackbar = Snackbar.make(binding.container, R.string.nfc_blocked_while_viewing_card, Snackbar.LENGTH_LONG)
+                        .setAnchorView(binding.fabEdit)
+                        .setAction(R.string.change_settings, view -> {
+                            // Open settings activity
+                            Intent intent = new Intent(getApplicationContext(), SettingsActivity.class);
+                            startActivity(intent);
+                        });
+                        snackbar.show();
                 }, NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_NFC_B
                         | NfcAdapter.FLAG_READER_NFC_F | NfcAdapter.FLAG_READER_NFC_V
                         | NfcAdapter.FLAG_READER_NFC_BARCODE

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -82,6 +82,10 @@ public class Settings {
         return getBoolean(R.string.settings_key_disable_lockscreen_while_viewing_card, true);
     }
 
+    public boolean getDisableNfcWhileViewingCard() {
+        return getBoolean(R.string.settings_key_disable_nfc_while_viewing_card, false);
+    }
+
     public boolean getAllowContentProviderRead() {
         return getBoolean(R.string.settings_key_allow_content_provider_read, true);
     }

--- a/app/src/main/java/protect/card_locker/preferences/Settings.java
+++ b/app/src/main/java/protect/card_locker/preferences/Settings.java
@@ -83,7 +83,7 @@ public class Settings {
     }
 
     public boolean getDisableNfcWhileViewingCard() {
-        return getBoolean(R.string.settings_key_disable_nfc_while_viewing_card, false);
+        return getBoolean(R.string.settings_key_disable_nfc_while_viewing_card, true);
     }
 
     public boolean getAllowContentProviderRead() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,9 @@
     <string name="settings_key_keep_screen_on" translatable="false">pref_keep_screen_on</string>
     <string name="settings_disable_lockscreen_while_viewing_card">Prevent screen lock</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Disables screen lock while viewing a card</string>
+    <string name="settings_disable_nfc_while_viewing_card">Pause NFC</string>
+    <string name="settings_disable_nfc_while_viewing_card_summary">Pauses NFC to prevent interference with scanners while viewing a card</string>
+    <string name="settings_key_disable_nfc_while_viewing_card" translatable="false">pref_disable_nfc_while_viewing_card</string>
     <string name="settings_allow_content_provider_read_title">Allow other apps to access my data</string>
     <string name="settings_allow_content_provider_read_summary">Apps will still have to request permission to be granted access</string>
     <string name="settings_key_disable_lockscreen_while_viewing_card" translatable="false">pref_disable_lockscreen_while_viewing_card</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,4 +348,6 @@
     <string name="nothing_to_copy">No value found</string>
     <string name="barcodeEncoding">Barcode encoding</string>
     <string name="back">Back</string>
+    <string name="nfc_blocked_while_viewing_card">NFC is paused</string>
+    <string name="change_settings">Change settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="settings_disable_lockscreen_while_viewing_card">Prevent screen lock</string>
     <string name="settings_disable_lockscreen_while_viewing_card_summary">Disables screen lock while viewing a card</string>
     <string name="settings_disable_nfc_while_viewing_card">Pause NFC</string>
-    <string name="settings_disable_nfc_while_viewing_card_summary">Pauses NFC to prevent interference with scanners while viewing a card</string>
+    <string name="settings_disable_nfc_while_viewing_card_summary">Pauses NFC to prevent NFC payments from triggering while viewing a card</string>
     <string name="settings_key_disable_nfc_while_viewing_card" translatable="false">pref_disable_nfc_while_viewing_card</string>
     <string name="settings_allow_content_provider_read_title">Allow other apps to access my data</string>
     <string name="settings_allow_content_provider_read_summary">Apps will still have to request permission to be granted access</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -109,6 +109,15 @@
             android:title="@string/settings_disable_lockscreen_while_viewing_card"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
+
+        <SwitchPreferenceCompat
+            android:widgetLayout="@layout/preference_material_switch"
+            android:defaultValue="false"
+            android:key="@string/settings_key_disable_nfc_while_viewing_card"
+            android:summary="@string/settings_disable_nfc_while_viewing_card_summary"
+            android:title="@string/settings_disable_nfc_while_viewing_card"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -112,7 +112,7 @@
 
         <SwitchPreferenceCompat
             android:widgetLayout="@layout/preference_material_switch"
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="@string/settings_key_disable_nfc_while_viewing_card"
             android:summary="@string/settings_disable_nfc_while_viewing_card_summary"
             android:title="@string/settings_disable_nfc_while_viewing_card"


### PR DESCRIPTION
⚠️ This solution has been coded with the help of LLM and NOT tested on a real device. Exactly what is discouraged in https://github.com/CatimaLoyalty/Android/blob/main/CONTRIBUTING.md

❌  Therefore, the pull request can simply be declined without further discussion or put on hold until someone is capable of thoroughly testing it – no one will complain 🙂

 😇 I couldn't resist experimenting with vibecoding to try fixing an issue that’s been bugging me, and that has been raised by others in the past (see #2158)

### Problem
When displaying a loyalty card barcode, nearby NFC readers can interfere with barcode readers resulting in failed read – or accidental payments as described in #2158

### Solution
Added an optional "Pause NFC" setting that temporarily suppresses NFC tag dispatch while viewing a card.
It uses NfcAdapter.enableReaderMode() with a no-op callback to intercept all NFC technologies (A, B, F, V, Barcode) without processing them. NFC behavior automatically restores when the card view is exited.
The code added to LoyaltyCardViewActivity.onResume() was "stolen" from https://stackoverflow.com/questions/78570610/disable-programmatically-nfc-while-my-app-is-open

### Implementation

- Added android.permission.NFC permission and feature declaration
- Added "Pause NFC" toggle in Settings > Card view (default: off)
- Modified LoyaltyCardViewActivity.onResume() to enable reader mode when setting is active