### PR TITLE
WearOS: Hide barcode as a hack for Google approval

### DIFF
--- a/wear/src/main/java/me/hackerchick/catima/wear/ui/CardViewScreen.kt
+++ b/wear/src/main/java/me/hackerchick/catima/wear/ui/CardViewScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color as ComposeColor
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.stringResource
@@ -138,6 +139,9 @@ private fun CardDetail(card: WearCard) {
                 textAlign = TextAlign.Center,
                 maxLines = 2,
                 color = ComposeColor.Black,
+                // Hide the barcode value until we can be completely certain the element won't partially fall out of the UI
+                // This is a workaround for a requirement for Google Play: https://github.com/CatimaLoyalty/Android/issues/3284
+                modifier = Modifier.alpha(0f)
             )
         }
     }


### PR DESCRIPTION
Not going to lie, I am quite unhappy about having to remove the barcode value being shown. It's useful info. However, the vast majority of Wear OS users will likely get it from Google Play, and this is blocking Google approval (see #3284), see I see no other way right now to start getting this in the hands of people.

Help with getting this UI screen redesigned so it can display the barcode value without ever falling out of the screen very much welcome.

| Before | After |
| - | - |
| <img width="456" height="456" alt="image" src="https://github.com/user-attachments/assets/e4d1238d-992c-426f-9578-2191c42140da" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/348f3d5c-dc36-4acc-9aad-40e3a574f785" /> |

Fixes #3284, though can't say it makes me happy