### PR TITLE
Consistently use Wear OS naming

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,9 +307,9 @@
     <string name="settings_key_wear_sync" translatable="false">pref_wear_sync</string>
     <string name="settings_wear_sync">Sync with Wear OS</string>
     <string name="settings_wear_sync_summary">Allows the Wear OS companion app to read your cards over Bluetooth</string>
-    <string name="wear_sync_permission_required">Catima needs the permissions you denied to sync with your smartwatch</string>
+    <string name="wear_sync_permission_required">Catima needs the permissions you denied to sync with your Wear OS smartwatch</string>
     <string name="settings_key_wear_sync_devices" translatable="false">pref_wear_sync_devices</string>
-    <string name="settings_wear_sync_devices">Allowed Wear devices</string>
+    <string name="settings_wear_sync_devices">Allowed Wear OS devices</string>
     <string name="settings_wear_sync_devices_summary">Manage devices allowed to sync over Bluetooth</string>
     <string name="settings_wear_sync_no_devices">No allowed devices</string>
     <plurals name="settings_wear_sync_devices_summary_count">
@@ -317,8 +317,8 @@
         <item quantity="other"><xliff:g>%d</xliff:g> devices allowed</item>
     </plurals>
     <string name="settings_key_wear_sync_blocked_devices" translatable="false">pref_wear_sync_blocked_devices</string>
-    <string name="settings_wear_sync_blocked_devices">Blocked Wear devices</string>
-    <string name="settings_wear_sync_blocked_devices_summary">Manage blocked Wear devices</string>
+    <string name="settings_wear_sync_blocked_devices">Blocked Wear OS devices</string>
+    <string name="settings_wear_sync_blocked_devices_summary">Manage blocked Wear OS devices</string>
     <string name="settings_wear_sync_no_blocked_devices">No blocked devices</string>
     <plurals name="settings_wear_sync_blocked_devices_summary_count">
         <item quantity="one"><xliff:g>%d</xliff:g> device blocked</item>
@@ -330,15 +330,15 @@
     <string name="settings_wear_sync_unpair">Remove</string>
     <string name="settings_wear_sync_device_name"><xliff:g>%1$s</xliff:g> (<xliff:g>%2$s</xliff:g>)</string>
     <string name="settings_wear_sync_tap_to_remove">Tap a device to remove it.</string>
-    <string name="wear_bt_pairing_channel_name">Wear device pairing</string>
-    <string name="wear_bt_pairing_title">Wear device wants to sync</string>
+    <string name="wear_bt_pairing_channel_name">Wear OS device pairing</string>
+    <string name="wear_bt_pairing_title">Wear OS device wants to sync</string>
     <string name="wear_bt_pairing_message">Allow <xliff:g>%1$s</xliff:g> to access your cards?</string>
     <string name="wear_bt_pairing_allow">Allow</string>
     <string name="wear_bt_pairing_block">Block</string>
     <string name="wear_bt_pairing_allowed"><xliff:g>%1$s</xliff:g> is now allowed to sync.</string>
     <string name="wear_bt_pairing_blocked"><xliff:g>%1$s</xliff:g> has been blocked.</string>
     <string name="wear_bt_pairing_mismatch_title">New authorization request from "<xliff:g>%1$s</xliff:g>"</string>
-    <string name="wear_bt_pairing_mismatch_message">This device was previously authorized but is now presenting a different identity token. This happens when the WearOS app is reinstalled or its data is cleared. It can also indicate a Bluetooth MAC spoofing attempt.\n\nOnly accept if you recently reinstalled the Catima WearOS app on this watch.</string>
+    <string name="wear_bt_pairing_mismatch_message">This device was previously authorized but is now presenting a different identity token. This happens when the Wear OS app is reinstalled or its data is cleared. It can also indicate a Bluetooth MAC spoofing attempt.\n\nOnly accept if you recently reinstalled the Catima Wear OS app on this watch.</string>
     <string name="open_settings">Open settings</string>
     <string name="action_display_options">Display options</string>
     <string name="show_archived_cards">Show archived cards</string>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="no_barcode">No barcode available for this card.</string>
     <string name="card_id_label">Card ID</string>
     <string name="syncing">Syncing with phone…</string>
-    <string name="sync_failed">Offline – showing cached cards</string>
+    <string name="sync_failed">Phone unreachable – showing cached cards</string>
     <string name="version_incompatible">Catima on your phone and watch are incompatible.\nPlease update both.</string>
     <string name="bluetooth_permission_denied">Bluetooth permission denied.\nGrant it in Settings to sync cards.</string>
     <string name="bluetooth_disabled">Bluetooth is turned off.\nEnable it to sync cards from your phone.</string>


### PR DESCRIPTION
The strings wear a bit all over the place. Sometimes "Wear", sometimes "WearOS", sometimes "Wear OS".

Given Google calls it "Wear OS", that's the string I went for.

I also changed the "Offline – showing cached cards" text to "Phone unreachable – showing cached cards" because I don't want people to think their cards are sent to a server: they remain on the phone. Data privacy stays the number one priority for Catima.

I think it looks fine on the watch:
<img width="450" height="450" alt="Screenshot_20260805_172939" src="https://github.com/user-attachments/assets/6be9aac0-0c35-4948-a09f-246e30b9f91b" />
