### PR TITLE
Versioning and CHANGELOG changes for new Wear OS setup

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,8 +43,19 @@ jobs:
         run: ./gradlew assemble${sentenceCasedFlavor}Release
       - name: Check for non-free libraries
         run: |
-          wget -q https://codeberg.org/Katastima/apkscanner/releases/download/v0.0.7/apk-scanner_v0.0.7.jar
-          java -jar apk-scanner_v0.0.7.jar scan-apk "$(echo 'app/build/outputs/apk/${{ matrix.flavor }}/release/app-${{ matrix.flavor }}-release-unsigned.apk')"
+          # Get Katastima APK scanner
+          wget -q https://codeberg.org/Katastima/apkscanner/releases/download/v0.0.9/apk-scanner_v0.0.9.jar
+          # Print pretty result
+          java -jar apk-scanner_v0.0.9.jar scan-apk "$(echo 'app/build/outputs/apk/${{ matrix.flavor }}/release/app-${{ matrix.flavor }}-release-unsigned.apk')"
+          # Check for offending libraries
+          # Exit code 4 = no result, which is what we want
+          set +e
+          java -jar apk-scanner_v0.0.9.jar scan-apk --json=yes "$(echo 'app/build/outputs/apk/${{ matrix.flavor }}/release/app-${{ matrix.flavor }}-release-unsigned.apk')" | jq --exit-status '.libraryCheckResult.offendingLibraries[] | select((.libraryId == "/org/acra" and .license == "Apache-2.0")|not)'
+          if [ "$?" -ne 4 ]; then
+            echo "Bad libraries found!"
+            exit 1
+          fi
+          set -e
       - name: Check lint
         run: ./gradlew lint${sentenceCasedFlavor}Release
       - name: Run unit tests

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-      - staging
-      - trying
   pull_request:
-    branches:
-      - main
 permissions:
   actions: none
   checks: none
@@ -30,8 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flavor: [Foss, Gplay]
+        flavor: [fdroidLegacy, foss, gplay]
     steps:
+      - name: Ensure sentence-cased flavor variables
+        run: |
+          flavor="$(echo ${{ matrix.flavor }})"
+          echo "sentenceCasedFlavor=${flavor^}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7.0.0
       - uses: gradle/actions/wrapper-validation@v6.2.0
       - name: set up OpenJDK 25
@@ -40,15 +40,15 @@ jobs:
           sudo apt-get install -y openjdk-25-jdk-headless
           sudo update-alternatives --auto java
       - name: Build
-        run: ./gradlew assemble${{ matrix.flavor }}Release
+        run: ./gradlew assemble${sentenceCasedFlavor}Release
       - name: Check for non-free libraries
         run: |
           wget -q https://codeberg.org/Katastima/apkscanner/releases/download/v0.0.7/apk-scanner_v0.0.7.jar
-          java -jar apk-scanner_v0.0.7.jar scan-apk "$(echo 'app/build/outputs/apk/${{ matrix.flavor }}/release/app-${{ matrix.flavor }}-release-unsigned.apk' | tr '[:upper:]' '[:lower:]')"
+          java -jar apk-scanner_v0.0.7.jar scan-apk "$(echo 'app/build/outputs/apk/${{ matrix.flavor }}/release/app-${{ matrix.flavor }}-release-unsigned.apk')"
       - name: Check lint
-        run: ./gradlew lint${{ matrix.flavor }}Release
+        run: ./gradlew lint${sentenceCasedFlavor}Release
       - name: Run unit tests
-        run: timeout 5m ./gradlew test${{ matrix.flavor }}DebugUnitTest || { ./gradlew --stop && timeout 5m ./gradlew test${{ matrix.flavor }}DebugUnitTest; }
+        run: timeout 5m ./gradlew test${sentenceCasedFlavor}DebugUnitTest || { ./gradlew --stop && timeout 5m ./gradlew test${sentenceCasedFlavor}DebugUnitTest; }
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -59,16 +59,16 @@ jobs:
         with:
           api-level: 23
           arch: x86_64
