### PR TITLE
Add scroll bar and fix some padding bugs

### DIFF
--- a/wear/src/main/java/me/hackerchick/catima/wear/ui/CardListScreen.kt
+++ b/wear/src/main/java/me/hackerchick/catima/wear/ui/CardListScreen.kt
@@ -17,10 +17,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.CircularProgressIndicator
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
@@ -67,32 +69,43 @@ fun CardListScreen(
                 )
             }
             else -> {
-                val transformationSpec = rememberTransformationSpec()
-                TransformingLazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 32.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    items(cards, key = { it.id }) { card ->
-                        Button(
-                            modifier = Modifier.fillMaxWidth().transformedHeight(this, transformationSpec),
-                            transformation = SurfaceTransformation(transformationSpec),
-                            label = {
-                                Text(
-                                    text = card.store,
-                                    maxLines = 1,
-                                )
-                            },
-                            onClick = { onCardClick(card) },
-                            colors = if (card.headerColor != null) {
-                                ButtonDefaults.buttonColors(
-                                    containerColor = Color(card.headerColor),
-                                    contentColor = if (ForegroundColorHelper.needsDarkForeground(card.headerColor)) Color.Black else Color.White
-                                )
-                            } else {
-                                ButtonDefaults.buttonColors()
-                            },
-                        )
+                val columnState = rememberTransformingLazyColumnState()
+                ScreenScaffold(
+                    scrollState = columnState,
+                ) { contentPadding ->
+                    val transformationSpec = rememberTransformationSpec()
+                    TransformingLazyColumn(
+                        state = columnState,
+                        contentPadding = contentPadding,
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        items(cards, key = { it.id }) { card ->
+                            Button(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .transformedHeight(this, transformationSpec)
+                                    .minimumVerticalContentPadding(ButtonDefaults.minimumVerticalListContentPadding),
+                                transformation = SurfaceTransformation(transformationSpec),
+                                label = {
+                                    Text(
+                                        text = card.store,
+                                        maxLines = 1,
+                                    )
+                                },
+                                onClick = { onCardClick(card) },
+                                colors = if (card.headerColor != null) {
+                                    ButtonDefaults.buttonColors(
+                                        containerColor = Color(card.headerColor),
+                                        contentColor = if (ForegroundColorHelper.needsDarkForeground(
+                                                card.headerColor
+                                            )
+                                        ) Color.Black else Color.White
+                                    )
+                                } else {
+                                    ButtonDefaults.buttonColors()
+                                },
+                            )
+                        }
                     }
                 }
                 val footerLabel = syncStatus.labelRes


### PR DESCRIPTION
Google is not very clear and just sent 2 screenshots for "content falling out of the screen".

I *think* their main complaint was the first item being slightly cut off near the top, which this fixes by using the ScreenScaffold's contentPadding.

| Before | After |
| - | - |
| <img width="456" height="456" alt="IN_APP_EXPERIENCE-1627-2" src="https://github.com/user-attachments/assets/db59d6c7-e096-4eeb-8ce6-f028a30bb269" /> | <img width="535" height="535" alt="image" src="https://github.com/user-attachments/assets/d7d5c30e-51b9-4145-8ffd-4a6b0666d8c6" /> |

Also adds a scroll bar while moving.

Fixes #3283, improves #3284