### PR TITLE
Add option to display card ID in card list

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -105,6 +105,12 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
             inputHolder.setNoteField(null);
         }
 
+        if (mLoyaltyCardListDisplayOptions.showingCardId() && !loyaltyCard.cardId.isEmpty()) {
+            inputHolder.setExtraField(inputHolder.mCardIdField, loyaltyCard.cardId, null, showDivider);
+        } else {
+            inputHolder.setExtraField(inputHolder.mCardIdField, null, null, false);
+        }
+
         if (mLoyaltyCardListDisplayOptions.showingBalance() && !loyaltyCard.balance.equals(new BigDecimal("0"))) {
             inputHolder.setExtraField(inputHolder.mBalanceField, Utils.formatBalance(mContext, loyaltyCard.balance, loyaltyCard.balanceType), null, showDivider);
         } else {
@@ -121,12 +127,6 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
             inputHolder.setExtraField(inputHolder.mExpiryField, DateFormat.getDateInstance(DateFormat.MEDIUM).format(loyaltyCard.expiry), Utils.hasExpired(loyaltyCard.expiry) ? Color.RED : null, showDivider);
         } else {
             inputHolder.setExtraField(inputHolder.mExpiryField, null, null, false);
-        }
-
-        if (mLoyaltyCardListDisplayOptions.showingCardId() && !loyaltyCard.cardId.isEmpty()) {
-            inputHolder.setExtraField(inputHolder.mCardIdField, loyaltyCard.cardId, null, showDivider);
-        } else {
-            inputHolder.setExtraField(inputHolder.mCardIdField, null, null, false);
         }
 
         inputHolder.mCardIcon.setContentDescription(loyaltyCard.store);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -217,7 +217,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
 
     public class LoyaltyCardListItemViewHolder extends RecyclerView.ViewHolder {
 
-        public TextView mCardText, mStoreField, mNoteField, mBalanceField, mValidFromField, mExpiryField, mCardIdField;
+        public TextView mCardText, mStoreField, mNoteField, mCardIdField, mBalanceField, mValidFromField, mExpiryField;
         public ImageView mCardIcon, mTickIcon;
         public MaterialCardView mRow;
         public ConstraintLayout mStar, mArchived;
@@ -230,10 +230,10 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
             mDivider = loyaltyCardLayoutBinding.infoDivider;
             mStoreField = loyaltyCardLayoutBinding.store;
             mNoteField = loyaltyCardLayoutBinding.note;
+            mCardIdField = loyaltyCardLayoutBinding.cardId;
             mBalanceField = loyaltyCardLayoutBinding.balance;
             mValidFromField = loyaltyCardLayoutBinding.validFrom;
             mExpiryField = loyaltyCardLayoutBinding.expiry;
-            mCardIdField = loyaltyCardLayoutBinding.cardId;
             mCardIcon = loyaltyCardLayoutBinding.thumbnail;
             mCardText = loyaltyCardLayoutBinding.thumbnailText;
             mStar = loyaltyCardLayoutBinding.star;

--- a/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardCursorAdapter.java
@@ -123,6 +123,12 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
             inputHolder.setExtraField(inputHolder.mExpiryField, null, null, false);
         }
 
+        if (mLoyaltyCardListDisplayOptions.showingCardId() && !loyaltyCard.cardId.isEmpty()) {
+            inputHolder.setExtraField(inputHolder.mCardIdField, loyaltyCard.cardId, null, showDivider);
+        } else {
+            inputHolder.setExtraField(inputHolder.mCardIdField, null, null, false);
+        }
+
         inputHolder.mCardIcon.setContentDescription(loyaltyCard.store);
         Utils.setIconOrTextWithBackground(mContext, loyaltyCard, icon, inputHolder.mCardIcon, inputHolder.mCardText, new Settings(mContext).getPreferredColumnCount());
 