-          script: ./gradlew connected${{ matrix.flavor }}DebugAndroidTest
+          script: ./gradlew connected${sentenceCasedFlavor}DebugAndroidTest
       - name: Run instrumented tests (API 35)
         uses: ReactiveCircus/android-emulator-runner@v2.38.0
         with:
           api-level: 35
           arch: x86_64
-          script: ./gradlew connected${{ matrix.flavor }}DebugAndroidTest
+          script: ./gradlew connected${sentenceCasedFlavor}DebugAndroidTest
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: test-results-flavor${{ matrix.flavor }}
+          name: test-results-flavor-${{ matrix.flavor }}
           path: app/build/reports

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-      - staging
-      - trying
   pull_request:
-    branches:
-      - main
 permissions:
   actions: none
   checks: none

--- a/.github/workflows/wear.yml
+++ b/.github/workflows/wear.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-      - staging
-      - trying
   pull_request:
-    branches:
-      - main
 permissions:
   actions: none
   checks: none

--- a/.github/workflows/wear.yml
+++ b/.github/workflows/wear.yml
@@ -36,7 +36,18 @@ jobs:
         run: ./gradlew :wear:assembleRelease
       - name: Check for non-free libraries
         run: |
-          wget -q https://codeberg.org/Katastima/apkscanner/releases/download/v0.0.7/apk-scanner_v0.0.7.jar
-          java -jar apk-scanner_v0.0.7.jar scan-apk 'wear/build/outputs/apk/release/wear-release-unsigned.apk'
+          # Get Katastima APK scanner
+          wget -q https://codeberg.org/Katastima/apkscanner/releases/download/v0.0.9/apk-scanner_v0.0.9.jar
+          # Print pretty result
+          java -jar apk-scanner_v0.0.9.jar scan-apk "wear/build/outputs/apk/release/wear-release-unsigned.apk"
+          # Check for offending libraries
+          # Exit code 4 = no result, which is what we want
+          set +e
+          java -jar apk-scanner_v0.0.9.jar scan-apk --json=yes "wear/build/outputs/apk/release/wear-release-unsigned.apk" | jq --exit-status '.libraryCheckResult.offendingLibraries[]'
+          if [ "$?" -ne 4 ]; then
+            echo "Bad libraries found!"
+            exit 1
+          fi
+          set -e
       - name: Check lint
         run: ./gradlew :wear:lintRelease

--- a/.scripts/changelog_to_fastlane.py
+++ b/.scripts/changelog_to_fastlane.py
@@ -15,7 +15,7 @@ with open('CHANGELOG.md') as changelog:
                 changelogs[version_code] = text
 
             text = []
