### PR TITLE
Java fixes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,7 @@ permissions:
   security-events: none
   statuses: none
 env:
-  JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
+  JAVA_HOME: /usr/lib/jvm/java-25-openjdk-amd64
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -34,10 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: gradle/actions/wrapper-validation@v5
-      - name: set up OpenJDK 21
+      - name: set up OpenJDK 25
         run: |
           sudo apt-get update
-          sudo apt-get install -y openjdk-21-jdk-headless
+          sudo apt-get install -y openjdk-25-jdk-headless
           sudo update-alternatives --auto java
       - name: Build
         run: ./gradlew assemble${{ matrix.flavor }}Release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,7 +98,7 @@ android {
 
     kotlin {
         compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
+            jvmTarget = JvmTarget.JVM_21
         }
     }
     compileOptions {
@@ -107,8 +107,8 @@ android {
         // Flag to enable support for the new language APIs
         isCoreLibraryDesugaringEnabled = true
 
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }
 

--- a/build.sh
+++ b/build.sh
@@ -11,13 +11,13 @@ if [ -z "${ANDROID_HOME:-}" ]; then
 fi
 
 if [ -z "${JAVA_HOME:-}" ]; then
-  echo "JAVA_HOME is not set, setting to Java 21"
+  echo "JAVA_HOME is not set, setting to Java 25"
   if [ -f "/etc/debian_version" ]; then
-    echo "Debian-based distro, Java 21 is /usr/lib/jvm/java-21-openjdk-amd64"
-    export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+    echo "Debian-based distro, Java 25 is /usr/lib/jvm/java-25-openjdk-amd64"
+    export JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64
   else
-    echo "Not Debian-based, assuming Fedora and setting Java 21 as /usr/lib/jvm/java-21-openjdk"
-    export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+    echo "Not Debian-based, assuming Fedora and setting Java 25 as /usr/lib/jvm/java-25-openjdk"
+    export JAVA_HOME=/usr/lib/jvm/java-25-openjdk
   fi
 fi
 


### PR DESCRIPTION
Use 25 in build.sh (Fedora 44 doesn't ship with 21 anymore) and target 21 consistently (Android Studio doesn't support 25 yet)