### PR TITLE
Open a card from the lockscreen widget without unlock

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,7 +96,8 @@
         <activity
             android:name=".LoyaltyCardViewActivity"
             android:exported="true"
-            android:theme="@style/AppTheme.NoActionBar" />
+            android:theme="@style/AppTheme.NoActionBar"
+            android:showWhenLocked="true" />
         <activity
             android:name=".LoyaltyCardEditActivity"
             android:exported="true"

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -1,6 +1,5 @@
 package protect.card_locker;
 
-import android.app.KeyguardManager;
 import android.content.ActivityNotFoundException;
 import android.content.ClipData;
 import android.content.ClipboardManager;

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -1286,9 +1286,4 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         Toast.makeText(this, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show();
     }
-
-    private boolean isLockScreenShowing() {
-        KeyguardManager km = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
-        return km.isKeyguardLocked();
-    }
 }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -671,12 +671,8 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1) {
                     showWhenLockedSdkLessThan27(window);
                 }
-            } else if (isLockScreenShowing()) {
-                Log.d(TAG, "Finish activity due to disabled lock screen viewing");
-                // If the user disabled lock screen viewing and lock the device with this activity open
-                // this will finish it and the user will go to the previous activity in the stack or none
-                // Unfortunately we don't have a better way to handle this yet
-                finish();
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                setShowWhenLocked(false);
             }
 
             window.setAttributes(attributes);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -1,5 +1,6 @@
 package protect.card_locker;
 
+import android.app.KeyguardManager;
 import android.content.ActivityNotFoundException;
 import android.content.ClipData;
 import android.content.ClipboardManager;
@@ -667,11 +668,15 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             }
 
             if (settings.getDisableLockscreenWhileViewingCard()) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-                    setShowWhenLocked(true);
-                } else {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1) {
                     showWhenLockedSdkLessThan27(window);
                 }
+            } else if (isLockScreenShowing()) {
+                Log.d(TAG, "Finish activity due to disabled lock screen viewing");
+                // If the user disabled lock screen viewing and lock the device with this activity open
+                // this will finish it and the user will go to the previous activity in the stack or none
+                // Unfortunately we don't have a better way to handle this yet
+                finish();
             }
 
             window.setAttributes(attributes);
@@ -1284,5 +1289,10 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         cm.setPrimaryClip(clip);
 
         Toast.makeText(this, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show();
+    }
+
+    private boolean isLockScreenShowing() {
+        KeyguardManager km = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
+        return km.isKeyguardLocked();
     }
 }


### PR DESCRIPTION
To open the activity over the lockscreen we can't use the `setShowWhenLocked(true)`, we need to define the activity manifest as `showWhenLocked=true`, as stated in the Android Developers [FAQ](https://android-developers.googleblog.com/2025/03/widgets-on-lock-screen-faq.html). 

This PR adds the manifest configuration needed to open the activity and disable/hide the activity if the user chose `DisableLockscreenWhileViewingCard` setting

In the first commit I was finishing the activity if `DisableLockscreenWhileViewingCard` was off and the lockscreen was up, but I figured out that we can just call `showWhenLocked(false)` and the activity is sent to behind the lockscreen again.

Notes:
- I tested this in my device and it works without glitches or activities jumping around.
- I didn't use any llm, bot, code agent or something like that, for this or anything in my life.
- Only the test `startWithLoyaltyCardNoExpirySetExpiry` is failing for me, it says it expected April 22 but receives April 21, I don't know why but maybe it 's something with my timezone?


Fixes #2916 