-            match = re.match("## \S* - (\d*).*", line)
+            match = re.match("## .+ - (\d*).*", line)
             if not match:
                 raise ValueError(f"Invalid version line: {line}")
             version_code = match.group(1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased (Android) - 1002
+
+- Add a Bluetooth server for Wear OS companion app support
+- Remove embedded CHANGELOG
+
+## Unreleased (Wear OS) - 200
+
+- Initial release of Wear OS companion app
+
 ## v2.43.0 - 167 (2026-07-12)
 
 - Add support for showing the card ID in the card list

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,8 +59,14 @@ android {
             dimension = "type"
             isDefault = true
         }
+        create("fdroidLegacy") {
+            dimension = "type"
+            versionNameSuffix = " (F-Droid)"
+            versionCode = defaultConfig.versionCode!! - 1
+        }
         create("gplay") {
             dimension = "type"
+            versionNameSuffix = " (Google)"
 
             // Google doesn't allow donation links
             buildConfigField("boolean", "showDonate", "false")
@@ -167,7 +173,6 @@ dependencies {
 
 tasks.register("copyRawResFiles", Copy::class) {
     from(
-        layout.projectDirectory.file("../CHANGELOG.md"),
         layout.projectDirectory.file("../PRIVACY.md")
     )
     into(layout.projectDirectory.dir("src/main/res/raw"))
@@ -175,7 +180,7 @@ tasks.register("copyRawResFiles", Copy::class) {
 }.also {
     tasks.preBuild.dependsOn(it)
     tasks.getByName<Delete>("clean") {
-        val filesNamesToDelete = listOf("CHANGELOG", "PRIVACY")
+        val filesNamesToDelete = listOf("PRIVACY")
         filesNamesToDelete.forEach { fileName ->
             delete(layout.projectDirectory.file("src/main/res/raw/${fileName.lowercase()}.md"))
         }

--- a/app/src/main/java/protect/card_locker/AboutActivity.kt
+++ b/app/src/main/java/protect/card_locker/AboutActivity.kt
@@ -69,16 +69,7 @@ fun AboutScreenContent(
                 stringResource(R.string.version_history),
                 content.versionHistory,
                 modifier = Modifier.testTag("card_version_history"),
-                onClickUrl = "https://catima.app/changelog/",
-                onClickDialogText = AnnotatedString.fromHtml(
-                    htmlString = content.historyHtml,
-                    linkStyles = TextLinkStyles(
-                        style = SpanStyle(
-                            textDecoration = TextDecoration.Underline,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    )
-                )
+                onClickUrl = "https://catima.app/changelog/"
             )
             CatimaAboutSection(
                 stringResource(R.string.credits),

--- a/app/src/main/java/protect/card_locker/AboutContent.java
+++ b/app/src/main/java/protect/card_locker/AboutContent.java
@@ -62,18 +62,6 @@ public class AboutContent {
         return contributors.replace("\n", "<br />");
     }
 
-    public String getHistoryHtml() {
-        String versionHistory;
-        try {
-            versionHistory = Utils.readTextFile(context, R.raw.changelog)
-                    .replace("# Changelog\n\n", "");
-        }  catch (IOException ignored) {
-            return "";
-        }
-        return Utils.linkify(Utils.basicMDToHTML(versionHistory))
-                .replace("\n", "<br />");
-    }
-
     public String getLicenseHtml() {
         try {
             return Utils.readTextFile(context, R.raw.license);

--- a/app/src/test/java/protect/card_locker/UtilsTest.java
+++ b/app/src/test/java/protect/card_locker/UtilsTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import protect.card_locker.shared.ForegroundColorHelper;
+
 
 @RunWith(RobolectricTestRunner.class)
 public class UtilsTest {
@@ -26,7 +28,7 @@ public class UtilsTest {
                 for (int i = 0; i < colors.length(); i++) {
                     // Grab white as fallback so that if the retrieval somehow fails the test is guaranteed to fail because a white background will have black foreground
                     int color = colors.getColor(i, Color.WHITE);
-                    assertFalse(Utils.needsDarkForeground(color));
+                    assertFalse(ForegroundColorHelper.Companion.needsDarkForeground(color));
                 }
             });
         }

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,16 @@ IFS=$'\n\t'
 ### build.sh
 ### Builds Catima the same way rbtlog/IzzyOnDroid does for reproducible builds
 
+if [ -z "${BUILD_TYPE:-}" ]; then
+  echo "BUILD_TYPE is not set, setting to app."
+  export BUILD_TYPE="app"
+fi
+
+if [ "${BUILD_TYPE}" != "app" ] && [ "${BUILD_TYPE}" != "wear" ]; then
+  echo "Invalid BUILD_TYPE ${BUILD_TYPE}, must be either app or wear."
+  exit 1
+fi
+
 if [ -z "${ANDROID_HOME:-}" ]; then
   echo "ANDROID_HOME is not set, setting to $HOME/Android/Sdk";
   export ANDROID_HOME=$HOME/Android/Sdk
@@ -22,13 +32,17 @@ if [ -z "${JAVA_HOME:-}" ]; then
 fi
 
 echo "Starting build"
-./gradlew clean assembleRelease
+./gradlew clean ":${BUILD_TYPE}:assembleRelease"
 
 echo "Build finished (unsigned)"
-flavourDirs=$(find app/build/outputs/apk/ -mindepth 1 -maxdepth 1 -type d)
+flavourDirs=$(find "${BUILD_TYPE}/build/outputs/apk/" -mindepth 1 -maxdepth 1 -type d)
 for flavourDir in $flavourDirs; do
   flavourName="$(basename "$flavourDir")"
-  echo "Your $flavourName flavour is at $flavourDir/release/app-$flavourName-release-unsigned.apk"
+  if [ "$flavourName" == "release" ]; then
+    echo "Your $flavourName flavour is at $flavourDir/${BUILD_TYPE}-release-unsigned.apk"
+  else
+    echo "Your $flavourName flavour is at $flavourDir/release/${BUILD_TYPE}-$flavourName-release-unsigned.apk"
+  fi
 done
 
 if [ -z "${KEYSTORE:-}" ]; then
@@ -44,19 +58,33 @@ else
   for flavourDir in $flavourDirs; do
     flavourName="$(basename "$flavourDir")"
     echo "Signing $flavourName flavour..."
-    cp "$flavourDir/release/app-$flavourName-release-unsigned.apk" "$flavourDir/release/app-$flavourName-release.apk"
-    "$ANDROID_HOME/build-tools/$apksigner_version/apksigner" sign -v --ks "$KEYSTORE" --ks-key-alias "$KEYSTORE_ALIAS" "$flavourDir/release/app-$flavourName-release.apk"
+    if [ "$flavourName" == "release" ]; then
+      cp "$flavourDir/${BUILD_TYPE}-release-unsigned.apk" "$flavourDir/${BUILD_TYPE}-release.apk"
+      "$ANDROID_HOME/build-tools/$apksigner_version/apksigner" sign -v --ks "$KEYSTORE" --ks-key-alias "$KEYSTORE_ALIAS" "$flavourDir/${BUILD_TYPE}-release.apk"
+    else
+      cp "$flavourDir/release/${BUILD_TYPE}-$flavourName-release-unsigned.apk" "$flavourDir/release/${BUILD_TYPE}-$flavourName-release.apk"
+      "$ANDROID_HOME/build-tools/$apksigner_version/apksigner" sign -v --ks "$KEYSTORE" --ks-key-alias "$KEYSTORE_ALIAS" "$flavourDir/release/${BUILD_TYPE}-$flavourName-release.apk"
+    fi
 
     echo "Build finished (signed)"
-    echo "Your $flavourName flavour is at $flavourDir/release/app-$flavourName-release.apk"
+    if [ "$flavourName" == "release" ]; then
+      echo "Your $flavourName flavour is at $flavourDir/${BUILD_TYPE}-release.apk"
+    else
+      echo "Your $flavourName flavour is at $flavourDir/release/${BUILD_TYPE}-$flavourName-release.apk"
+    fi
   done
 
   shasumPath="$(pwd)/SHA256SUMS"
   echo "" > "$shasumPath"
 
   for flavourDir in $flavourDirs; do
-    pushd "$flavourDir/release/"
-    sha256sum -- *.apk >> "$shasumPath"
+    flavourName="$(basename "$flavourDir")"
+    if [ "$flavourName" == "release" ]; then
+      pushd "$flavourDir"
+    else
+      pushd "$flavourDir/release/"
+    fi
+    sha256sum -- "${BUILD_TYPE}"-*.apk >> "$shasumPath"
     popd
   done
 

--- a/docs/RELEASE_STEPS.md
+++ b/docs/RELEASE_STEPS.md
@@ -1,14 +1,31 @@
 **This documentation is for maintainers. If you're a user, please ignore it.**
 
+# General versioning note
+Android releases should be at least versionCode 1000 and end on an even number (the uneven numbers are used for F-Droid legacy builds). Valid: 1002, 1004, etc.
+
+WearOS releases should be between 200 and 999 and only have to be bumped by 1. Valid: 200, 201, etc.
+
+Version codes below 200 are from the pre-WearOS days.
+
 # When releasing, do the following:
 1. Press "Commit" and "Push" on Weblate to ensure all translations are up to date
 2. Merge Weblate pull request
 3. Make sure to pull the `main` branch locally
 4. Update `CHANGELOG.md` with the new version name and the release date
-5. Update `app/build.gradle.kts` with the new `versionCode` and `versionName`
-6. Create a commit for the new release: `git add CHANGELOG.md app/build.gradle.kts && git commit -m "Release Catima <VERSION>"`
-7. Build the new .apks: `KEYSTORE=/path/to/keystore KEYSTORE_ALIAS=catima ./build.sh`
-8. Upload `app/build/outputs/apk/gplay/release/app-gplay-release.apk` to Google Play Open Testing
+5. Update the relevant build.gradle.kts with the new `versionCode` and `versionName`
+   - For Android releases, this is `app/build.gradle.kts`, make sure to use an even number above 1000
+   - For Wear OS releases, this is `wear/build.gradle.kts`, make sure to use a number between 200 and 1000
+6. Create a commit for the new release:
+   - For Android releases, `git add CHANGELOG.md app/build.gradle.kts && git commit -m "Release Catima <VERSION>"`
+   - For Wear OS releases, `git add CHANGELOG.md wear/build.gradle.kts && git commit -m "Release Catima Wear OS <VERSION>"`
+7. Build the new .apks:
+   - For Android releases, `BUILD_TYPE=app KEYSTORE=/path/to/keystore KEYSTORE_ALIAS=catima ./build.sh`
+   - For Wear OS releases, `BUILD_TYPE=wear KEYSTORE=/path/to/keystore KEYSTORE_ALIAS=catima ./build.sh`
+8. Upload the Google release to Google Play Open Testing
+   - For Android releases, this is `app/build/outputs/apk/gplay/release/app-gplay-release.apk`
+   - For Wear OS releases, this is `wear/build/outputs/apk/release/wear-release.apk` (Wear OS currently does not use flavours)
 9. Push the version update commit: `git push`
-10. Create a new release on GitHub and attach the `app/build/outputs/apk/foss/release/app-foss-release.apk` and `SHA256SUMS` files
+10. Create a new release on GitHub and attach the non-Google APKs and `SHA256SUMS` files
+    - For Android releases, this is `app/build/outputs/apk/foss/release/app-foss-release.apk` and `SHA256SUMS`. Releases are tagged vX.X.X.
+    - For Wear OS releases, this is `wear/build/outputs/apk/release/wear-release.apk` and `SHA256SUMs` (Wear OS currently does not use flavours). Releases are tagged vX.X.X-wearos.
 11. When pushing the release to Google Play Production, update the metadata there: `bundle exec fastlane supply --version_code <VERSION_CODE>`

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,12 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+}
+
+kotlin {
+    jvmToolchain(21)
 }
 
 android {
@@ -18,7 +24,7 @@ android {
 
     kotlin {
         compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+            jvmTarget = JvmTarget.JVM_21
         }
     }
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.0 Wear OS"
     }
 
     buildTypes {

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">Catima</string>
     <string name="no_cards">No cards found.\nOpen Catima on your phone to add cards.</string>
-    <string name="phone_not_connected">Could not reach Catima on your phone.\nMake sure the app is installed, your watch is connected and WearOS is enabled in Catima settings.</string>
+    <string name="phone_not_connected">Could not reach Catima on your phone.\nMake sure Catima is running on your phone, your watch is connected and Wear OS support is enabled in Catima smartwatch settings.</string>
     <string name="loading_cards">Loading cards…</string>
     <string name="no_barcode">No barcode available for this card.</string>
     <string name="card_id_label">Card ID</string>


### PR DESCRIPTION
Allows us to clearly differentiate between Android and Wear OS releases.

Version codes between 200 and 999 will be for WearOS. There is only 1 flavour.
Version codes above 1000 will be for Android. We go from 2 to 3 flavours. foss and gplay flavours remain unchanged. fdroidLegacy flavor is new, and is the exact same as foss but with the versionCode 1 lower. The new fdroidLegacy APK will not be uploaded, but its SHA will be written down in the SHASUMS file. This allows F-Droid to build RB Catima builds with the official signature as well as continue to provide Catima builds for users on the F-Droid signature.

TODO:
- [x] Figure out versioning and all.
- [x] Make build.sh work with building Android or Wear OS

This also removes the embedded CHANGELOG, as it will likely contain WIP Wear OS release notes at times of including into the app