@@ -211,7 +217,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
 
     public class LoyaltyCardListItemViewHolder extends RecyclerView.ViewHolder {
 
-        public TextView mCardText, mStoreField, mNoteField, mBalanceField, mValidFromField, mExpiryField;
+        public TextView mCardText, mStoreField, mNoteField, mBalanceField, mValidFromField, mExpiryField, mCardIdField;
         public ImageView mCardIcon, mTickIcon;
         public MaterialCardView mRow;
         public ConstraintLayout mStar, mArchived;
@@ -227,6 +233,7 @@ public class LoyaltyCardCursorAdapter extends BaseCursorAdapter<LoyaltyCardCurso
             mBalanceField = loyaltyCardLayoutBinding.balance;
             mValidFromField = loyaltyCardLayoutBinding.validFrom;
             mExpiryField = loyaltyCardLayoutBinding.expiry;
+            mCardIdField = loyaltyCardLayoutBinding.cardId;
             mCardIcon = loyaltyCardLayoutBinding.thumbnail;
             mCardText = loyaltyCardLayoutBinding.thumbnailText;
             mStar = loyaltyCardLayoutBinding.star;

--- a/app/src/main/java/protect/card_locker/LoyaltyCardListDisplayOptionsManager.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardListDisplayOptionsManager.java
@@ -37,6 +37,7 @@ public class LoyaltyCardListDisplayOptionsManager {
     private boolean mShowNote;
     private boolean mShowBalance;
     private boolean mShowValidity;
+    private boolean mShowCardId;
     private boolean mShowArchivedCards;
 
     public LoyaltyCardListDisplayOptionsManager(Context context, @NonNull Runnable refreshCardsCallback, @Nullable Runnable swapCursorCallback) {
@@ -52,6 +53,7 @@ public class LoyaltyCardListDisplayOptionsManager {
         mShowNote = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_note), true);
         mShowBalance = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_balance), true);
         mShowValidity = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_validity), true);
+        mShowCardId = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_card_id), false);
         mShowArchivedCards = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_archived_cards), true);
     }
 
@@ -105,6 +107,17 @@ public class LoyaltyCardListDisplayOptionsManager {
         return mShowValidity;
     }
 
+    public void showCardId(boolean show) {
+        mShowCardId = show;
+        mRefreshCardsCallback.run();
+
+        saveDetailState(R.string.sharedpreference_card_details_show_card_id, show);
+    }
+
+    public boolean showingCardId() {
+        return mShowCardId;
+    }
+
     public void showArchivedCards(boolean show) {
         if (mSwapCursorCallback == null) {
             throw new IllegalStateException("No swap cursor callback is available, can not manage archive state");
@@ -146,6 +159,11 @@ public class LoyaltyCardListDisplayOptionsManager {
                 mContext.getString(R.string.show_validity),
                 showingValidity(),
                 this::showValidity
+        ));
+        displayOptions.add(new LoyaltyCardDisplayOption(
+                mContext.getString(R.string.show_card_id),
+                showingCardId(),
+                this::showCardId
         ));
 
         // Hide "Show archived cards" option unless the callback exists

--- a/app/src/main/java/protect/card_locker/LoyaltyCardListDisplayOptionsManager.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardListDisplayOptionsManager.java
@@ -35,9 +35,9 @@ public class LoyaltyCardListDisplayOptionsManager {
 
     private boolean mShowNameBelowThumbnail;
     private boolean mShowNote;
+    private boolean mShowCardId;
     private boolean mShowBalance;
     private boolean mShowValidity;
-    private boolean mShowCardId;
     private boolean mShowArchivedCards;
 
     public LoyaltyCardListDisplayOptionsManager(Context context, @NonNull Runnable refreshCardsCallback, @Nullable Runnable swapCursorCallback) {
@@ -51,9 +51,9 @@ public class LoyaltyCardListDisplayOptionsManager {
                 Context.MODE_PRIVATE);
         mShowNameBelowThumbnail = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_name_below_thumbnail), false);
         mShowNote = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_note), true);
+        mShowCardId = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_card_id), false);
         mShowBalance = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_balance), true);
         mShowValidity = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_validity), true);
-        mShowCardId = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_card_id), false);
         mShowArchivedCards = mCardDetailsPref.getBoolean(mContext.getString(R.string.sharedpreference_card_details_show_archived_cards), true);
     }
 
@@ -85,6 +85,17 @@ public class LoyaltyCardListDisplayOptionsManager {
         return mShowNote;
     }
 
