### PR TITLE
Add most-recently-added card sort option

### DIFF
--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -76,6 +76,7 @@ public class DBHelper extends SQLiteOpenHelper {
 
     public enum LoyaltyCardOrder {
         Alpha,
+        LastAdded,
         LastUsed,
         ValidFrom,
         Expiry
@@ -1089,6 +1090,10 @@ public class DBHelper extends SQLiteOpenHelper {
             return LoyaltyCardDbIds.STORE;
         }
 
+        if (order == LoyaltyCardOrder.LastAdded) {
+            return LoyaltyCardDbIds.ID;
+        }
+
         if (order == LoyaltyCardOrder.LastUsed) {
             return LoyaltyCardDbIds.LAST_USED;
         }
@@ -1105,7 +1110,7 @@ public class DBHelper extends SQLiteOpenHelper {
     }
 
     private static String getDbDirection(LoyaltyCardOrder order, LoyaltyCardOrderDirection direction) {
-        if (order == LoyaltyCardOrder.LastUsed) {
+        if (order == LoyaltyCardOrder.LastUsed || order == LoyaltyCardOrder.LastAdded) {
             // We want the default sorting to put the most recently used first
             return direction == LoyaltyCardOrderDirection.Descending ? "ASC" : "DESC";
         }

--- a/app/src/main/java/protect/card_locker/DBHelper.java
+++ b/app/src/main/java/protect/card_locker/DBHelper.java
@@ -1110,8 +1110,8 @@ public class DBHelper extends SQLiteOpenHelper {
     }
 
     private static String getDbDirection(LoyaltyCardOrder order, LoyaltyCardOrderDirection direction) {
-        if (order == LoyaltyCardOrder.LastUsed || order == LoyaltyCardOrder.LastAdded) {
-            // We want the default sorting to put the most recently used first
+        if (order == LoyaltyCardOrder.LastAdded || order == LoyaltyCardOrder.LastUsed) {
+            // We want the default sorting to put the most recently added/used first
             return direction == LoyaltyCardOrderDirection.Descending ? "ASC" : "DESC";
         }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -9,6 +9,7 @@
 
     <string-array name="sort_types_array">
         <item>@string/sort_by_name</item>
+        <item>@string/sort_by_most_recently_added</item>
         <item>@string/sort_by_most_recently_used</item>
         <item>@string/sort_by_valid_from</item>
         <item>@string/sort_by_expiry</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="failedToRetrieveImageFile">Failed to retrieve image file</string>
     <string name="barcodeLongPressMessage">Only images can be opened in the gallery app</string>
     <string name="sort_by_name">Name</string>
+    <string name="sort_by_most_recently_added">Most recently added</string>
     <string name="sort_by_most_recently_used">Most recently used</string>
     <string name="sort_by_valid_from">Valid from</string>
     <string name="sort_by_expiry">Expiry</string>


### PR DESCRIPTION
### Summary

Adds a new **Most recently added** sort option for cards.

### Details

This adds a new `LastAdded` card sort order, placed before **Most recently used** in the sort options.

The new option sorts cards by their database ID, which represents the order in which cards were added. The default sort order remains unchanged.

### Changes

- Added `LastAdded` to `LoyaltyCardOrder`
- Sorts `LastAdded` by card ID
- Added the new sort option to the sort options array
- Added the default English string for "Most recently added"

### Testing

Tested locally on a physical Android device.

Verified that:

- The app builds and runs successfully
- The default sort order is still unchanged
- The new **Most recently added** option appears in the sort menu
- Selecting the new option sorts cards correctly
- Reversing the order also works correctly

### Notes

This PR only adds the default English string. Localized translations can be added later through the project's translation workflow.

Closes #3188