### PR TITLE
Revert "Remove unneeded NFC permission"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,12 @@
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="23" />
 
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />


### PR DESCRIPTION
Reverts CatimaLoyalty/Android#3095

LoyaltyCardViewActivity started crashing:
```
java.lang.SecurityException: NFC permission required
```

Turns out it was necessary after all despite none of the documentation stating so.