### PR TITLE
Add timestamp to export filename

### DIFF
--- a/app/src/main/java/protect/card_locker/ImportExportActivity.kt
+++ b/app/src/main/java/protect/card_locker/ImportExportActivity.kt
@@ -27,6 +27,9 @@ import protect.card_locker.importexport.ImportExportResultType
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class ImportExportActivity : CatimaAppCompatActivity() {
     private lateinit var binding: ImportExportActivityBinding
@@ -45,6 +48,11 @@ class ImportExportActivity : CatimaAppCompatActivity() {
 
     companion object {
         private const val TAG = "Catima"
+
+        internal fun getExportFilename(): String {
+            val sdf = SimpleDateFormat("yyyyMMdd", Locale.US)
+            return "catima_${sdf.format(Date())}.zip"
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -107,7 +115,7 @@ class ImportExportActivity : CatimaAppCompatActivity() {
         val intentCreateDocumentAction = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
             type = "application/zip"
-            putExtra(Intent.EXTRA_TITLE, "catima.zip")
+            putExtra(Intent.EXTRA_TITLE, getExportFilename())
         }
 
         val exportButton: Button = binding.exportButton

--- a/app/src/test/java/protect/card_locker/ImportExportActivityTest.kt
+++ b/app/src/test/java/protect/card_locker/ImportExportActivityTest.kt
@@ -7,6 +7,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.ResolveInfo
 import android.view.View
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -59,6 +60,12 @@ class ImportExportActivityTest {
         assertEquals(state, titleView.visibility)
         assertEquals(state, messageView.visibility)
         assertEquals(state, buttonView.visibility)
+    }
+
+    @Test
+    fun testExportFilenameHasTimestamp() {
+        val filename = ImportExportActivity.getExportFilename()
+        assertTrue(filename.matches(Regex("catima_\\d{8}\\.zip")))
     }
 
     @Test


### PR DESCRIPTION
Fixes #3086

Export files now get timestamped names. Generates catima_YYYYMMDD.zip instead of the hardcoded version, with a test to verify the format.