### PR TITLE
Re-enabling Catalan, since it is more than 29% translated.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled = true
 
-        resourceConfigurations += listOf("ar", "be", "bg", "bn", "bn-rIN", "bs", "cs", "da", "de", "el-rGR", "en", "eo", "es", "es-rAR", "et", "fa", "fi", "fr", "gl", "he-rIL", "hi", "hr", "hu", "in-rID", "is", "it", "ja", "ko", "lt", "lv", "nb-rNO", "nl", "oc", "peo", "pl", "pt", "pt-rBR", "pt-rPT", "ro-rRO", "ru", "sk", "sl", "sr", "sv", "ta", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
+        resourceConfigurations += listOf("ar", "be", "bg", "bn", "bn-rIN", "bs", "ca", "cs", "da", "de", "el-rGR", "en", "eo", "es", "es-rAR", "et", "fa", "fi", "fr", "gl", "he-rIL", "hi", "hr", "hu", "in-rID", "is", "it", "ja", "ko", "lt", "lv", "nb-rNO", "nl", "oc", "peo", "pl", "pt", "pt-rBR", "pt-rPT", "ro-rRO", "ru", "sk", "sl", "sr", "sv", "ta", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -61,7 +61,7 @@
         <item>bn</item>
         <item>bn-rIN</item>
         <item>bs</item>
-        <!-- <item>ca</item> -->
+        <item>ca</item>
         <item>cs</item>
         <!-- <item>cy</item> -->
         <item>da</item>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -7,6 +7,7 @@
     <locale android:name="bn" />
     <locale android:name="bn-IN" />
     <locale android:name="bs" />
+    <locale android:name="ca" />
     <locale android:name="cs" />
     <locale android:name="da" />
     <locale android:name="de" />


### PR DESCRIPTION
Hi,

Catalan was disabled years ago in commit 1367e29bd48e4eb4341183135c1ebd8ba91b9481 as it was at less than 29% translated,
in October last year there was a person(@mrestivill) who updated the translation in c702efbd1e071cd19dc87a349878b5c0000b030a now it is more than 80% translated.

HTH
Pere

Note: I can't currently compile Catima, so I haven't tested myself if it works.