### PR TITLE
Add overflow menu to image viewer to open image in gallery

### DIFF
--- a/app/src/main/java/protect/card_locker/cardimageview/LoyaltyCardImageViewActivity.kt
+++ b/app/src/main/java/protect/card_locker/cardimageview/LoyaltyCardImageViewActivity.kt
@@ -1,5 +1,6 @@
 package protect.card_locker.cardimageview
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -17,8 +18,15 @@ import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -35,6 +43,8 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntSize
+import androidx.core.content.FileProvider
+import protect.card_locker.BuildConfig
 import protect.card_locker.CatimaComponentActivity
 import protect.card_locker.ImageLocationType
 import protect.card_locker.R
@@ -69,9 +79,24 @@ class LoyaltyCardImageViewActivity : CatimaComponentActivity() {
                 LoyaltyCardImageViewScreen(
                     bitmap = bitmap,
                     contentDescriptionRes = imageLocationType.descriptionRes(),
-                    onBackPressedDispatcher = onBackPressedDispatcher
+                    onBackPressedDispatcher = onBackPressedDispatcher,
+                    onOpenInGallery = { openInGallery(loyaltyCardId, imageLocationType) }
                 )
             }
+        }
+    }
+
+    private fun openInGallery(loyaltyCardId: Int, imageLocationType: ImageLocationType) {
+        val imageFile = Utils.retrieveCardImageAsFile(this, loyaltyCardId, imageLocationType)
+        val imageUri = FileProvider.getUriForFile(this, BuildConfig.APPLICATION_ID, imageFile)
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setDataAndType(imageUri, IMAGE_MIME_TYPE)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(this, R.string.failedToOpenGallery, Toast.LENGTH_LONG).show()
         }
     }
 
@@ -126,6 +151,7 @@ fun LoyaltyCardImageViewScreen(
     bitmap: Bitmap,
     @StringRes contentDescriptionRes: Int,
     onBackPressedDispatcher: OnBackPressedDispatcher,
+    onOpenInGallery: () -> Unit,
 ) {
     var scale by remember { mutableFloatStateOf(1F) }
     var offset by remember { mutableStateOf(Offset.Zero) }
@@ -144,7 +170,33 @@ fun LoyaltyCardImageViewScreen(
         topBar = {
             CatimaTopAppBar(
                 title = stringResource(contentDescriptionRes),
-                onBackPressedDispatcher = onBackPressedDispatcher
+                onBackPressedDispatcher = onBackPressedDispatcher,
+                actions = {
+                    var menuExpanded by remember { mutableStateOf(false) }
+
+                    IconButton(
+                        onClick = { menuExpanded = true },
+                        modifier = Modifier.testTag("card_image_overflow_menu")
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.MoreVert,
+                            contentDescription = stringResource(R.string.overflowMenu)
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.openInGallery)) },
+                            onClick = {
+                                menuExpanded = false
+                                onOpenInGallery()
+                            },
+                            modifier = Modifier.testTag("card_image_open_in_gallery")
+                        )
+                    }
+                }
             )
         }
     ) { innerPadding ->
@@ -197,3 +249,4 @@ private fun Offset.clampTo(size: IntSize, scale: Float): Offset {
 }
 
 private const val MAX_IMAGE_SCALE = 5F
+private const val IMAGE_MIME_TYPE = "image/png"

--- a/app/src/main/java/protect/card_locker/compose/Catima.kt
+++ b/app/src/main/java/protect/card_locker/compose/Catima.kt
@@ -3,6 +3,7 @@ package protect.card_locker.compose
 import androidx.activity.OnBackPressedDispatcher
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -22,7 +23,11 @@ import protect.card_locker.preferences.Settings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CatimaTopAppBar(title: String, onBackPressedDispatcher: OnBackPressedDispatcher?) {
+fun CatimaTopAppBar(
+    title: String,
+    onBackPressedDispatcher: OnBackPressedDispatcher?,
+    actions: @Composable RowScope.() -> Unit = {}
+) {
     // Use pure black in OLED theme
     val context = LocalContext.current
     val settings = Settings(context)
@@ -51,6 +56,7 @@ fun CatimaTopAppBar(title: String, onBackPressedDispatcher: OnBackPressedDispatc
                     )
                 }
             }
-        }
+        },
+        actions = actions
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,8 @@
     <string name="unarchived">Card unarchived</string>
     <string name="overflowMenu" translatable="false">Overflow menu</string>
     <string name="failedLaunchingPhotoPicker">Couldn\'t find a supported image picker</string>
+    <string name="openInGallery">Open in gallery</string>
+    <string name="failedToOpenGallery">Install a gallery app first</string>
     <plurals name="groupCardCountWithArchived">
         <item quantity="one"><xliff:g>%1$d</xliff:g> card (<xliff:g id="archivedCount">%2$d</xliff:g> archived)</item>
         <item quantity="other"><xliff:g>%1$d</xliff:g> cards (<xliff:g id="archivedCount">%2$d</xliff:g> archived)</item>


### PR DESCRIPTION
Fixes #3209

### What this does

Adds an overflow menu to the loyalty card image viewer with an "Open in gallery" action. The image is shared through the app's existing FileProvider (`files-path`, `${applicationId}` authority) using `ACTION_VIEW` with a read URI grant, so the image opens in the user's gallery app. If no app can handle the intent, a toast asks the user to install a gallery app first.

To host the menu, `CatimaTopAppBar` gains an optional `actions` slot with an empty default, so no other screen is affected. No new dependencies; the file lookup reuses the existing `Utils.retrieveCardImageAsFile` overload.

### AI assistance disclosure

Following the note in CONTRIBUTING.md: parts of this change were drafted with the help of an AI assistant, and I want to be upfront about that. Before submitting I reviewed every line and verified the parts that could actually break by hand:

- The FileProvider authority used in code (`BuildConfig.APPLICATION_ID`) matches the one declared in the manifest (`${applicationId}`), and card images are written with `openFileOutput`, so the existing `files-path` mapping covers them.
- No new helpers or libraries were introduced; strings reuse the existing `overflowMenu` and add only the two new user-facing ones.
- Everything below was tested by me on a real emulator, not assumed.

### How it was tested

- `./gradlew assembleDebug` builds clean.
- `./gradlew testGplayDebugUnitTest` passes. The only failure is the pre-existing date-boundary flake in `LoyaltyCardViewActivityTest.startWithLoyaltyCardNoExpirySetExpiry`, which fails identically on current `main` (it compares "today" across timezones; I ran it on a UTC-offset machine near the date boundary).
- `./gradlew lintGplayRelease` reports no errors.
- Manual test on an Android 36 emulator (Pixel 7 AVD): added a card with a front image, opened the image viewer, tapped the new overflow menu, chose "Open in gallery", and the image opened in Google Photos. The "no gallery app" toast path is guarded by `ActivityNotFoundException`.

Screenshots in the comment below.
