### PR TITLE
Always display sync status on screen

### DIFF
--- a/wear/src/main/java/me/hackerchick/catima/wear/ui/CardListScreen.kt
+++ b/wear/src/main/java/me/hackerchick/catima/wear/ui/CardListScreen.kt
@@ -85,17 +85,24 @@ fun CardListScreen(
                             },
                         )
                     }
-                    val footerLabel = syncStatus.labelRes
-                    if (footerLabel != null) {
-                        item {
-                            Text(
-                                text = stringResource(footerLabel),
-                                textAlign = TextAlign.Center,
-                                fontSize = 11.sp,
-                                color = Color.Gray,
-                                modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
-                            )
-                        }
+                }
+                val footerLabel = syncStatus.labelRes
+                if (footerLabel != null) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.BottomCenter)
+                            .background(Color.Black.copy(alpha = 0.75f))
+                    ) {
+                        Text(
+                            text = stringResource(footerLabel),
+                            textAlign = TextAlign.Center,
+                            fontSize = 11.sp,
+                            color = Color.LightGray,
+                            modifier = Modifier
+                                .padding(40.dp, 4.dp, 40.dp, 20.dp)
+                                .align(Alignment.Center)
+                        )
                     }
                 }
             }


### PR DESCRIPTION
In the old setup, the syncing state is only visible on the bottom of the screen, which you won't see unless you happen to scroll to the last card:

<img width="450" height="450" alt="Screenshot_20260801_222433" src="https://github.com/user-attachments/assets/bdd0a772-9bcb-46c7-ad9d-3fa0f4dd2b44" />

I've modified it to always show the syncing state, in a way where you can tap through it (so it will be visible, but it won't affect usability aside from some cards being hard to read):

<img width="450" height="450" alt="Screenshot_20260801_222538" src="https://github.com/user-attachments/assets/973592f1-c663-43d2-a91b-0890f6109798" />

(This screenshot is the worst case scenario, most text is shorter than this)

We should consider keeping all labels as succinct as possible to prevent half the screen being covered. I think they're probably as succinct as reasonably possible but a good moment to think extra about this.