### PR TITLE
Restructure smartwatch support settings

### DIFF
--- a/app/src/main/java/protect/card_locker/preferences/SettingsActivity.kt
+++ b/app/src/main/java/protect/card_locker/preferences/SettingsActivity.kt
@@ -170,6 +170,10 @@ class SettingsActivity : CatimaAppCompatActivity() {
                 true
             }
 
+            // Hide crash reporter settings on builds it's not enabled on
+            val crashReporterPreference = findPreference<Preference>("acra.enable")
+            crashReporterPreference!!.isVisible = BuildConfig.useAcraCrashReporter
+
             val wearSyncPreference = findPreference<SwitchPreferenceCompat>(getString(R.string.settings_key_wear_sync))
             wearSyncPreference!!.setOnPreferenceChangeListener { preference, newValue ->
                 val enabled = newValue as Boolean
@@ -187,10 +191,6 @@ class SettingsActivity : CatimaAppCompatActivity() {
                     true
                 }
             }
-
-            // Hide crash reporter settings on builds it's not enabled on
-            val crashReporterPreference = findPreference<Preference>("acra.enable")
-            crashReporterPreference!!.isVisible = BuildConfig.useAcraCrashReporter
         }
 
         private fun showWearSyncPermissionDeniedSnackbar() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,8 +104,8 @@
     <string name="settings_disable_nfc_while_viewing_card">Pause NFC</string>
     <string name="settings_disable_nfc_while_viewing_card_summary">Pauses NFC to prevent NFC payments from triggering while viewing a card</string>
     <string name="settings_key_disable_nfc_while_viewing_card" translatable="false">pref_disable_nfc_while_viewing_card</string>
-    <string name="settings_allow_content_provider_read_title">Allow other apps to access my data</string>
-    <string name="settings_allow_content_provider_read_summary">Apps will still have to request permission to be granted access</string>
+    <string name="settings_allow_content_provider_read_title">Sync with Gadgetbridge</string>
+    <string name="settings_allow_content_provider_read_summary">Allows the Gadgetbridge app to sync your cards to supported watches</string>
     <string name="settings_key_disable_lockscreen_while_viewing_card" translatable="false">pref_disable_lockscreen_while_viewing_card</string>
     <string name="settings_key_allow_content_provider_read" translatable="false">pref_allow_content_provider_read</string>
     <string name="settings_key_oled_dark" translatable="false">pref_oled_dark</string>
@@ -304,10 +304,9 @@
     <string name="setting_key_column_count_landscape" translatable="false">pref_column_count_landscape</string>
     <string name="settings_category_title_general">General</string>
     <string name="settings_category_title_privacy">Privacy</string>
-    <string name="settings_category_title_wear">Wear OS</string>
     <string name="settings_key_wear_sync" translatable="false">pref_wear_sync</string>
     <string name="settings_wear_sync">Sync with Wear OS</string>
-    <string name="settings_wear_sync_summary">Allow a Wear OS companion app to read your cards over Bluetooth</string>
+    <string name="settings_wear_sync_summary">Allows the Wear OS companion app to read your cards over Bluetooth</string>
     <string name="wear_sync_permission_required">Allow Catima access to nearby devices to sync with your smartwatch</string>
     <string name="open_settings">Open settings</string>
     <string name="action_display_options">Display options</string>
@@ -361,4 +360,5 @@
     <string name="nfc_block_system_error">Failed to pause NFC</string>
     <string name="wear_bt_channel_name">Wear OS companion</string>
     <string name="wear_bt_notification_title">Catima watch sync active</string>
+    <string name="settings_category_title_smartwatch">Smartwatch support</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -121,7 +121,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/settings_category_title_privacy"
+        android:title="@string/settings_category_title_smartwatch"
         app:iconSpaceReserved="false">
 
         <SwitchPreferenceCompat
@@ -132,11 +132,6 @@
             android:title="@string/settings_allow_content_provider_read_title"
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:title="@string/settings_category_title_wear"
-        app:iconSpaceReserved="false">
 
         <SwitchPreferenceCompat
             android:widgetLayout="@layout/preference_material_switch"


### PR DESCRIPTION
This renames the "Allow other apps to access my data" setting to "Sync with Gadgetbridge" and moves it to smartwatch support. Functionality remains unchanged and technically it is less correct, but Gadgetbridge is the only user of this system right now and has been the only user for 3 years and I think this is describing the settings in more of a way people can find it.

| Before | After |
| - | - |
| <img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/3e2901cb-2861-43ec-b78c-7f8e84c83220" /> | <img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/399c586c-5890-4531-a539-2b5c68195322" /> |