### PR TITLE
Migrate WearOS app to Material3

### DIFF
--- a/app/src/main/java/protect/card_locker/Utils.java
+++ b/app/src/main/java/protect/card_locker/Utils.java
@@ -39,7 +39,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
-import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.Insets;
 import androidx.core.os.LocaleListCompat;
 import androidx.core.view.ViewCompat;
@@ -95,6 +94,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import protect.card_locker.preferences.Settings;
+import protect.card_locker.shared.ForegroundColorHelper;
 
 public class Utils {
     private static final String TAG = "Catima";
@@ -114,8 +114,6 @@ public class Utils {
     public static final int CARD_IMAGE_FROM_FILE_ICON = 12;
 
     public static final String CARD_IMAGE_FILENAME_REGEX = "^(card_)(\\d+)(_(?:front|back|icon)\\.png)$";
-
-    static final double LUMINANCE_MIDPOINT = 0.5;
 
     static final int BITMAP_SIZE_SMALL = 512;
     static final int BITMAP_SIZE_BIG = 1600;
@@ -147,11 +145,7 @@ public class Utils {
         }
 
         return new LetterBitmap(context, store, store,
-                tileLetterFontSize, pixelSize, pixelSize, backgroundColor, needsDarkForeground(backgroundColor) ? Color.BLACK : Color.WHITE);
-    }
-
-    static public boolean needsDarkForeground(Integer backgroundColor) {
-        return ColorUtils.calculateLuminance(backgroundColor) > LUMINANCE_MIDPOINT;
+                tileLetterFontSize, pixelSize, pixelSize, backgroundColor, ForegroundColorHelper.Companion.needsDarkForeground(backgroundColor) ? Color.BLACK : Color.WHITE);
     }
 
     static public List<ParseResult> retrieveBarcodesFromImage(Context context, Uri uri) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,8 +47,8 @@ ch-acra-acra-mail = { group = "ch.acra", name = "acra-mail", version.ref = "acra
 ch-acra-acra-dialog = { group = "ch.acra", name = "acra-dialog", version.ref = "acra" }
 
 # Wear OS
-androidx-wear-compose-material = { group = "androidx.wear.compose", name = "compose-material", version.ref = "wearCompose" }
 androidx-wear-compose-foundation = { group = "androidx.wear.compose", name = "compose-foundation", version.ref = "wearCompose" }
+androidx-wear-compose-material3 = { group = "androidx.wear.compose", name = "compose-material3", version.ref = "wearCompose" }
 androidx-wear-compose-navigation = { group = "androidx.wear.compose", name = "compose-navigation", version.ref = "wearCompose" }
 
 # Testing

--- a/shared/src/main/java/protect/card_locker/shared/ForegroundColorHelper.kt
+++ b/shared/src/main/java/protect/card_locker/shared/ForegroundColorHelper.kt
@@ -1,0 +1,13 @@
+package protect.card_locker.shared
+
+import androidx.core.graphics.ColorUtils
+
+class ForegroundColorHelper {
+    companion object {
+        const val LUMINANCE_MIDPOINT: Double = 0.5
+
+        fun needsDarkForeground(backgroundColor: Int): Boolean {
+            return ColorUtils.calculateLuminance(backgroundColor) > LUMINANCE_MIDPOINT
+        }
+    }
+}

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     implementation(libs.androidx.activity.activity.compose)
 
     // Wear OS Compose
-    implementation(libs.androidx.wear.compose.material)
+    implementation(libs.androidx.wear.compose.material3)
     implementation(libs.androidx.wear.compose.foundation)
     implementation(libs.androidx.wear.compose.navigation)
 

--- a/wear/src/main/java/me/hackerchick/catima/wear/ui/CardListScreen.kt
+++ b/wear/src/main/java/me/hackerchick/catima/wear/ui/CardListScreen.kt
@@ -15,15 +15,19 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.CircularProgressIndicator
-import androidx.wear.compose.material.Text
+import androidx.wear.compose.material3.CircularProgressIndicator
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.SurfaceTransformation
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import me.hackerchick.catima.wear.R
 import me.hackerchick.catima.wear.SyncStatus
 import me.hackerchick.catima.wear.WearCard
+import protect.card_locker.shared.ForegroundColorHelper
 
 @Composable
 fun CardListScreen(
@@ -63,14 +67,16 @@ fun CardListScreen(
                 )
             }
             else -> {
-                ScalingLazyColumn(
+                val transformationSpec = rememberTransformationSpec()
+                TransformingLazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 32.dp),
                     verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     items(cards, key = { it.id }) { card ->
-                        Chip(
-                            modifier = Modifier.fillMaxWidth(),
+                        Button(
+                            modifier = Modifier.fillMaxWidth().transformedHeight(this, transformationSpec),
+                            transformation = SurfaceTransformation(transformationSpec),
                             label = {
                                 Text(
                                     text = card.store,
@@ -79,9 +85,12 @@ fun CardListScreen(
                             },
                             onClick = { onCardClick(card) },
                             colors = if (card.headerColor != null) {
-                                ChipDefaults.chipColors(backgroundColor = Color(card.headerColor))
+                                ButtonDefaults.buttonColors(
+                                    containerColor = Color(card.headerColor),
+                                    contentColor = if (ForegroundColorHelper.needsDarkForeground(card.headerColor)) Color.Black else Color.White
+                                )
                             } else {
-                                ChipDefaults.primaryChipColors()
+                                ButtonDefaults.buttonColors()
                             },
                         )
                     }

--- a/wear/src/main/java/me/hackerchick/catima/wear/ui/CardViewScreen.kt
+++ b/wear/src/main/java/me/hackerchick/catima/wear/ui/CardViewScreen.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.CircularProgressIndicator
-import androidx.wear.compose.material.MaterialTheme
-import androidx.wear.compose.material.Text
+import androidx.wear.compose.material3.CircularProgressIndicator
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.MultiFormatWriter
@@ -40,7 +40,7 @@ fun CardViewScreen(card: WearCard?) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colors.background),
+            .background(MaterialTheme.colorScheme.background),
         contentAlignment = Alignment.Center,
     ) {
         if (card == null) {


### PR DESCRIPTION
Several Material2 libraries were used. Migrate to Material 3 to be fully up to date.

Looks slightly different but not really much.

| Before | After |
| - | - |
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/71dd5aa2-cae9-435f-aabd-675d8a4a2aab" /> | <img width="450" height="450" alt="Screenshot_20260801_234115" src="https://github.com/user-attachments/assets/736a53c6-cc9e-46cb-b238-8553abc87f22" />

Also switched to Transforming for that slightly nicer "focus on center" effect:
https://github.com/user-attachments/assets/e57ddde6-9a1f-4566-b057-42b95434f112