+    public void showCardId(boolean show) {
+        mShowCardId = show;
+        mRefreshCardsCallback.run();
+
+        saveDetailState(R.string.sharedpreference_card_details_show_card_id, show);
+    }
+
+    public boolean showingCardId() {
+        return mShowCardId;
+    }
+
     public void showBalance(boolean show) {
         mShowBalance = show;
         mRefreshCardsCallback.run();
@@ -105,17 +116,6 @@ public class LoyaltyCardListDisplayOptionsManager {
 
     public boolean showingValidity() {
         return mShowValidity;
-    }
-
-    public void showCardId(boolean show) {
-        mShowCardId = show;
-        mRefreshCardsCallback.run();
-
-        saveDetailState(R.string.sharedpreference_card_details_show_card_id, show);
-    }
-
-    public boolean showingCardId() {
-        return mShowCardId;
     }
 
     public void showArchivedCards(boolean show) {
@@ -151,6 +151,11 @@ public class LoyaltyCardListDisplayOptionsManager {
                 this::showNote
         ));
         displayOptions.add(new LoyaltyCardDisplayOption(
+                mContext.getString(R.string.show_card_id),
+                showingCardId(),
+                this::showCardId
+        ));
+        displayOptions.add(new LoyaltyCardDisplayOption(
                 mContext.getString(R.string.show_balance),
                 showingBalance(),
                 this::showBalance
@@ -159,11 +164,6 @@ public class LoyaltyCardListDisplayOptionsManager {
                 mContext.getString(R.string.show_validity),
                 showingValidity(),
                 this::showValidity
-        ));
-        displayOptions.add(new LoyaltyCardDisplayOption(
-                mContext.getString(R.string.show_card_id),
-                showingCardId(),
-                this::showCardId
         ));
 
         // Hide "Show archived cards" option unless the callback exists

--- a/app/src/main/res/drawable/ic_card_id_24dp.xml
+++ b/app/src/main/res/drawable/ic_card_id_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M2,6h2v12L2,18L2,6zM5,6h1v12L5,18L5,6zM7,6h3v12L7,18L7,6zM11,6h1v12h-1L11,6zM13,6h2v12h-2L13,6zM16,6h2v12h-2L16,6zM19,6h1v12h-1L19,6zM21,6h1v12h-1L21,6z"/>
+</vector>

--- a/app/src/main/res/layout/loyalty_card_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_layout.xml
@@ -158,9 +158,30 @@
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintTop_toBottomOf="@+id/note"
-            app:layout_constraintBottom_toTopOf="@+id/balance"
+            app:layout_constraintBottom_toTopOf="@+id/cardId"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
+
+        <TextView
+            android:id="@+id/cardId"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="4dp"
+            android:textAppearance="?attr/textAppearanceBody2"
+            app:drawableLeftCompat="@drawable/ic_card_id_24dp"
+            android:drawablePadding="4dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/info_divider"
+            app:layout_constraintBottom_toTopOf="@+id/balance"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:visibility="visible"
+            tools:text="1234567890"/>
 
         <TextView
             android:id="@+id/balance"
@@ -174,7 +195,7 @@
             app:drawableLeftCompat="@drawable/ic_baseline_payments_24"
             android:drawablePadding="4dp"
             android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@+id/info_divider"
+            app:layout_constraintTop_toBottomOf="@+id/cardId"
             app:layout_constraintBottom_toTopOf="@+id/validFrom"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -213,30 +234,11 @@
             android:drawablePadding="4dp"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@+id/validFrom"
-            app:layout_constraintBottom_toTopOf="@+id/cardId"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:visibility="visible"
-            tools:text="Tomorrow"/>
-
-        <TextView
-            android:id="@+id/cardId"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginBottom="4dp"
-            android:textAppearance="?attr/textAppearanceBody2"
-            app:drawableLeftCompat="@drawable/ic_card_id_24dp"
-            android:drawablePadding="4dp"
-            android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@+id/expiry"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             tools:visibility="visible"
-            tools:text="1234567890"/>
+            tools:text="Tomorrow"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/loyalty_card_layout.xml
+++ b/app/src/main/res/layout/loyalty_card_layout.xml
@@ -213,11 +213,30 @@
             android:drawablePadding="4dp"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@+id/validFrom"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/cardId"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             tools:visibility="visible"
             tools:text="Tomorrow"/>
+
+        <TextView
+            android:id="@+id/cardId"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="4dp"
+            android:textAppearance="?attr/textAppearanceBody2"
+            app:drawableLeftCompat="@drawable/ic_card_id_24dp"
+            android:drawablePadding="4dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/expiry"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:visibility="visible"
+            tools:text="1234567890"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,10 +280,12 @@
     <string name="show_note">Show note</string>
     <string name="show_balance">Show balance</string>
     <string name="show_validity">Show validity</string>
+    <string name="show_card_id">Show card ID</string>
     <string name="sharedpreference_card_details_show_name_below_thumbnail" translatable="false">sharedpreference_card_details_show_name_below_thumbnail</string>
     <string name="sharedpreference_card_details_show_note" translatable="false">sharedpreference_card_details_show_note</string>
     <string name="sharedpreference_card_details_show_balance" translatable="false">sharedpreference_card_details_show_balance</string>
     <string name="sharedpreference_card_details_show_validity" translatable="false">sharedpreference_card_details_show_validity</string>
+    <string name="sharedpreference_card_details_show_card_id" translatable="false">sharedpreference_card_details_show_card_id</string>
     <string name="sharedpreference_card_details_show_archived_cards" translatable="false">sharedpreference_card_details_show_archived_cards</string>
     <string name="settings_category_title_cards">Card view</string>
     <string name="settings_category_title_cards_overview">Cards overview</string>

--- a/app/src/test/java/protect/card_locker/MainActivityTest.java
+++ b/app/src/test/java/protect/card_locker/MainActivityTest.java
@@ -137,6 +137,7 @@ public class MainActivityTest {
 
         assertEquals(1, list.getAdapter().getItemCount());
 
+        // Make sure there is enough space to render all
         list.measure(0, 0);
         list.layout(0, 0, 100, 1000);
 
@@ -175,6 +176,7 @@ public class MainActivityTest {
 
         assertEquals(1, list.getAdapter().getItemCount());
 
+        // Make sure there is enough space to render all
         list.measure(0, 0);
         list.layout(0, 0, 100, 1000);
 

--- a/app/src/test/java/protect/card_locker/MainActivityTest.java
+++ b/app/src/test/java/protect/card_locker/MainActivityTest.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 
 import androidx.appcompat.widget.SearchView;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.core.app.ApplicationProvider;
 
 import com.google.android.material.tabs.TabLayout;
 import com.google.zxing.BarcodeFormat;
@@ -112,6 +113,74 @@ public class MainActivityTest {
         assertEquals(View.VISIBLE, list.getVisibility());
 
         assertEquals(1, list.getAdapter().getItemCount());
+
+        database.close();
+    }
+
+    @Test
+    public void cardIdHiddenByDefault() {
+        ActivityController activityController = Robolectric.buildActivity(MainActivity.class).create();
+
+        Activity mainActivity = (Activity) activityController.get();
+        activityController.start();
+        activityController.resume();
+        activityController.visible();
+
+        RecyclerView list = mainActivity.findViewById(R.id.list);
+
+        SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
+        DBHelper.insertLoyaltyCard(database, "store", "", null, null, new BigDecimal("0"), null, "1234567890", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), StandardCharsets.ISO_8859_1, Color.BLACK, 0, null, 0);
+
+        activityController.pause();
+        activityController.resume();
+        activityController.visible();
+
+        assertEquals(1, list.getAdapter().getItemCount());
+
+        list.measure(0, 0);
+        list.layout(0, 0, 100, 1000);
+
+        // Card ID is hidden by default
+        TextView cardIdField = list.findViewHolderForAdapterPosition(0).itemView.findViewById(R.id.cardId);
+        assertEquals(View.GONE, cardIdField.getVisibility());
+
+        database.close();
+    }
+
+    @Test
+    public void showCardIdDisplayOption() {
+        // The display option is read in the adapter's constructor (during onCreate), so the
+        // preference must be set before the activity is built.
+        SharedPreferences cardDetailsPref = ApplicationProvider.getApplicationContext().getSharedPreferences(
+                ApplicationProvider.getApplicationContext().getString(R.string.sharedpreference_card_details),
+                Activity.MODE_PRIVATE);
+        cardDetailsPref.edit().putBoolean(
+                ApplicationProvider.getApplicationContext().getString(R.string.sharedpreference_card_details_show_card_id), true).apply();
+
+        ActivityController activityController = Robolectric.buildActivity(MainActivity.class).create();
+
+        Activity mainActivity = (Activity) activityController.get();
+        activityController.start();
+        activityController.resume();
+        activityController.visible();
+
+        RecyclerView list = mainActivity.findViewById(R.id.list);
+
+        SQLiteDatabase database = TestHelpers.getEmptyDb(mainActivity).getWritableDatabase();
+        DBHelper.insertLoyaltyCard(database, "store", "", null, null, new BigDecimal("0"), null, "1234567890", null, CatimaBarcode.fromBarcode(BarcodeFormat.UPC_A), StandardCharsets.ISO_8859_1, Color.BLACK, 0, null, 0);
+
+        activityController.pause();
+        activityController.resume();
+        activityController.visible();
+
+        assertEquals(1, list.getAdapter().getItemCount());
+
+        list.measure(0, 0);
+        list.layout(0, 0, 100, 1000);
+
+        TextView cardIdField = list.findViewHolderForAdapterPosition(0).itemView.findViewById(R.id.cardId);
+        assertEquals(View.VISIBLE, cardIdField.getVisibility());
+        assertEquals("1234567890", cardIdField.getText().toString());
 
         database.close();
     }


### PR DESCRIPTION
## Summary

Adds a "Show card ID" option to the card list Display Options menu. When enabled, each card row shows its card ID (barcode value) below the existing fields, using the same render path as the other display options (note, balance, validity). The option is disabled by default.

## Why this matters

Resolves #2742. Users currently work around the missing feature by copying the card ID into the note field so it shows in the list. As discussed on the issue, this is a natural second entry in Display Options, rendered with the same logic the rest of the row uses, and kept off by default because the raw ID is somewhat technical.

The implementation follows the existing `showNote` / `showBalance` / `showValidity` pattern verbatim:

- `LoyaltyCardListDisplayOptionsManager`: new `mShowCardId` boolean backed by a `sharedpreference_card_details_show_card_id` key (default `false`), with `showCardId(boolean)` / `showingCardId()` and a new entry in the Display Options dialog.
- `LoyaltyCardCursorAdapter`: binds a new `cardId` row and renders `loyaltyCard.cardId` via the existing `setExtraField` helper when the option is on and the ID is non-empty; hidden otherwise.
- `loyalty_card_layout.xml`: new `cardId` `TextView` appended below `expiry`.
- `strings.xml`: `show_card_id` label and the `translatable="false"` preference key (English only; translations come from Weblate).
- New `ic_card_id_24dp` drawable for the row icon.

## Testing

Added two Robolectric tests in `MainActivityTest`:

- `cardIdHiddenByDefault`: with the option off (default), the card ID field stays `GONE`.
- `showCardIdDisplayOption`: with the preference enabled before the activity is built, the field renders `VISIBLE` with the card's ID text.

Full Gradle build/tests were not run locally (no Android SDK/JDK in this environment); the changes mirror the existing display-option pattern and CI runs the unit/lint jobs.

## AI disclosure

Per CONTRIBUTING.md: an LLM assisted with writing this change, so I want to be open about it. What was generated was the boilerplate mirroring of the existing `showNote` / `showBalance` / `showValidity` flow (the manager field/getter/setter, the dialog entry, the adapter binding, the layout row, the strings, and the tests). I reviewed every line against the existing pattern to confirm it fits the project's design rather than introducing a new approach: no new libraries, the render reuses the existing `setExtraField` helper, the preference plumbing matches the other options exactly, and only `values/strings.xml` gains strings (translations left to Weblate). I also caught and fixed one correctness issue in the first draft of the test, where the preference was set after the adapter had already cached it in the constructor; the test now sets the preference before the activity is built so it actually exercises the visible path. The changes are scoped to this feature with no unrelated edits. I was not able to run the Gradle suite locally (no Android SDK in my environment), so I am relying on CI for the build/lint/unit-test verification and am happy to iterate on any review feedback.

Fixes #2742
