### PR TITLE
Implement Wear OS splash screen

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
     implementation(libs.androidx.core.core.ktx)
     implementation(libs.androidx.activity.activity.compose)
 
+    // AndroidX
+    implementation(libs.androidx.core.core.splashscreen)
+
     // Wear OS Compose
     implementation(libs.androidx.wear.compose.material3)
     implementation(libs.androidx.wear.compose.foundation)

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name">
+            android:taskAffinity=""
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/wear/src/main/java/me/hackerchick/catima/wear/MainActivity.kt
+++ b/wear/src/main/java/me/hackerchick/catima/wear/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
@@ -33,6 +34,7 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         WearCardRepository.loadCache(this)

--- a/wear/src/main/res/values/ic_launcher_background.xml
+++ b/wear/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1F4262</color>
+</resources>

--- a/wear/src/main/res/values/styles.xml
+++ b/wear/src/main/res/values/styles.xml
@@ -1,0 +1,14 @@
+<resources>
+    <style name="Theme.App" parent="@android:style/Theme.DeviceDefault" />
+
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen.IconBackground">
+        <!--
+          Google Wear OS guidelines require a black background
+          See https://developer.android.com/design/ui/wear/guides/m2-5/behaviors-and-patterns/launch#branded
+        -->
+        <item name="windowSplashScreenBackground">@android:color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="windowSplashScreenIconBackgroundColor">@color/ic_launcher_background</item>
+        <item name="postSplashScreenTheme">@style/Theme.App</item>
+    </style>ss
+</resources>


### PR DESCRIPTION
Fixes #3285

I think it looks kinda stupid, but Google is very clear that it *needs* to use a black background on https://developer.android.com/design/ui/wear/guides/m2-5/behaviors-and-patterns/launch#branded

<img width="535" height="535" alt="image" src="https://github.com/user-attachments/assets/d3412200-2438-4f8c-b918-b64c1ba3eca6" />
